### PR TITLE
increase timeout to 4000 for mac tests

### DIFF
--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -55,7 +55,8 @@ describe("Model & ScmProvider modules", () => {
     after(() => {
         doc.dispose();
     });
-    beforeEach(async () => {
+    beforeEach(async function() {
+        this.timeout(4000);
         const showMessage = sinon.spy(Display, "showMessage");
         const showError = sinon.spy(Display, "showError");
 


### PR DESCRIPTION
mac tests on azure pipelines seem to be slow and fail on the beforeEach stage when doing work involving perforce commands. Try doubling timeout to reduce rate of failure