### PR TITLE
Improve bottleneck configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,27 +44,27 @@
                 "perforce.bottleneck.maxConcurrent": {
                     "scope": "application",
                     "type": "number",
-                    "description": "How many jobs can be executing at the same time",
+                    "description": "How many perforce commands can be executing at the same time. Use zero for unlimited.",
                     "minimum": 0,
-                    "default": null
+                    "default": 10
                 },
                 "perforce.bottleneck.minTime": {
                     "scope": "application",
                     "type": "number",
-                    "description": "How long to wait after launching a job before launching another one",
+                    "description": "How long to wait (in milliseconds) after launching a perforce command before launching another one",
                     "minimum": 0
                 },
                 "perforce.bottleneck.highWater": {
                     "scope": "application",
                     "type": "number",
-                    "description": "How long can the queue be? When the queue length exceeds that value, the selected strategy is executed to shed the load",
+                    "description": "How many perforce commands can be queued? When the queue length exceeds that value, the selected strategy is executed to shed the load from the queue. Use zero for unlimited. **Low values are NOT recommended as useful commands may be dropped**",
                     "minimum": 0,
-                    "default": 50
+                    "default": 150
                 },
                 "perforce.bottleneck.strategy": {
                     "scope": "application",
                     "type": "string",
-                    "description": "Which strategy to use when the queue gets longer than the high water mark",
+                    "description": "Which strategy to use when the queue gets longer than the high water mark. Only applies when high water is > 0. See https://www.npmjs.com/package/bottleneck#strategies",
                     "enum": [
                         "LEAK",
                         "OVERFLOW_PRIORITY",
@@ -77,7 +77,7 @@
                     "type": "number",
                     "description": "The penalty value used by the BLOCK strategy",
                     "minimum": 0,
-                    "default": null
+                    "default": 0
                 },
                 "perforce.debugModeActive": {
                     "type": "boolean",

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -46,13 +46,14 @@ export function matchConfig(config: IPerforceConfig, uri: Uri): boolean {
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace PerforceService {
     const limiter: Bottleneck = new Bottleneck({
-        maxConcurrent: workspace
-            .getConfiguration("perforce")
-            .get<number>("bottleneck.maxConcurrent"),
+        maxConcurrent:
+            workspace
+                .getConfiguration("perforce")
+                .get<number>("bottleneck.maxConcurrent") || null,
         minTime: workspace.getConfiguration("perforce").get<number>("bottleneck.minTime"),
-        highWater: workspace
-            .getConfiguration("perforce")
-            .get<number>("bottleneck.highWater"),
+        highWater:
+            workspace.getConfiguration("perforce").get<number>("bottleneck.highWater") ||
+            null,
         strategy:
             Bottleneck.strategy[
                 workspace.getConfiguration("perforce").get<string>("bottleneck.strategy")
@@ -173,6 +174,9 @@ export namespace PerforceService {
         if (debugModeActive && !debugModeSetup) {
             limiter.on("error", err => {
                 console.warn("Bottleneck ERROR:", err);
+            });
+            limiter.on("dropped", info => {
+                console.warn("Bottleneck DROPPED:", info);
             });
             limiter.on("debug", (message, data) => {
                 console.log("Bottleneck Debug:", message, data);


### PR DESCRIPTION
Fixes #9

It's no longer possible to accidentally limit the max concurrent jobs to zero, which would prevent any perforce commands from running.

Default settings now limit to 10 max concurrent jobs, while high water is set to 150 as a failsafe.

Descriptions have been updated to clarify documentation - e.g. setting a low value for high water seems to be dangerous - in that commands will be dropped without explanation.

The high water is more of a failsafe in case the extension goes crazy, so ideally it should not be required. Seems most likely to occur in large perforce workspaces when syncing, with edit on modified / save enabled?


More things to look at:

* Bottleneck config is loaded on startup - must be reloaded to be applied. The API does provide an option to change the settings after initialisation.
* Tests for this