### PR TITLE
Refresh performance

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -36,6 +36,13 @@
                 "kind": "build",
                 "isDefault": true
             }
+        },
+        {
+            "type": "npm",
+            "script": "compile",
+            "presentation": {
+                "reveal": "silent"
+            }
         }
     ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ To contribute code:
 
 For non-trivial changes, it's a good idea to create an issue first to cover the change you would like to make.
 
+Note that references in the text below to `npm run` can generally be replaced with clicking on the correct button in vscode's `npm scripts` section in the explorer!
+
 ## Writing & Testing your Changes
 
 ### ESLint, Prettier and Webpack
@@ -43,7 +45,22 @@ The original project from which this was forked did not have a test framework, s
 
 Test suites are defined in `src/test`
 
-A launch configuration is provided to run the tests. Run the `Launch Extension` configuration and it will compile the typescript and open up vscode to run the tests (using the `vscode-test` package). Note that this uses tsc directly instead of webpack, as the tests are not included in the webpack build.
+There are two types of test:
+
+* **Unit tests**, that do not require the vscode API
+  * A single run can be started using `npm run unittest`
+  * You can also run a watch built that automatically runs the unit tests on every code change with `npm run watchunit`
+  * As the majority of files require the vscode API, the number of tests here is relatively small
+* **Integration tests**, that require the vscode API and run with a vscode window, using the `vscode-test` package
+  * Running the integration tests also includes the unit tests
+  * A single run of the integration tests can be started using `npm run integrationtest`, however a launch configuration is provided to run the tests in the debugger. Run the `Launch Extension` configuration and it will compile the typescript and open up vscode to run the tests (using the `vscode-test` package).
+  * You should leave the window alone while the tests run. If run from the debugger, the results will appear in the DEBUG CONSOLE view.
+  * Note that the integration tests stub the perforce command line. There can ocassionally be some 'interference' where error messages appear in the debug log, due to the extension reacting to events / editor windows opened by the test, between tests and after the stub has been destroyed. These can generally be ignored as long as they do not cause test failures and the errors do not show up repeatedly.
+
+Note that all of the tests use tsc directly instead of webpack, as the tests are not included in the webpack build.
+
+When you raise a pull request, the continuous integration job will run `npm run test`, which does both of the above - so make sure these pass before raising the pull request.
+
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1526,6 +1526,12 @@
             "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
             "dev": true
         },
+        "duplexer": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+            "dev": true
+        },
         "duplexify": {
             "version": "3.7.1",
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -1900,6 +1906,21 @@
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
+        },
+        "event-stream": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+            "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+            "dev": true,
+            "requires": {
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
+                "pause-stream": "0.0.11",
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
+            }
         },
         "events": {
             "version": "3.1.0",
@@ -2324,6 +2345,12 @@
             "requires": {
                 "map-cache": "^0.2.2"
             }
+        },
+        "from": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+            "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+            "dev": true
         },
         "from2": {
             "version": "2.3.0",
@@ -3893,6 +3920,12 @@
             "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
             "dev": true
         },
+        "map-stream": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+            "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+            "dev": true
+        },
         "map-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -4334,6 +4367,12 @@
                 "path-to-regexp": "^1.7.0"
             }
         },
+        "node-cleanup": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
+            "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
+            "dev": true
+        },
         "node-environment-flags": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
@@ -4708,6 +4747,15 @@
             "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
             "dev": true
         },
+        "pause-stream": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+            "dev": true,
+            "requires": {
+                "through": "~2.3"
+            }
+        },
         "pbkdf2": {
             "version": "3.0.17",
             "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -4817,6 +4865,21 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
             "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+            "dev": true
+        },
+        "ps-tree": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+            "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+            "dev": true,
+            "requires": {
+                "event-stream": "=3.3.4"
+            }
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
             "dev": true
         },
         "psl": {
@@ -5484,6 +5547,15 @@
             "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
             "dev": true
         },
+        "split": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+            "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+            "dev": true,
+            "requires": {
+                "through": "2"
+            }
+        },
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -5556,6 +5628,15 @@
                 "readable-stream": "^2.0.2"
             }
         },
+        "stream-combiner": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+            "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+            "dev": true,
+            "requires": {
+                "duplexer": "~0.1.1"
+            }
+        },
         "stream-each": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
@@ -5583,6 +5664,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
             "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+            "dev": true
+        },
+        "string-argv": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.1.2.tgz",
+            "integrity": "sha512-mBqPGEOMNJKXRo7z0keX0wlAhbBAjilUdPW13nN0PecVryZxdHIeM7TqbsSUA7VYuS00HGC6mojP7DlQzfa9ZA==",
             "dev": true
         },
         "string-width": {
@@ -5924,6 +6011,48 @@
                     "requires": {
                         "is-number": "^7.0.0"
                     }
+                }
+            }
+        },
+        "tsc-watch": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/tsc-watch/-/tsc-watch-4.1.0.tgz",
+            "integrity": "sha512-/czn0zT/4PXffuUyqtTTRkZwenk5UKQR0HN0N1iFW9k7tZXoJWvJq9H0w9orulSqAmyIwhVTNkcvsVf7e3NPPg==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^5.1.0",
+                "node-cleanup": "^2.1.2",
+                "ps-tree": "^1.2.0",
+                "string-argv": "^0.1.1",
+                "strip-ansi": "^4.0.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "lru-cache": {
+                    "version": "4.1.5",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+                    "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                    "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+                    "dev": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -700,7 +700,7 @@
         "unittest-nocompile": "node ./out/test/runUnitTest.js",
         "integrationtest-nocompile": "node ./out/test/runTest.js",
         "unittest": "npm run pretest && npm run unittest-nocompile",
-        "integrationtest": "npm run pretest && npm run unittest-nocompile",
+        "integrationtest": "npm run pretest && npm run integrationtest-nocompile",
         "watchunit": "tsc-watch -p ./ --onSuccess \"npm run unittest\""
     }
 }

--- a/package.json
+++ b/package.json
@@ -44,40 +44,9 @@
                 "perforce.bottleneck.maxConcurrent": {
                     "scope": "application",
                     "type": "number",
-                    "description": "How many jobs can be executing at the same time",
+                    "description": "How many perforce commands can be executing at the same time. This is intended to prevent the extension from overloading the perforce server if many files are modified at the same time. Further commands will be queued until the number of running commands reduces. Use 0 for unlimited (not recommended)",
                     "minimum": 0,
-                    "default": null
-                },
-                "perforce.bottleneck.minTime": {
-                    "scope": "application",
-                    "type": "number",
-                    "description": "How long to wait after launching a job before launching another one",
-                    "minimum": 0
-                },
-                "perforce.bottleneck.highWater": {
-                    "scope": "application",
-                    "type": "number",
-                    "description": "How long can the queue be? When the queue length exceeds that value, the selected strategy is executed to shed the load",
-                    "minimum": 0,
-                    "default": 50
-                },
-                "perforce.bottleneck.strategy": {
-                    "scope": "application",
-                    "type": "string",
-                    "description": "Which strategy to use when the queue gets longer than the high water mark",
-                    "enum": [
-                        "LEAK",
-                        "OVERFLOW_PRIORITY",
-                        "OVERFLOW",
-                        "BLOCK"
-                    ]
-                },
-                "perforce.bottleneck.penalty": {
-                    "scope": "application",
-                    "type": "number",
-                    "description": "The penalty value used by the BLOCK strategy",
-                    "minimum": 0,
-                    "default": null
+                    "default": 10
                 },
                 "perforce.debugModeActive": {
                     "type": "boolean",
@@ -708,6 +677,7 @@
         "sinon": "^8.1.0",
         "sinon-chai": "^3.4.0",
         "ts-loader": "^6.2.1",
+        "tsc-watch": "^4.1.0",
         "typescript": "^3.7.5",
         "vscode": "^1.1.36",
         "vscode-test": "^1.3.0",
@@ -726,6 +696,11 @@
         "compile": "tsc -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
         "pretest": "npm run compile",
-        "test": "node ./out/test/runTest.js"
+        "test": "npm run unittest-nocompile && npm run integrationtest-nocompile",
+        "unittest-nocompile": "node ./out/test/runUnitTest.js",
+        "integrationtest-nocompile": "node ./out/test/runTest.js",
+        "unittest": "npm run pretest && npm run unittest-nocompile",
+        "integrationtest": "npm run pretest && npm run unittest-nocompile",
+        "watchunit": "tsc-watch -p ./ --onSuccess \"npm run unittest\""
     }
 }

--- a/package.json
+++ b/package.json
@@ -701,6 +701,6 @@
         "integrationtest-nocompile": "node ./out/test/runTest.js",
         "unittest": "npm run pretest && npm run unittest-nocompile",
         "integrationtest": "npm run pretest && npm run integrationtest-nocompile",
-        "watchunit": "tsc-watch -p ./ --onSuccess \"npm run unittest\""
+        "watchunit": "tsc-watch -p ./ --onSuccess \"npm run unittest-nocompile\""
     }
 }

--- a/src/CommandLimiter.ts
+++ b/src/CommandLimiter.ts
@@ -1,0 +1,157 @@
+class QueueItem<T> {
+    private _next?: QueueItem<T>;
+    constructor(private _item: T) {}
+    set next(next: QueueItem<T>) {
+        this._next = next;
+    }
+    get next() {
+        return this._next;
+    }
+    get item() {
+        return this._item;
+    }
+}
+
+export class Queue<T> {
+    private _head?: QueueItem<T>;
+    private _tail?: QueueItem<T>;
+    private _length: number;
+
+    public get length() {
+        return this._length;
+    }
+
+    constructor() {
+        this._length = 0;
+    }
+
+    public enqueue(item: T) {
+        const qi = new QueueItem(item);
+        if (this._tail) {
+            this._tail.next = qi;
+        } else {
+            this._head = qi;
+        }
+        this._tail = qi;
+        ++this._length;
+    }
+
+    public dequeue(): T | undefined {
+        if (this._head) {
+            const ret = this._head;
+            this._head = this._head.next;
+            if (!this._head) {
+                this._tail = undefined;
+            }
+            --this._length;
+            return ret.item;
+        }
+    }
+}
+
+interface QueuedCommand {
+    id: string;
+    command: (callback: LimiterCallback) => any;
+    callback: LimiterCallback;
+}
+
+type LimiterCallback = () => void;
+
+export class CommandLimiter {
+    private _queue: Queue<QueuedCommand>;
+    private _running: Map<string, QueuedCommand>;
+    private _inDebugMode: boolean;
+
+    constructor(private _maxConcurrent: number) {
+        this._queue = new Queue<QueuedCommand>();
+        this._running = new Map<string, QueuedCommand>();
+        this._inDebugMode = false;
+    }
+
+    get queueLength() {
+        return this._queue.length;
+    }
+
+    get runningCount() {
+        return this._running.size;
+    }
+
+    set debugMode(on: boolean) {
+        this._inDebugMode = on;
+    }
+
+    private get logPrefix() {
+        return (
+            "Command Limiter: R: " + this.runningCount + " Q: " + this.queueLength + " : "
+        );
+    }
+
+    /**
+     * Submit a job to be executed
+     * @param command the command to run when the job is dequeued. The command MUST call the callback to indicate that it has completed.
+     * @param id an identifier for the job. MUST BE UNIQUE (TODO validate uniqueness)
+     * @returns a promise that resolves once the job has called the callback, or rejects if the job throws an error (regardless of whether it called the callback)
+     */
+    public submit(
+        command: (callback: LimiterCallback) => any,
+        id: string
+    ): Promise<void> {
+        let item: QueuedCommand;
+        const promise = new Promise<void>((res, rej) => {
+            const doneCallback = () => {
+                this.completed(id);
+                res();
+            };
+            item = {
+                id,
+                command: () => {
+                    try {
+                        command(doneCallback);
+                    } catch (err) {
+                        this.completed(id);
+                        rej(err);
+                    }
+                },
+                callback: doneCallback
+            };
+
+            if (this._maxConcurrent > 0 && this._running.size >= this._maxConcurrent) {
+                if (this._inDebugMode) {
+                    console.log(this.logPrefix + " ENQUEUE " + item.id);
+                }
+                this._queue.enqueue(item);
+            } else {
+                this.execute(item);
+            }
+        });
+
+        return promise;
+    }
+
+    private completed(id: string) {
+        if (this._inDebugMode) {
+            console.log(this.logPrefix + " COMPLETED " + id);
+        }
+        if (this._running.has(id)) {
+            this._running.delete(id);
+            this.executeNext();
+        }
+    }
+
+    private execute(item: QueuedCommand) {
+        if (this._inDebugMode) {
+            console.log(this.logPrefix + " EXECUTING " + item.id);
+        }
+        this._running.set(item.id, item);
+        setImmediate(() => item.command(item.callback));
+    }
+
+    private executeNext() {
+        if (this._maxConcurrent <= 0 || this._running.size < this._maxConcurrent) {
+            const item = this._queue.dequeue();
+            if (item) {
+                this.execute(item);
+            }
+        }
+    }
+}

--- a/src/ConfigService.ts
+++ b/src/ConfigService.ts
@@ -28,6 +28,10 @@ export class ConfigAccessor {
     public get maxFilePerCommand(): number {
         return this.getConfigItem("maxFilePerCommand");
     }
+
+    public get countBadge(): string {
+        return this.getConfigItem<string>("countBadge");
+    }
 }
 
 export class WorkspaceConfigAccessor extends ConfigAccessor {

--- a/src/ConfigService.ts
+++ b/src/ConfigService.ts
@@ -32,6 +32,10 @@ export class ConfigAccessor {
     public get countBadge(): string {
         return this.getConfigItem<string>("countBadge");
     }
+
+    public get refreshDebounceTime(): number {
+        return 1000;
+    }
 }
 
 export class WorkspaceConfigAccessor extends ConfigAccessor {

--- a/src/ConfigService.ts
+++ b/src/ConfigService.ts
@@ -1,0 +1,45 @@
+import { Uri, workspace } from "vscode";
+
+export class ConfigAccessor {
+    constructor() {
+        /**/
+    }
+
+    private getConfigItem<T>(item: string): T | undefined {
+        return workspace.getConfiguration("perforce").get<T>(item);
+    }
+
+    public get changelistOrder(): string {
+        return this.getConfigItem("changelistOrder") ?? "descending";
+    }
+
+    public get ignoredChangelistPrefix(): string | undefined {
+        return this.getConfigItem("ignoredChangelistPrefix");
+    }
+
+    public get hideNonWorkspaceFiles(): boolean {
+        return this.getConfigItem("hideNonWorkspaceFiles");
+    }
+
+    public get hideShelvedFiles(): boolean {
+        return this.getConfigItem("hideShelvedFiles");
+    }
+
+    public get maxFilePerCommand(): number {
+        return this.getConfigItem("maxFilePerCommand");
+    }
+}
+
+export class WorkspaceConfigAccessor extends ConfigAccessor {
+    constructor(private _workspaceUri: Uri) {
+        super();
+    }
+
+    private getWorkspaceConfigItem<T>(item: string): T | undefined {
+        return workspace.getConfiguration("perforce", this._workspaceUri).get<T>(item);
+    }
+
+    public get dir(): string {
+        return this.getWorkspaceConfigItem("dir");
+    }
+}

--- a/src/Debounce.ts
+++ b/src/Debounce.ts
@@ -1,0 +1,136 @@
+class DebouncedCall<P extends any[], T> {
+    private _expires: number;
+    private _expired: boolean;
+    private _promise: Promise<T>;
+    private _timer: NodeJS.Timeout;
+    res: (val: T) => void;
+    rej: (err: any) => void;
+
+    public constructor(
+        private _func: (...rest: P) => T,
+        now: number,
+        private _time: number
+    ) {
+        this._expires = now + _time;
+        this._expired = false;
+    }
+
+    public executeNow(...args: P): Promise<T> {
+        this._timer = setTimeout(() => {
+            this._expired = true;
+        }, this._expires - Date.now());
+        return Promise.resolve(this._func(...args));
+    }
+
+    public get canExecute() {
+        return !this._expired;
+    }
+
+    public executeAfterDebounce(now: number, ...args: P): Promise<T> {
+        this._expires = now + this._time;
+
+        if (this._promise === undefined) {
+            // a promise for the last execution
+            this._promise = new Promise((res, rej) => {
+                this.res = (val: T) => res(val);
+                this.rej = (err: any) => rej(err);
+            });
+        }
+
+        if (this._timer) {
+            clearTimeout(this._timer);
+        }
+        // overrides args with the last call
+        this._timer = setTimeout(() => {
+            try {
+                const ret = this._func(...args);
+                this.res(ret);
+            } catch (err) {
+                this.rej(err);
+            }
+            this._expired = true;
+        }, this._expires - Date.now());
+        return this._promise;
+    }
+
+    public cancel() {
+        if (this._timer && !this._expired) {
+            clearTimeout(this._timer);
+        }
+    }
+}
+
+export type DebouncedFunction<P extends any[], T> = {
+    (...args: P): Promise<T>;
+    /**
+     * Executes the function without attempting to perform a leading call.
+     * Even if the function has not been recently called, it will still wait for the
+     * timeout before running.
+     * @param args the arguments to pass to the function
+     */
+    withoutLeadingCall(...args: P): Promise<T>;
+    dispose(): void;
+};
+
+/**
+ * Factory to create a debounced function that:
+ * * Always executes on the leading edge,
+ * * Executes on the trailing edge if it is called again during the debounce period.
+ *
+ * For the first invocation of the returned function, the underlying function is
+ * called immediately and the result is returned in a resolved promise.
+ *
+ * For the next invocation, if `time` ms has not elapsed since the previous call,
+ * a promise is returned that resolves after `time` ms with the result of the function.
+ *
+ * For subsequent invocations, the same promise is returned, and the promise is delayed
+ * so that it resolves `time` ms after this call.
+ *
+ * If `time` ms has already elapsed since the last function call, the next invocation
+ * behaves like the first function call again.
+ *
+ * The leading function is invoked with the parameters of the first call.
+ * The trailing function is invoked with the parameters of the last call.
+ *
+ * The returned function is `disposable` (clears any waiting timeouts) and includes
+ * a `withoutLeadingCall` function, that can be used to omit the leading call.
+ *
+ * @param func The function to debounce
+ * @param time The time to wait before executing the trailing function
+ * @returns The debounced function
+ */
+export function debounce<P extends any[], T>(
+    func: (...rest: P) => T,
+    time: number
+): DebouncedFunction<P, T> {
+    let lastDebounced: DebouncedCall<P, T>;
+
+    const ret = (...args: P): Promise<T> => {
+        const now = Date.now();
+
+        if (!lastDebounced || !lastDebounced.canExecute) {
+            lastDebounced = new DebouncedCall(func, now, time);
+            return lastDebounced.executeNow(...args);
+        }
+
+        return lastDebounced.executeAfterDebounce(now, ...args);
+    };
+
+    ret.withoutLeadingCall = (...args: P): Promise<T> => {
+        const now = Date.now();
+
+        if (!lastDebounced || !lastDebounced.canExecute) {
+            lastDebounced = new DebouncedCall(func, now, time);
+        }
+
+        return lastDebounced.executeAfterDebounce(now, ...args);
+    };
+
+    ret.dispose = () => {
+        if (lastDebounced) {
+            lastDebounced.cancel();
+        }
+    };
+
+    return ret;
+}

--- a/src/Debounce.ts
+++ b/src/Debounce.ts
@@ -57,6 +57,9 @@ class DebouncedCall<P extends any[], T> {
         if (this._timer && !this._expired) {
             clearTimeout(this._timer);
         }
+        if (this._promise !== undefined && this.rej) {
+            this.rej("Debounced function cancelled");
+        }
     }
 }
 
@@ -130,6 +133,7 @@ export function debounce<P extends any[], T>(
         if (lastDebounced) {
             lastDebounced.cancel();
         }
+        lastDebounced = undefined;
     };
 
     return ret;

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -4,12 +4,15 @@ import * as Path from "path";
 
 import { PerforceService } from "./PerforceService";
 import { Utils } from "./Utils";
+import { debounce } from "./Debounce";
 
 let _statusBarItem: StatusBarItem;
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Display {
     export const channel = window.createOutputChannel("Perforce Log");
+
+    export const updateEditor = debounce(updateEditorImpl, 1000);
 
     export function initialize() {
         _statusBarItem = window.createStatusBarItem(
@@ -21,7 +24,7 @@ export namespace Display {
         updateEditor();
     }
 
-    export function updateEditor() {
+    function updateEditorImpl() {
         const editor = window.activeTextEditor;
         if (!editor) {
             if (_statusBarItem) {

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -119,6 +119,8 @@ export class PerforceSCMProvider {
             this.compatibilityMode
         );
 
+        this.disposables.push(this._model);
+
         PerforceSCMProvider.instances.push(this);
         this._model._sourceControl = scm.createSourceControl(
             this.id,

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -139,7 +139,7 @@ export class PerforceSCMProvider {
         this._model._sourceControl.inputBox.placeholder =
             "Message (press {0} to create changelist)";
 
-        await this._model.FullRefresh();
+        await this._model.RefreshImmediately();
     }
 
     public static registerCommands() {
@@ -290,12 +290,12 @@ export class PerforceSCMProvider {
         const perforceProvider = PerforceSCMProvider.GetInstance(
             sourceControl ? sourceControl.rootUri : null
         );
-        await perforceProvider._model.FullRefresh();
+        await perforceProvider._model.RefreshPolitely();
     }
 
     public static async RefreshAll() {
         const promises = PerforceSCMProvider.instances.map(provider =>
-            provider._model.FullRefresh()
+            provider._model.Refresh()
         );
         await Promise.all(promises);
     }

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -44,6 +44,10 @@ export class PerforceSCMProvider {
         return mapEvent(this._model.onDidChange, () => this);
     }
 
+    get onRefreshStarted(): Event<this> {
+        return mapEvent(this._model.onRefreshStarted, () => this);
+    }
+
     public get resources(): SourceControlResourceGroup[] {
         return this._model.ResourceGroups;
     }
@@ -120,7 +124,7 @@ export class PerforceSCMProvider {
 
         // Hook up the model change event to trigger our own event
         this._model.onDidChange(this.onDidModelChange.bind(this), this, this.disposables);
-        this._model.Refresh();
+        this._model.FullRefresh();
 
         this._model._sourceControl.inputBox.value = "";
         this._model._sourceControl.inputBox.placeholder =
@@ -273,12 +277,12 @@ export class PerforceSCMProvider {
         const perforceProvider = PerforceSCMProvider.GetInstance(
             sourceControl ? sourceControl.rootUri : null
         );
-        perforceProvider._model.Refresh();
+        perforceProvider._model.FullRefresh();
     }
 
     public static RefreshAll() {
         for (const provider of PerforceSCMProvider.instances) {
-            provider._model.Refresh();
+            provider._model.FullRefresh();
         }
     }
 

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -19,6 +19,7 @@ import { FileType } from "./scm/FileTypes";
 import { IPerforceConfig, matchConfig } from "./PerforceService";
 import * as Path from "path";
 import * as fs from "fs";
+import { WorkspaceConfigAccessor } from "./ConfigService";
 
 enum DiffType {
     WORKSPACE_V_DEPOT,
@@ -99,14 +100,24 @@ export class PerforceSCMProvider {
         return "idle";
     }
 
-    constructor(config: IPerforceConfig, wksFolder: Uri, compatibilityMode: string) {
+    constructor(
+        config: IPerforceConfig,
+        wksFolder: Uri,
+        private _workspaceConfig: WorkspaceConfigAccessor,
+        compatibilityMode: string
+    ) {
         this.compatibilityMode = compatibilityMode;
         this.wksFolder = wksFolder;
         this.config = config;
     }
 
     public async Initialize() {
-        this._model = new Model(this.config, this.wksFolder, this.compatibilityMode);
+        this._model = new Model(
+            this.config,
+            this.wksFolder,
+            this._workspaceConfig,
+            this.compatibilityMode
+        );
 
         PerforceSCMProvider.instances.push(this);
         this._model._sourceControl = scm.createSourceControl(

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -247,14 +247,16 @@ export class PerforceSCMProvider {
         return null;
     }
 
-    public static OpenFile(...resourceStates: SourceControlResourceState[]) {
+    public static async OpenFile(...resourceStates: SourceControlResourceState[]) {
         const selection = resourceStates.filter(s => s instanceof Resource) as Resource[];
         const preview = selection.length == 1;
-        for (const resource of selection) {
-            commands.executeCommand<void>("vscode.open", resource.underlyingUri, {
+        const promises = selection.map(resource => {
+            return commands.executeCommand<void>("vscode.open", resource.underlyingUri, {
                 preview
             });
-        }
+        });
+
+        await Promise.all(promises);
     }
 
     public static async Open(...resourceStates: SourceControlResourceState[]) {
@@ -486,11 +488,11 @@ export class PerforceSCMProvider {
                 console.error("Status not supported: " + resource.status.toString());
                 return;
             }
-            await commands.executeCommand<void>("vscode.open", right);
+            await window.showTextDocument(right);
             return;
         }
         if (!right) {
-            await commands.executeCommand<void>("vscode.open", left);
+            await window.showTextDocument(left);
             return;
         }
         await commands.executeCommand<void>("vscode.diff", left, right, title);

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -59,9 +59,7 @@ export class PerforceSCMProvider {
         return "Perforce";
     }
     public get count(): number {
-        const countBadge = workspace
-            .getConfiguration("perforce")
-            .get<string>("countBadge");
+        const countBadge = this._workspaceConfig.countBadge;
         const statuses = this._model.ResourceGroups.reduce(
             (a, b) =>
                 a.concat(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,7 +64,9 @@ function TryCreateP4(uri: vscode.Uri): Promise<boolean> {
             }
 
             PerforceService.addConfig(config, wksUri.fsPath);
-            _disposable.push(new PerforceSCMProvider(config, wksUri, compatibilityMode));
+            const scm = new PerforceSCMProvider(config, wksUri, compatibilityMode);
+            scm.Initialize();
+            _disposable.push(scm);
             _disposable.push(new FileSystemListener(wksFolder));
 
             // Register only once

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import * as Path from "path";
 import * as fs from "fs";
 import * as Ini from "ini";
 import { Disposable } from "vscode";
+import { WorkspaceConfigAccessor } from "./ConfigService";
 
 let _isRegistered = false;
 const _disposable: vscode.Disposable[] = [];
@@ -64,7 +65,13 @@ function TryCreateP4(uri: vscode.Uri): Promise<boolean> {
             }
 
             PerforceService.addConfig(config, wksUri.fsPath);
-            const scm = new PerforceSCMProvider(config, wksUri, compatibilityMode);
+            const workspaceConfig = new WorkspaceConfigAccessor(wksUri);
+            const scm = new PerforceSCMProvider(
+                config,
+                wksUri,
+                workspaceConfig,
+                compatibilityMode
+            );
             scm.Initialize();
             _disposable.push(scm);
             _disposable.push(new FileSystemListener(wksFolder));

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -40,6 +40,7 @@ export class Model implements Disposable {
     }
 
     public dispose() {
+        this.clean();
         if (this._disposables) {
             this._disposables.forEach(d => d.dispose());
             this._disposables = [];
@@ -739,7 +740,7 @@ export class Model implements Disposable {
         this._onDidChange.fire();
     }
 
-    private getResourceForOpenFile(fstatInfo: {}) {
+    private getResourceForOpenFile(fstatInfo: {}): Resource | undefined {
         const clientFile = fstatInfo["clientFile"];
         const change = fstatInfo["change"];
         const action = fstatInfo["action"];
@@ -769,7 +770,10 @@ export class Model implements Disposable {
         return resource;
     }
 
-    private createResourceGroups(changelists: ChangeInfo[], resources: Resource[]) {
+    private createResourceGroups(
+        changelists: ChangeInfo[],
+        resources: (Resource | undefined)[]
+    ) {
         this.clean();
 
         this._defaultGroup = this._sourceControl.createResourceGroup(
@@ -778,7 +782,7 @@ export class Model implements Disposable {
         );
         this._defaultGroup["model"] = this;
         this._defaultGroup.resourceStates = resources.filter(
-            resource => resource.change === "default"
+            resource => resource && resource.change === "default"
         );
 
         const groups = changelists.map(c => {
@@ -788,7 +792,7 @@ export class Model implements Disposable {
             );
             group["model"] = this;
             group.resourceStates = resources.filter(
-                resource => resource.change === c.chnum.toString()
+                resource => resource && resource.change === c.chnum.toString()
             );
             return group;
         });
@@ -913,7 +917,7 @@ export class Model implements Disposable {
             opened = output.trim().split("\n");
         } catch (err) {
             // perforce writes to stderr if no files are opened.
-            console.log("ERROR: " + err);
+            //console.log("ERROR: " + err);
         }
 
         const files = [];

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -125,14 +125,14 @@ export class Model implements Disposable {
     }
 
     public async RefreshPolitely() {
-        await this._refresh();
+        await this._refresh(true);
     }
 
     public async RefreshImmediately() {
-        await this.RefreshImpl();
+        await this.RefreshImpl(true);
     }
 
-    private async RefreshImpl(): Promise<void> {
+    private async RefreshImpl(refreshClientInfo?: boolean): Promise<void> {
         // don't clean the changelists now - this will be done by updateStatus
         // seeing an empty scm view and waiting for it to populate makes it feel slower.
         this._onRefreshStarted.fire();
@@ -145,7 +145,7 @@ export class Model implements Disposable {
             return;
         }
 
-        if (!this.clientName) {
+        if (!this.clientName || refreshClientInfo) {
             await window.withProgress(
                 {
                     location: ProgressLocation.SourceControl,

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -906,7 +906,9 @@ export class Model implements Disposable {
             await depotOpenedFilePromises,
             "-Or"
         );
-        return fstatInfo.map(info => this.getResourceForOpenFile(info));
+        return fstatInfo
+            .filter(info => !!info) // in case fstat doesn't have output for this file
+            .map(info => this.getResourceForOpenFile(info));
     }
 
     private async getDepotOpenedFilePaths(): Promise<string[]> {

--- a/src/test/helpers/helpers.d.ts
+++ b/src/test/helpers/helpers.d.ts
@@ -2,6 +2,7 @@ declare module "chai" {
     global {
         export namespace Chai {
             interface Assertion {
+                p4Uri(resource: import("vscode").Uri): void;
                 vscodeOpenCall(resource: import("vscode").Uri): void;
                 vscodeDiffCall(
                     left: import("vscode").Uri,

--- a/src/test/helpers/helpers.d.ts
+++ b/src/test/helpers/helpers.d.ts
@@ -8,6 +8,18 @@ declare module "chai" {
                     right: import("vscode").Uri,
                     title: string
                 ): void;
+                resources(
+                    expecteds: {
+                        depotPath: string;
+                        operation: import("../../scm/Status").Status;
+                    }[]
+                ): void;
+                shelvedResources(
+                    expecteds: {
+                        depotPath: string;
+                        operation: import("../../scm/Status").Status;
+                    }[]
+                ): void;
             }
         }
     }

--- a/src/test/helpers/p4Commands.ts
+++ b/src/test/helpers/p4Commands.ts
@@ -37,6 +37,12 @@ function resourceToString(resource: Resource) {
 export default function(chai: Chai.ChaiStatic, _utils: Chai.ChaiUtils) {
     const Assertion = chai.Assertion;
 
+    Assertion.addMethod("p4Uri", function(resource: vscode.Uri) {
+        const obj: vscode.Uri = this._obj as vscode.Uri;
+
+        assertP4UriMatches(Assertion, obj, resource, "uri");
+    });
+
     Assertion.addMethod("vscodeOpenCall", function(resource: vscode.Uri) {
         const obj: SinonSpyCall = this._obj as SinonSpyCall;
 

--- a/src/test/helpers/p4Commands.ts
+++ b/src/test/helpers/p4Commands.ts
@@ -21,6 +21,19 @@ function assertP4UriMatches(
     new Assertion(got.query).to.have.string(expected.query, message);
 }
 
+function resourceToString(resource: Resource) {
+    return JSON.stringify(
+        {
+            uri: resource.uri,
+            depotPath: resource.depotPath,
+            status: resource.status,
+            isShelved: resource.isShelved
+        },
+        undefined,
+        2
+    );
+}
+
 export default function(chai: Chai.ChaiStatic, _utils: Chai.ChaiUtils) {
     const Assertion = chai.Assertion;
 
@@ -44,6 +57,7 @@ export default function(chai: Chai.ChaiStatic, _utils: Chai.ChaiUtils) {
         new Assertion(obj.args[3]).to.be.string(title, "Title");
     });
 
+    // TODO - this code is excessive - can be simplified - possibly with expect.to.include
     Assertion.addMethod("resources", function(
         expecteds: { depotPath: string; operation: Status }[]
     ) {
@@ -57,14 +71,21 @@ export default function(chai: Chai.ChaiStatic, _utils: Chai.ChaiUtils) {
             const resource: Resource = obj[i];
             new Assertion(resource.depotPath).to.be.equal(
                 expected.depotPath,
-                "Unexpected depot path for resource " + i
-            );
-            new Assertion(resource.status, "Resource " + i + "operation").to.equal(
-                expected.operation
+                "Unexpected depot path for resource " +
+                    i +
+                    " : " +
+                    resourceToString(resource)
             );
             new Assertion(
+                resource.status,
+                "Resource " + i + "operation mismatch : " + resourceToString(resource)
+            ).to.equal(expected.operation);
+            new Assertion(
                 resource.isShelved,
-                "Resource " + i + " should not be marked as shelved"
+                "Resource " +
+                    i +
+                    " should not be marked as shelved : " +
+                    resourceToString(resource)
             ).to.be.false;
             // TODO rest of the fields
         });
@@ -83,15 +104,24 @@ export default function(chai: Chai.ChaiStatic, _utils: Chai.ChaiUtils) {
             const resource: Resource = obj[i];
             new Assertion(resource.depotPath).to.be.equal(
                 expected.depotPath,
-                "Unexpected depot path for resource " + i
+                "Unexpected depot path for resource " +
+                    i +
+                    " : " +
+                    resourceToString(resource)
             );
             new Assertion(
                 resource.status,
-                "Shelved resource " + i + "operation"
+                "Shelved resource " +
+                    i +
+                    "operation mismatch : " +
+                    resourceToString(resource)
             ).to.equal(expected.operation);
             new Assertion(
                 resource.isShelved,
-                "Shelved resource " + i + " should not be marked as shelved"
+                "Shelved resource " +
+                    i +
+                    " should not be marked as shelved : " +
+                    resourceToString(resource)
             ).to.be.true;
             // TODO rest of the fields
         });

--- a/src/test/helpers/p4Commands.ts
+++ b/src/test/helpers/p4Commands.ts
@@ -1,5 +1,7 @@
 import { SinonSpyCall } from "sinon";
 import * as vscode from "vscode";
+import { Resource } from "../../scm/Resource";
+import { Status } from "../../scm/Status";
 
 function assertP4UriMatches(
     Assertion: Chai.AssertionStatic,
@@ -40,5 +42,58 @@ export default function(chai: Chai.ChaiStatic, _utils: Chai.ChaiUtils) {
         assertP4UriMatches(Assertion, obj.args[1], left, "Left Resource");
         assertP4UriMatches(Assertion, obj.args[2], right, "Right Resource");
         new Assertion(obj.args[3]).to.be.string(title, "Title");
+    });
+
+    Assertion.addMethod("resources", function(
+        expecteds: { depotPath: string; operation: Status }[]
+    ) {
+        const obj: Resource[] = this._obj as Resource[];
+
+        new Assertion(obj).to.have.length(
+            expecteds.length,
+            "Unexpected length for resource array"
+        );
+        expecteds.forEach((expected, i) => {
+            const resource: Resource = obj[i];
+            new Assertion(resource.depotPath).to.be.equal(
+                expected.depotPath,
+                "Unexpected depot path for resource " + i
+            );
+            new Assertion(resource.status, "Resource " + i + "operation").to.equal(
+                expected.operation
+            );
+            new Assertion(
+                resource.isShelved,
+                "Resource " + i + " should not be marked as shelved"
+            ).to.be.false;
+            // TODO rest of the fields
+        });
+    });
+
+    Assertion.addMethod("shelvedResources", function(
+        expecteds: { depotPath: string; operation: Status }[]
+    ) {
+        const obj: Resource[] = this._obj as Resource[];
+
+        new Assertion(obj).to.have.length(
+            expecteds.length,
+            "Unexpected length for shelved resource array"
+        );
+        expecteds.forEach((expected, i) => {
+            const resource: Resource = obj[i];
+            new Assertion(resource.depotPath).to.be.equal(
+                expected.depotPath,
+                "Unexpected depot path for resource " + i
+            );
+            new Assertion(
+                resource.status,
+                "Shelved resource " + i + "operation"
+            ).to.equal(expected.operation);
+            new Assertion(
+                resource.isShelved,
+                "Shelved resource " + i + " should not be marked as shelved"
+            ).to.be.true;
+            // TODO rest of the fields
+        });
     });
 }

--- a/src/test/runUnitTest.ts
+++ b/src/test/runUnitTest.ts
@@ -1,0 +1,12 @@
+import { run } from "./suite/unit/index";
+
+async function main() {
+    try {
+        await run();
+    } catch (err) {
+        console.error("Failed to run tests " + err);
+        process.exit(1);
+    }
+}
+
+main();

--- a/src/test/suite/StubPerforceService.ts
+++ b/src/test/suite/StubPerforceService.ts
@@ -345,9 +345,9 @@ export class StubPerforceService {
             throw new Error("No stub for perforce command: " + cmd);
         }
         const ret = func(this, resource, allArgs, directoryOverride, input);
-        setTimeout(() => {
+        setImmediate(() => {
             responseCallback(undefined, ret[0], ret[1]);
-        }, 0);
+        });
     }
 
     getChangelist(chnum: string) {

--- a/src/test/suite/StubPerforceService.ts
+++ b/src/test/suite/StubPerforceService.ts
@@ -195,6 +195,11 @@ export const makeResponses = (
                                   .join("\n");
                           })
                           .join("\n");
+
+                      if (!ret) {
+                          return stderr("no open files (not a real error - ignore)");
+                      }
+
                       return stdout(ret);
                   }
               },

--- a/src/test/suite/StubPerforceService.ts
+++ b/src/test/suite/StubPerforceService.ts
@@ -39,7 +39,7 @@ interface StubChangelist {
 }
 
 export interface StubFile {
-    localFile: vscode.Uri;
+    localFile?: vscode.Uri; // may be undefined where shelved for add and no local file
     depotPath: string;
     depotRevision: number;
     behaviours?: StubFileBehaviours;
@@ -185,8 +185,9 @@ export const makeResponses = (
                                   .map(
                                       f =>
                                           getDepotPathAndOp(f, true) +
-                                          " change " +
-                                          c.chnum +
+                                          (c.chnum === "default"
+                                              ? " default change"
+                                              : " change " + c.chnum) +
                                           " (" +
                                           (f.fileType ?? "text") +
                                           ")"

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -38,6 +38,72 @@ interface TestItems {
 
 describe("Model & ScmProvider modules", () => {
     const workspaceUri = vscode.workspace.workspaceFolders[0].uri;
+
+    const basicFiles = {
+        edit: {
+            localFile: getLocalFile(workspaceUri, "testFolder", "a.txt"),
+            depotPath: "//depot/testArea/testFolder/a.txt",
+            depotRevision: 1,
+            operation: Status.EDIT
+        },
+        delete: {
+            localFile: getLocalFile(workspaceUri, "testFolder", "deleted.txt"),
+            depotPath: "//depot/testArea/testFolder/deleted.txt",
+            depotRevision: 2,
+            operation: Status.DELETE
+        },
+        add: {
+            localFile: getLocalFile(workspaceUri, "testFolder", "new.txt"),
+            depotPath: "//depot/testArea/testFolder/new.txt",
+            depotRevision: 3,
+            operation: Status.ADD
+        },
+        moveAdd: {
+            localFile: getLocalFile(workspaceUri, "testFolder", "moved.txt"),
+            depotPath: "//depot/testArea/testFolder/moved.txt",
+            depotRevision: 1,
+            operation: Status.MOVE_ADD,
+            resolveFromDepotPath: "//depot/testArea/testFolderOld/movedFrom.txt"
+        },
+        moveDelete: {
+            localFile: getLocalFile(workspaceUri, "testFolderOld", "movedFrom.txt"),
+            depotPath: "//depot/testArea/testFolderOld/movedFrom.txt",
+            depotRevision: 3,
+            operation: Status.MOVE_DELETE
+        },
+        branch: {
+            localFile: getLocalFile(workspaceUri, "testFolder", "branched.txt"),
+            depotPath: "//depot/testArea/testFolder/branched.txt",
+            depotRevision: 1,
+            operation: Status.BRANCH,
+            resolveFromDepotPath: "//depot/testAreaOld/testFolder/branchedFrom.txt"
+        },
+        integrate: {
+            localFile: getLocalFile(workspaceUri, "testFolder", "integrated.txt"),
+            depotPath: "//depot/testArea/testFolder/integrated.txt",
+            depotRevision: 7,
+            operation: Status.INTEGRATE,
+            resolveFromDepotPath: "//depot/testAreaOld/testFolder/integrated.txt"
+        },
+        shelveNoWorkspace: {
+            depotPath: "//depot/testArea/testFolder/none.txt",
+            depotRevision: 1,
+            operation: Status.ADD
+        },
+        shelveEdit: {
+            localFile: getLocalFile(workspaceUri, "testFolder", "a.txt"),
+            depotPath: "//depot/testArea/testFolder/a.txt",
+            depotRevision: 1,
+            operation: Status.EDIT
+        },
+        shelveDelete: {
+            localFile: getLocalFile(workspaceUri, "testFolder", "deleted.txt"),
+            depotPath: "//depot/testArea/testFolder/deleted.txt",
+            depotRevision: 2,
+            operation: Status.DELETE
+        }
+    };
+
     const config: IPerforceConfig = {
         localDir: workspaceUri.fsPath,
         p4Client: "cli",
@@ -55,658 +121,896 @@ describe("Model & ScmProvider modules", () => {
     after(() => {
         doc.dispose();
     });
-    beforeEach(async function() {
-        this.timeout(4000);
-        const showMessage = sinon.spy(Display, "showMessage");
-        const showError = sinon.spy(Display, "showError");
-
-        const stubService = new StubPerforceService();
-        stubService.changelists = [
-            {
-                chnum: "1",
-                description: "Changelist 1",
-                files: [
-                    {
-                        localFile: getLocalFile(workspaceUri, "testFolder", "a.txt"),
-                        depotPath: "//depot/testArea/testFolder/a.txt",
-                        depotRevision: 1,
-                        operation: Status.EDIT
-                    },
-                    {
-                        localFile: getLocalFile(
-                            workspaceUri,
-                            "testFolder",
-                            "deleted.txt"
-                        ),
-                        depotPath: "//depot/testArea/testFolder/deleted.txt",
-                        depotRevision: 2,
-                        operation: Status.DELETE
-                    },
-                    {
-                        localFile: getLocalFile(workspaceUri, "testFolder", "new.txt"),
-                        depotPath: "//depot/testArea/testFolder/new.txt",
-                        depotRevision: 3,
-                        operation: Status.ADD
-                    },
-                    {
-                        localFile: getLocalFile(workspaceUri, "testFolder", "moved.txt"),
-                        depotPath: "//depot/testArea/testFolder/moved.txt",
-                        depotRevision: 1,
-                        operation: Status.MOVE_ADD,
-                        resolveFromDepotPath:
-                            "//depot/testArea/testFolderOld/movedFrom.txt"
-                    },
-                    {
-                        localFile: getLocalFile(
-                            workspaceUri,
-                            "testFolderOld",
-                            "movedFrom.txt"
-                        ),
-                        depotPath: "//depot/testArea/testFolderOld/movedFrom.txt",
-                        depotRevision: 3,
-                        operation: Status.MOVE_DELETE
-                    },
-                    {
-                        localFile: getLocalFile(
-                            workspaceUri,
-                            "testFolder",
-                            "branched.txt"
-                        ),
-                        depotPath: "//depot/testArea/testFolder/branched.txt",
-                        depotRevision: 1,
-                        operation: Status.BRANCH,
-                        resolveFromDepotPath:
-                            "//depot/testAreaOld/testFolder/branchedFrom.txt"
-                    },
-                    {
-                        localFile: getLocalFile(
-                            workspaceUri,
-                            "testFolder",
-                            "integrated.txt"
-                        ),
-                        depotPath: "//depot/testArea/testFolder/integrated.txt",
-                        depotRevision: 7,
-                        operation: Status.INTEGRATE,
-                        resolveFromDepotPath:
-                            "//depot/testAreaOld/testFolder/integrated.txt"
-                    }
-                ],
-                shelvedFiles: [
-                    {
-                        localFile: getLocalFile(workspaceUri, "testFolder", "a.txt"),
-                        depotPath: "//depot/testArea/testFolder/a.txt",
-                        depotRevision: 1,
-                        operation: Status.EDIT
-                    },
-                    {
-                        localFile: getLocalFile(
-                            workspaceUri,
-                            "testFolder",
-                            "deleted.txt"
-                        ),
-                        depotPath: "//depot/testArea/testFolder/deleted.txt",
-                        depotRevision: 2,
-                        operation: Status.DELETE
-                    }
-                ]
-            },
-            {
-                chnum: "2",
-                description: "Changelist 2",
-                files: [],
-                behaviours: {
-                    shelve: returnStdErr("my shelve error"),
-                    unshelve: returnStdErr("my unshelve error")
-                }
-            },
-            {
-                chnum: "3",
-                description: "Changelist 3",
-                submitted: true,
-                files: []
-            }
-        ];
-        const execute = stubService.stubExecute();
-
-        const instance = new PerforceSCMProvider(config, workspaceUri, "perforce");
-        subscriptions.push(instance);
-        const showImportantError = sinon.spy(Display, "showImportantError");
-
-        const promise = new Promise(res => {
-            subscriptions.push(
-                instance.onDidChange(() => {
-                    res();
-                })
-            );
-        });
-
-        const refresh = sinon.spy();
-
-        items = {
-            stubService,
-            instance,
-            execute,
-            showMessage,
-            showError,
-            showImportantError,
-            refresh
-        };
-
-        await promise;
-
-        subscriptions.push(instance.onRefreshStarted(refresh));
-    });
-    afterEach(async () => {
-        await vscode.commands.executeCommand("workbench.action.closeAllEditors");
-        subscriptions.forEach(sub => sub.dispose());
-        subscriptions = [];
-        sinon.restore();
-    });
-
-    describe("Shelving a changelist", () => {
-        it("Cannot shelve the default changelist", async () => {
-            await expect(
-                PerforceSCMProvider.ShelveChangelist(items.instance.resources[0])
-            ).to.eventually.be.rejectedWith("Cannot shelve the default changelist");
-            expect(items.execute).not.to.have.been.calledWithMatch(
-                workspaceUri,
-                "shelve"
-            );
-            expect(items.refresh).not.to.have.been.called;
-        });
-
-        it("Can shelve a valid Changelist", async () => {
-            await PerforceSCMProvider.ShelveChangelist(items.instance.resources[1]);
-            expect(items.execute).to.have.been.calledWithMatch(
-                workspaceUri,
-                "shelve",
-                sinon.match.any,
-                "-f -c 1"
-            );
-            expect(items.showMessage).to.have.been.calledOnceWith("Changelist shelved");
-            expect(items.refresh).to.have.been.calledOnce;
-        });
-
-        it("Can shelve and revert a valid changelist", async () => {
-            await PerforceSCMProvider.ShelveRevertChangelist(items.instance.resources[1]);
-            expect(items.execute).to.have.been.calledWithMatch(
-                workspaceUri,
-                "shelve",
-                sinon.match.any,
-                "-f -c 1"
-            );
-            expect(items.execute).to.have.been.calledWithMatch(
-                workspaceUri,
-                "revert",
-                sinon.match.any,
-                "-c 1 //..."
-            );
-            expect(items.showMessage).to.have.been.calledOnceWith("Changelist shelved");
-            expect(items.refresh).to.have.been.calledOnce;
-        });
-
-        it("Can handle an error when shelving a changelist", async () => {
-            await PerforceSCMProvider.ShelveChangelist(items.instance.resources[2]);
-            expect(items.execute).to.have.been.calledWithMatch(
-                workspaceUri,
-                "shelve",
-                sinon.match.any,
-                "-f -c 2"
-            );
-            expect(items.showMessage).not.to.have.been.called;
-            expect(items.showImportantError).to.have.been.calledOnceWith(
-                "my shelve error"
-            );
-            expect(items.refresh).to.have.been.calledOnce;
-        });
-
-        it("Can handle an error when shelving and reverting a changelist", async () => {
-            await PerforceSCMProvider.ShelveRevertChangelist(items.instance.resources[2]);
-            expect(items.execute).to.have.been.calledWithMatch(
-                workspaceUri,
-                "shelve",
-                sinon.match.any,
-                "-f -c 2"
-            );
-            expect(items.showMessage).not.to.have.been.called;
-            expect(items.showImportantError).to.have.been.calledOnceWith(
-                "my shelve error"
-            );
-            expect(items.execute).not.to.have.been.calledWithMatch(
-                workspaceUri,
-                "revert"
-            );
-            expect(items.refresh).to.have.been.calledOnce;
-        });
-    });
-
-    describe("Unshelving a changelist", () => {
-        it("Can unshelve a valid Changelist", async () => {
-            await PerforceSCMProvider.UnshelveChangelist(items.instance.resources[1]);
-            expect(items.execute).to.have.been.calledWithMatch(
-                workspaceUri,
-                "unshelve",
-                sinon.match.any,
-                "-f -s 1"
-            );
-            expect(items.showMessage).to.have.been.calledOnceWith("Changelist unshelved");
-            expect(items.refresh).to.have.been.calledOnce;
-        });
-
-        it("Cannot unshelve default changelist", async () => {
-            await expect(
-                PerforceSCMProvider.UnshelveChangelist(items.instance.resources[0])
-            ).to.eventually.be.rejectedWith("Cannot unshelve the default changelist");
-            expect(items.execute).not.to.have.been.calledWithMatch(
-                workspaceUri,
-                "unshelve"
-            );
-            expect(items.refresh).not.to.have.been.called;
-        });
-
-        it("Can handle an error when unshelving a changelist", async () => {
-            await PerforceSCMProvider.UnshelveChangelist(items.instance.resources[2]);
-            expect(items.execute).to.have.been.calledWithMatch(
-                workspaceUri,
-                "unshelve",
-                sinon.match.any,
-                "-f -s 2 -c 2"
-            );
-            expect(items.showMessage).not.to.have.been.called;
-            expect(items.showImportantError).to.have.been.calledOnceWith(
-                "my unshelve error"
-            );
-            expect(items.refresh).not.to.have.been.called;
-        });
-    });
-
-    describe("Deleting a shelve", () => {
-        it("Deletes a shelved changelist", async () => {
-            // accept the warning
-            const warn = sinon.stub(vscode.window, "showWarningMessage").resolvesArg(2);
-
-            await PerforceSCMProvider.DeleteShelvedChangelist(
-                items.instance.resources[1]
-            );
-
-            expect(warn).to.have.been.calledOnce;
-            expect(items.refresh).to.have.been.calledOnce;
-            expect(items.execute).to.have.been.calledWithMatch(
-                workspaceUri,
-                "shelve",
-                sinon.match.any,
-                "-d -c 1"
-            );
-        });
-
-        it("Can cancel deleting a shelved changelist", async () => {
-            // close the warning without accepting
-            const warn = sinon
-                .stub(vscode.window, "showWarningMessage")
-                .resolves(undefined);
-
-            await PerforceSCMProvider.DeleteShelvedChangelist(
-                items.instance.resources[1]
-            );
-
-            expect(warn).to.have.been.calledOnce;
-            expect(items.refresh).not.to.have.been.called;
-            expect(items.execute).not.to.have.been.calledWithMatch(
-                workspaceUri,
-                "shelve"
-            );
-        });
-
-        it("Can handle an error when deleting a shelved changelist", async () => {
-            // accept the warning
-            const warn = sinon.stub(vscode.window, "showWarningMessage").resolvesArg(2);
-
-            await PerforceSCMProvider.DeleteShelvedChangelist(
-                items.instance.resources[2]
-            );
-
-            expect(warn).to.have.been.calledOnce;
-            expect(items.execute).to.have.been.calledWithMatch(
-                workspaceUri,
-                "shelve",
-                sinon.match.any,
-                "-d -c 2"
-            );
-            expect(items.showImportantError).to.have.been.calledOnceWith(
-                "my shelve error"
-            );
-            expect(items.refresh).not.to.have.been.called;
-        });
-
-        it("Cannot delete from the default changelist", async () => {
-            await expect(
-                PerforceSCMProvider.DeleteShelvedChangelist(items.instance.resources[0])
-            ).to.eventually.be.rejectedWith(
-                "Cannot delete shelved files from the default changelist"
-            );
-            expect(items.execute).not.to.have.been.calledWithMatch(
-                workspaceUri,
-                "shelve"
-            );
-            expect(items.refresh).not.to.have.been.called;
-        });
-    });
-
-    describe("Opening", () => {
-        function findResourceForShelvedFile(
-            group: vscode.SourceControlResourceGroup,
-            file: StubFile
-        ) {
-            return group.resourceStates.find(
-                resource =>
-                    (resource as Resource).isShelved &&
-                    Utils.getDepotPathFromDepotUri(resource.resourceUri) ===
-                        file.depotPath
-            );
-        }
-
-        function findResourceForFile(
-            group: vscode.SourceControlResourceGroup,
-            file: StubFile
-        ) {
-            return group.resourceStates.find(
-                resource =>
-                    !(resource as Resource).isShelved &&
-                    (resource as Resource).resourceUri.fsPath === file.localFile.fsPath
-            );
-        }
-
-        /**
-         * Matches against a perforce URI, containing a local file's path
-         * @param file
-         */
-        function perforceLocalUriMatcher(file: StubFile) {
-            return Utils.makePerforceDocUri(file.localFile, "print", "-q", {
-                workspace: workspaceUri.fsPath
-            });
-        }
-
-        /**
-         * Matches against a perforce URI, using the depot path for a file
-         * @param file
-         */
-        function perforceDepotUriMatcher(file: StubFile) {
-            return Utils.makePerforceDocUri(
-                vscode.Uri.parse("perforce:" + file.depotPath),
-                "print",
-                "-q",
-                { depot: true, workspace: workspaceUri.fsPath }
-            );
-        }
-
-        /**
-         * Matches against a perforce URI, using the resolvedFromFile0 depot path
-         * @param file
-         */
-        function perforceFromFileUriMatcher(file: StubFile) {
-            return Utils.makePerforceDocUri(
-                vscode.Uri.parse("perforce:" + file.resolveFromDepotPath),
-                "print",
-                "-q",
-                { depot: true, workspace: workspaceUri.fsPath }
-            );
-        }
-
-        /**
-         * Matches against a perforce URI, using the depot path for the file AND containing a fragment for the shelved changelist number
-         * @param file
-         * @param chnum
-         */
-        function perforceShelvedUriMatcher(file: StubFile, chnum: string) {
-            return Utils.makePerforceDocUri(
-                vscode.Uri.parse("perforce:" + file.depotPath).with({
-                    fragment: "@=" + chnum
-                }),
-                "print",
-                "-q",
-                { depot: true, workspace: workspaceUri.fsPath }
-            );
-        }
-
-        function perforceLocalShelvedUriMatcher(file: StubFile, chnum: string) {
-            return Utils.makePerforceDocUri(
-                file.localFile.with({ fragment: "@=" + chnum }),
-                "print",
-                "-q",
-                { workspace: workspaceUri.fsPath }
-            );
-        }
-
-        let execCommand: sinon.SinonSpy;
-        beforeEach(function() {
+    describe("Refresh / Initialize", function() {
+        let stubService: StubPerforceService;
+        let instance: PerforceSCMProvider;
+        this.beforeEach(function() {
             this.timeout(4000);
-            execCommand = sinon.spy(vscode.commands, "executeCommand");
+
+            stubService = new StubPerforceService();
+            stubService.changelists = [];
+            stubService.stubExecute();
+
+            instance = new PerforceSCMProvider(config, workspaceUri, "perforce");
+            subscriptions.push(instance);
+        });
+        this.afterEach(() => {
+            subscriptions.forEach(sub => sub.dispose());
+            sinon.restore();
+        });
+        it("Handles no changelists", async () => {
+            stubService.changelists = [];
+
+            await instance.Initialize();
+            expect(instance.resources).to.have.length(1);
+            expect(instance.resources[0].resourceStates).to.be.resources([]);
+            expect(instance.resources[0].id).to.equal("default");
+            expect(instance.resources[0].label).to.equal("Default Changelist");
+        });
+        it("Handles changelists with no open files", async () => {
+            stubService.changelists = [
+                {
+                    chnum: "1",
+                    description: "changelist 1",
+                    files: []
+                }
+            ];
+            await instance.Initialize();
+            expect(instance.resources).to.have.length(2);
+            expect(instance.resources[0].id).to.equal("default");
+            expect(instance.resources[0].label).to.equal("Default Changelist");
+            expect(instance.resources[0].resourceStates).to.be.resources([]);
+            expect(instance.resources[1].id).to.equal("pending:1");
+            expect(instance.resources[1].label).to.equal("#1: changelist 1");
+            expect(instance.resources[1].resourceStates).to.be.resources([]);
+        });
+        it("Handles open files with no shelved files", async () => {
+            stubService.changelists = [
+                {
+                    chnum: "default",
+                    description: "n/a",
+                    files: [basicFiles.branch]
+                },
+                {
+                    chnum: "1",
+                    description: "changelist 1",
+                    files: [basicFiles.edit, basicFiles.delete, basicFiles.add]
+                },
+                {
+                    chnum: "2",
+                    description: "changelist 2",
+                    files: [basicFiles.moveAdd, basicFiles.moveDelete]
+                }
+            ];
+
+            await instance.Initialize();
+
+            expect(instance.resources).to.have.length(3);
+
+            expect(instance.resources[0].id).to.equal("default");
+            expect(instance.resources[0].resourceStates).to.be.resources([
+                basicFiles.branch
+            ]);
+            expect(instance.resources[1].id).to.equal("pending:1");
+            expect(instance.resources[1].label).to.equal("#1: changelist 1");
+            expect(instance.resources[1].resourceStates).to.be.resources([
+                basicFiles.edit,
+                basicFiles.delete,
+                basicFiles.add
+            ]);
+            expect(instance.resources[2].id).to.equal("pending:2");
+            expect(instance.resources[2].label).to.equal("#2: changelist 2");
+            expect(instance.resources[2].resourceStates).to.be.resources([
+                basicFiles.moveAdd,
+                basicFiles.moveDelete
+            ]);
+        });
+        it("Handles shelved files with no open files", async () => {
+            stubService.changelists = [
+                {
+                    chnum: "3",
+                    description: "shelved changelist 1",
+                    files: [],
+                    shelvedFiles: [basicFiles.shelveEdit]
+                },
+                {
+                    chnum: "4",
+                    description: "shelved changelist 2",
+                    files: [],
+                    shelvedFiles: [basicFiles.shelveDelete]
+                }
+            ];
+
+            await instance.Initialize();
+
+            expect(instance.resources).to.have.length(3);
+
+            expect(instance.resources[0].id).to.equal("default");
+            expect(instance.resources[0].resourceStates).to.be.resources([]);
+
+            expect(instance.resources[1].id).to.equal("pending:3");
+            expect(instance.resources[1].label).to.equal("#3: shelved changelist 1");
+            expect(instance.resources[1].resourceStates).to.be.shelvedResources([
+                basicFiles.shelveEdit
+            ]);
+
+            expect(instance.resources[2].id).to.equal("pending:4");
+            expect(instance.resources[2].label).to.equal("#4: shelved changelist 2");
+            expect(instance.resources[2].resourceStates).to.be.shelvedResources([
+                basicFiles.shelveDelete
+            ]);
+        });
+        it("Handles open and shelved files", async () => {
+            stubService.changelists = [
+                {
+                    chnum: "5",
+                    description: "mixed changelist 1",
+                    files: [basicFiles.edit, basicFiles.add],
+                    shelvedFiles: [basicFiles.shelveEdit]
+                },
+                {
+                    chnum: "6",
+                    description: "mixed changelist 2",
+                    files: [basicFiles.delete],
+                    shelvedFiles: [basicFiles.shelveDelete]
+                }
+            ];
+
+            await instance.Initialize();
+
+            expect(instance.resources).to.have.length(3);
+
+            expect(instance.resources[0].id).to.equal("default");
+            expect(instance.resources[0].resourceStates).to.be.resources([]);
+
+            expect(instance.resources[1].id).to.equal("pending:5");
+            expect(instance.resources[1].label).to.equal("#5: mixed changelist 1");
+            expect(
+                instance.resources[1].resourceStates.slice(0, 1)
+            ).to.be.shelvedResources([basicFiles.shelveEdit]);
+            expect(instance.resources[1].resourceStates.slice(1)).to.be.resources([
+                basicFiles.edit,
+                basicFiles.add
+            ]);
+
+            expect(instance.resources[2].id).to.equal("pending:6");
+            expect(instance.resources[2].label).to.equal("#6: mixed changelist 2");
+            expect(
+                instance.resources[2].resourceStates.slice(0, 1)
+            ).to.be.shelvedResources([basicFiles.shelveDelete]);
+            expect(instance.resources[2].resourceStates.slice(1)).to.be.resources([
+                basicFiles.delete
+            ]);
+        });
+        it("Includes new files open for shelve and not in the workspace", async () => {
+            stubService.changelists = [
+                {
+                    chnum: "7",
+                    description: "changelist 1",
+                    files: [],
+                    shelvedFiles: [basicFiles.shelveNoWorkspace]
+                }
+            ];
+
+            await instance.Initialize();
+
+            expect(instance.resources[0].id).to.equal("default");
+            expect(instance.resources[0].resourceStates).to.be.resources([]);
+
+            expect(instance.resources[1].id).to.equal("pending:7");
+            expect(instance.resources[1].label).to.equal("#7: changelist 1");
+
+            expect(instance.resources[1].resourceStates).to.be.shelvedResources([
+                basicFiles.shelveNoWorkspace
+            ]);
+        });
+        it("Handles the same file shelved in two changelists", async () => {
+            stubService.changelists = [
+                {
+                    chnum: "8",
+                    description: "changelist 1",
+                    files: [],
+                    shelvedFiles: [basicFiles.shelveEdit]
+                },
+                {
+                    chnum: "9",
+                    description: "changelist 2",
+                    files: [],
+                    shelvedFiles: [basicFiles.shelveEdit]
+                }
+            ];
+
+            await instance.Initialize();
+
+            expect(instance.resources).to.have.length(3);
+
+            expect(instance.resources[0].id).to.equal("default");
+            expect(instance.resources[0].resourceStates).to.be.resources([]);
+
+            expect(instance.resources[1].id).to.equal("pending:8");
+            expect(instance.resources[1].label).to.equal("#8: changelist 1");
+
+            expect(instance.resources[1].resourceStates).to.be.shelvedResources([
+                basicFiles.shelveEdit
+            ]);
+
+            expect(instance.resources[2].id).to.equal("pending:9");
+            expect(instance.resources[2].label).to.equal("#9: changelist 2");
+
+            expect(instance.resources[2].resourceStates).to.be.shelvedResources([
+                basicFiles.shelveEdit
+            ]);
+        });
+        // TODO configuration stubbing (or integration of config settings)
+        it("Can sort changelists descending");
+        it("Has decorations for files", async () => {
+            stubService.changelists = [
+                {
+                    chnum: "1",
+                    description: "changelist 1",
+                    files: [basicFiles.edit, basicFiles.delete],
+                    shelvedFiles: [basicFiles.shelveEdit, basicFiles.shelveDelete]
+                }
+            ];
+
+            await instance.Initialize();
+
+            expect(instance.resources[1].resourceStates[0].decorations).to.include({
+                strikeThrough: false,
+                faded: true
+            });
+
+            expect(instance.resources[1].resourceStates[1].decorations).to.include({
+                strikeThrough: true,
+                faded: true
+            });
+
+            expect(instance.resources[1].resourceStates[2].decorations).to.include({
+                strikeThrough: false,
+                faded: false
+            });
+
+            expect(instance.resources[1].resourceStates[3].decorations).to.include({
+                strikeThrough: true,
+                faded: false
+            });
+        });
+        // TODO config
+        it("Handles more than the max files per command");
+        it("Can be refreshed");
+        it("Can be refreshed multiple times without duplication");
+    });
+    describe("Actions", function() {
+        beforeEach(async function() {
+            this.timeout(4000);
+            const showMessage = sinon.spy(Display, "showMessage");
+            const showError = sinon.spy(Display, "showError");
+
+            const stubService = new StubPerforceService();
+            stubService.changelists = [
+                {
+                    chnum: "1",
+                    description: "Changelist 1",
+                    files: [
+                        basicFiles.edit,
+                        basicFiles.delete,
+                        basicFiles.add,
+                        basicFiles.moveAdd,
+                        basicFiles.moveDelete,
+                        basicFiles.branch,
+                        basicFiles.integrate
+                    ],
+                    shelvedFiles: [basicFiles.shelveEdit, basicFiles.shelveDelete]
+                },
+                {
+                    chnum: "2",
+                    description: "Changelist 2",
+                    files: [],
+                    behaviours: {
+                        shelve: returnStdErr("my shelve error"),
+                        unshelve: returnStdErr("my unshelve error")
+                    }
+                },
+                {
+                    chnum: "3",
+                    description: "Changelist 3",
+                    submitted: true,
+                    files: []
+                }
+            ];
+            const execute = stubService.stubExecute();
+
+            const instance = new PerforceSCMProvider(config, workspaceUri, "perforce");
+            subscriptions.push(instance);
+            await instance.Initialize();
+
+            const showImportantError = sinon.spy(Display, "showImportantError");
+
+            const refresh = sinon.spy();
+
+            items = {
+                stubService,
+                instance,
+                execute,
+                showMessage,
+                showError,
+                showImportantError,
+                refresh
+            };
+
+            subscriptions.push(instance.onRefreshStarted(refresh));
+        });
+        afterEach(async () => {
+            await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+            subscriptions.forEach(sub => sub.dispose());
+            subscriptions = [];
+            sinon.restore();
         });
 
-        describe("When opening a file", () => {
-            it("Opens the underlying workspace file", () => {
-                const file = items.stubService.changelists[0].files[0];
-                const resource = findResourceForFile(items.instance.resources[1], file);
-
-                PerforceSCMProvider.OpenFile(resource);
-
-                expect(execCommand.lastCall).to.be.vscodeOpenCall(file.localFile);
+        describe("Shelving a changelist", () => {
+            it("Cannot shelve the default changelist", async () => {
+                await expect(
+                    PerforceSCMProvider.ShelveChangelist(items.instance.resources[0])
+                ).to.eventually.be.rejectedWith("Cannot shelve the default changelist");
+                expect(items.execute).not.to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "shelve"
+                );
+                expect(items.refresh).not.to.have.been.called;
             });
-            it("Can open multiple files", () => {
-                const file1 = items.stubService.changelists[0].files[0];
-                const resource1 = findResourceForFile(items.instance.resources[1], file1);
 
-                const file2 = items.stubService.changelists[0].files[2];
-                const resource2 = findResourceForFile(items.instance.resources[1], file2);
+            it("Can shelve a valid Changelist", async () => {
+                await PerforceSCMProvider.ShelveChangelist(items.instance.resources[1]);
+                expect(items.execute).to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "shelve",
+                    sinon.match.any,
+                    "-f -c 1"
+                );
+                expect(items.showMessage).to.have.been.calledOnceWith(
+                    "Changelist shelved"
+                );
+                expect(items.refresh).to.have.been.calledOnce;
+            });
 
-                PerforceSCMProvider.OpenFile(resource1, resource2);
-                expect(execCommand.getCall(-2)).to.be.vscodeOpenCall(file1.localFile);
-                expect(execCommand.lastCall).to.be.vscodeOpenCall(file2.localFile);
+            it("Can shelve and revert a valid changelist", async () => {
+                await PerforceSCMProvider.ShelveRevertChangelist(
+                    items.instance.resources[1]
+                );
+                expect(items.execute).to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "shelve",
+                    sinon.match.any,
+                    "-f -c 1"
+                );
+                expect(items.execute).to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "revert",
+                    sinon.match.any,
+                    "-c 1 //..."
+                );
+                expect(items.showMessage).to.have.been.calledOnceWith(
+                    "Changelist shelved"
+                );
+                expect(items.refresh).to.have.been.calledOnce;
+            });
+
+            it("Can handle an error when shelving a changelist", async () => {
+                await PerforceSCMProvider.ShelveChangelist(items.instance.resources[2]);
+                expect(items.execute).to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "shelve",
+                    sinon.match.any,
+                    "-f -c 2"
+                );
+                expect(items.showMessage).not.to.have.been.called;
+                expect(items.showImportantError).to.have.been.calledOnceWith(
+                    "my shelve error"
+                );
+                expect(items.refresh).to.have.been.calledOnce;
+            });
+
+            it("Can handle an error when shelving and reverting a changelist", async () => {
+                await PerforceSCMProvider.ShelveRevertChangelist(
+                    items.instance.resources[2]
+                );
+                expect(items.execute).to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "shelve",
+                    sinon.match.any,
+                    "-f -c 2"
+                );
+                expect(items.showMessage).not.to.have.been.called;
+                expect(items.showImportantError).to.have.been.calledOnceWith(
+                    "my shelve error"
+                );
+                expect(items.execute).not.to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "revert"
+                );
+                expect(items.refresh).to.have.been.calledOnce;
             });
         });
-        describe("When opening an scm resource", () => {
-            it("Diffs a local file against the depot file", async () => {
-                const file = items.stubService.changelists[0].files[0];
-                const resource = findResourceForFile(items.instance.resources[1], file);
 
-                await PerforceSCMProvider.Open(resource);
-
-                expect(execCommand.lastCall).to.be.vscodeDiffCall(
-                    perforceLocalUriMatcher(file),
-                    file.localFile,
-                    path.basename(file.localFile.path) +
-                        " - Diff Workspace (right) Against Most Recent Revision (left)"
-                );
-                expect(items.execute).to.be.calledWithMatch(
-                    file.localFile,
-                    "print",
+        describe("Unshelving a changelist", () => {
+            it("Can unshelve a valid Changelist", async () => {
+                await PerforceSCMProvider.UnshelveChangelist(items.instance.resources[1]);
+                expect(items.execute).to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "unshelve",
                     sinon.match.any,
-                    '-q "' + file.localFile.fsPath + '"'
+                    "-f -s 1"
                 );
+                expect(items.showMessage).to.have.been.calledOnceWith(
+                    "Changelist unshelved"
+                );
+                expect(items.refresh).to.have.been.calledOnce;
             });
-            it("Can open multiple resources", async () => {
-                const file1 = items.stubService.changelists[0].files[0];
-                const resource1 = findResourceForFile(items.instance.resources[1], file1);
 
-                const file2 = items.stubService.changelists[0].files[1];
-                const resource2 = findResourceForFile(items.instance.resources[1], file2);
-
-                await PerforceSCMProvider.Open(resource1, resource2);
-                expect(execCommand.getCall(-2)).to.be.vscodeDiffCall(
-                    perforceLocalUriMatcher(file1),
-                    file1.localFile,
-                    path.basename(file1.localFile.path) +
-                        " - Diff Workspace (right) Against Most Recent Revision (left)"
+            it("Cannot unshelve default changelist", async () => {
+                await expect(
+                    PerforceSCMProvider.UnshelveChangelist(items.instance.resources[0])
+                ).to.eventually.be.rejectedWith("Cannot unshelve the default changelist");
+                expect(items.execute).not.to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "unshelve"
                 );
-                expect(items.execute).to.be.calledWithMatch(
-                    file1.localFile,
-                    "print",
+                expect(items.refresh).not.to.have.been.called;
+            });
+
+            it("Can handle an error when unshelving a changelist", async () => {
+                await PerforceSCMProvider.UnshelveChangelist(items.instance.resources[2]);
+                expect(items.execute).to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "unshelve",
                     sinon.match.any,
-                    '-q "' + file1.localFile.fsPath + '"'
+                    "-f -s 2 -c 2"
                 );
-                expect(execCommand.lastCall).to.be.vscodeOpenCall(
-                    perforceLocalUriMatcher(file2)
+                expect(items.showMessage).not.to.have.been.called;
+                expect(items.showImportantError).to.have.been.calledOnceWith(
+                    "my unshelve error"
                 );
+                expect(items.refresh).not.to.have.been.called;
             });
-            it("Displays the depot version of a deleted file", () => {
-                const file = items.stubService.changelists[0].files[1];
-                const resource = findResourceForFile(items.instance.resources[1], file);
+        });
 
-                PerforceSCMProvider.Open(resource);
+        describe("Deleting a shelve", () => {
+            it("Deletes a shelved changelist", async () => {
+                // accept the warning
+                const warn = sinon
+                    .stub(vscode.window, "showWarningMessage")
+                    .resolvesArg(2);
 
-                expect(execCommand.lastCall).to.be.vscodeOpenCall(
-                    perforceLocalUriMatcher(file)
+                await PerforceSCMProvider.DeleteShelvedChangelist(
+                    items.instance.resources[1]
                 );
-            });
-            it("Diffs a new file against an empty file", () => {
-                const file = items.stubService.changelists[0].files[2];
-                const resource = findResourceForFile(items.instance.resources[1], file);
 
-                PerforceSCMProvider.Open(resource);
-
-                expect(execCommand.lastCall).to.be.vscodeDiffCall(
-                    vscode.Uri.parse("perforce:EMPTY"),
-                    file.localFile,
-                    path.basename(file.localFile.path) +
-                        " - Diff Workspace (right) Against Most Recent Revision (left)"
-                );
-            });
-            it("Diffs a moved file against the original file", async () => {
-                const file = items.stubService.changelists[0].files[3];
-                const resource = findResourceForFile(items.instance.resources[1], file);
-
-                await PerforceSCMProvider.Open(resource);
-
-                expect(execCommand.lastCall).to.be.vscodeDiffCall(
-                    perforceFromFileUriMatcher(file),
-                    file.localFile,
-                    path.basename(file.localFile.path) +
-                        " - Diff Workspace (right) Against Most Recent Revision (left)"
-                );
-                expect(items.execute).to.be.calledWithMatch(
-                    sinon.match({ fsPath: workspaceUri.fsPath }),
-                    "print",
+                expect(warn).to.have.been.calledOnce;
+                expect(items.refresh).to.have.been.calledOnce;
+                expect(items.execute).to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "shelve",
                     sinon.match.any,
-                    '-q "' + file.resolveFromDepotPath + '"'
+                    "-d -c 1"
                 );
             });
-            it("Displays the depot version for a move / delete", () => {
-                const file = items.stubService.changelists[0].files[4];
-                const resource = findResourceForFile(items.instance.resources[1], file);
 
-                PerforceSCMProvider.Open(resource);
-            });
-            it("Diffs a file opened for branch against an empty file", () => {
-                const file = items.stubService.changelists[0].files[5];
-                const resource = findResourceForFile(items.instance.resources[1], file);
+            it("Can cancel deleting a shelved changelist", async () => {
+                // close the warning without accepting
+                const warn = sinon
+                    .stub(vscode.window, "showWarningMessage")
+                    .resolves(undefined);
 
-                PerforceSCMProvider.Open(resource);
-
-                expect(execCommand.lastCall).to.be.vscodeDiffCall(
-                    vscode.Uri.parse("perforce:EMPTY"),
-                    file.localFile,
-                    path.basename(file.localFile.path) +
-                        " - Diff Workspace (right) Against Most Recent Revision (left)"
-                );
-            });
-            it("Diffs an integration/merge against the target depot file", async () => {
-                const file = items.stubService.changelists[0].files[6];
-                const resource = findResourceForFile(items.instance.resources[1], file);
-
-                await PerforceSCMProvider.Open(resource);
-
-                expect(execCommand.lastCall).to.be.vscodeDiffCall(
-                    perforceLocalUriMatcher(file),
-                    file.localFile,
-                    path.basename(file.localFile.path) +
-                        " - Diff Workspace (right) Against Most Recent Revision (left)"
+                await PerforceSCMProvider.DeleteShelvedChangelist(
+                    items.instance.resources[1]
                 );
 
-                expect(items.execute).to.be.calledWithMatch(
-                    file.localFile,
-                    "print",
+                expect(warn).to.have.been.calledOnce;
+                expect(items.refresh).not.to.have.been.called;
+                expect(items.execute).not.to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "shelve"
+                );
+            });
+
+            it("Can handle an error when deleting a shelved changelist", async () => {
+                // accept the warning
+                const warn = sinon
+                    .stub(vscode.window, "showWarningMessage")
+                    .resolvesArg(2);
+
+                await PerforceSCMProvider.DeleteShelvedChangelist(
+                    items.instance.resources[2]
+                );
+
+                expect(warn).to.have.been.calledOnce;
+                expect(items.execute).to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "shelve",
                     sinon.match.any,
-                    '-q "' + file.localFile.fsPath + '"'
+                    "-d -c 2"
                 );
+                expect(items.showImportantError).to.have.been.calledOnceWith(
+                    "my shelve error"
+                );
+                expect(items.refresh).not.to.have.been.called;
             });
-            it("Diffs a shelved file against the depot file", async () => {
-                const file = items.stubService.changelists[0].shelvedFiles[0];
-                const resource = findResourceForShelvedFile(
-                    items.instance.resources[1],
-                    file
-                );
 
-                await PerforceSCMProvider.Open(resource);
-
-                expect(execCommand.lastCall).to.be.vscodeDiffCall(
-                    perforceDepotUriMatcher(file),
-                    perforceShelvedUriMatcher(file, "1"),
-                    path.basename(file.localFile.path) +
-                        " - Diff Shelve (right) Against Depot Version (left)"
+            it("Cannot delete from the default changelist", async () => {
+                await expect(
+                    PerforceSCMProvider.DeleteShelvedChangelist(
+                        items.instance.resources[0]
+                    )
+                ).to.eventually.be.rejectedWith(
+                    "Cannot delete shelved files from the default changelist"
                 );
-                expect(items.execute).to.be.calledWithMatch(
-                    { fsPath: workspaceUri.fsPath },
-                    "print",
-                    sinon.match.any,
-                    '-q "' + file.depotPath + '@=1"'
+                expect(items.execute).not.to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "shelve"
                 );
-                expect(items.execute).to.be.calledWithMatch(
-                    { fsPath: workspaceUri.fsPath },
-                    "print",
-                    sinon.match.any,
-                    '-q "' + file.depotPath + '"'
-                );
+                expect(items.refresh).not.to.have.been.called;
             });
-            it("Can diff a local file against the shelved file (from the shelved file)", async () => {
-                const file = items.stubService.changelists[0].shelvedFiles[0];
-                const resource = findResourceForShelvedFile(
-                    items.instance.resources[1],
-                    file
-                );
+        });
 
-                await PerforceSCMProvider.OpenvShelved(resource);
-
-                expect(execCommand.lastCall).to.be.vscodeDiffCall(
-                    perforceShelvedUriMatcher(file, "1"),
-                    file.localFile,
-                    path.basename(file.localFile.path) +
-                        " - Diff Workspace (right) Against Shelved Version (left)"
+        describe("Opening", () => {
+            function findResourceForShelvedFile(
+                group: vscode.SourceControlResourceGroup,
+                file: StubFile
+            ) {
+                return group.resourceStates.find(
+                    resource =>
+                        (resource as Resource).isShelved &&
+                        Utils.getDepotPathFromDepotUri(resource.resourceUri) ===
+                            file.depotPath
                 );
-                expect(items.execute).to.be.calledWithMatch(
-                    { fsPath: workspaceUri.fsPath },
+            }
+
+            function findResourceForFile(
+                group: vscode.SourceControlResourceGroup,
+                file: StubFile
+            ) {
+                return group.resourceStates.find(
+                    resource =>
+                        !(resource as Resource).isShelved &&
+                        (resource as Resource).resourceUri.fsPath ===
+                            file.localFile.fsPath
+                );
+            }
+
+            /**
+             * Matches against a perforce URI, containing a local file's path
+             * @param file
+             */
+            function perforceLocalUriMatcher(file: StubFile) {
+                return Utils.makePerforceDocUri(file.localFile, "print", "-q", {
+                    workspace: workspaceUri.fsPath
+                });
+            }
+
+            /**
+             * Matches against a perforce URI, using the depot path for a file
+             * @param file
+             */
+            function perforceDepotUriMatcher(file: StubFile) {
+                return Utils.makePerforceDocUri(
+                    vscode.Uri.parse("perforce:" + file.depotPath),
                     "print",
-                    sinon.match.any,
-                    '-q "' + file.depotPath + '@=1"'
+                    "-q",
+                    { depot: true, workspace: workspaceUri.fsPath }
                 );
-            });
-            it("Can diff a local file against the shelved file (from the local file)", async () => {
-                const file = items.stubService.changelists[0].files[0];
-                const resource = findResourceForFile(items.instance.resources[1], file);
+            }
 
-                await PerforceSCMProvider.OpenvShelved(resource);
-
-                expect(execCommand.lastCall).to.be.vscodeDiffCall(
-                    perforceLocalShelvedUriMatcher(file, "1"),
-                    file.localFile,
-                    path.basename(file.localFile.path) +
-                        " - Diff Workspace (right) Against Shelved Version (left)"
-                );
-                expect(items.execute).to.be.calledWithMatch(
-                    file.localFile,
+            /**
+             * Matches against a perforce URI, using the resolvedFromFile0 depot path
+             * @param file
+             */
+            function perforceFromFileUriMatcher(file: StubFile) {
+                return Utils.makePerforceDocUri(
+                    vscode.Uri.parse("perforce:" + file.resolveFromDepotPath),
                     "print",
-                    sinon.match.any,
-                    '-q "' + file.localFile.fsPath + '@=1"'
+                    "-q",
+                    { depot: true, workspace: workspaceUri.fsPath }
                 );
+            }
+
+            /**
+             * Matches against a perforce URI, using the depot path for the file AND containing a fragment for the shelved changelist number
+             * @param file
+             * @param chnum
+             */
+            function perforceShelvedUriMatcher(file: StubFile, chnum: string) {
+                return Utils.makePerforceDocUri(
+                    vscode.Uri.parse("perforce:" + file.depotPath).with({
+                        fragment: "@=" + chnum
+                    }),
+                    "print",
+                    "-q",
+                    { depot: true, workspace: workspaceUri.fsPath }
+                );
+            }
+
+            function perforceLocalShelvedUriMatcher(file: StubFile, chnum: string) {
+                return Utils.makePerforceDocUri(
+                    file.localFile.with({ fragment: "@=" + chnum }),
+                    "print",
+                    "-q",
+                    { workspace: workspaceUri.fsPath }
+                );
+            }
+
+            let execCommand: sinon.SinonSpy;
+            beforeEach(function() {
+                this.timeout(4000);
+                execCommand = sinon.spy(vscode.commands, "executeCommand");
             });
-            it("Displays the depot version for a shelved deletion", async () => {
-                const file = items.stubService.changelists[0].files[1];
-                const resource = findResourceForFile(items.instance.resources[1], file);
 
-                await PerforceSCMProvider.Open(resource);
+            describe("When opening a file", () => {
+                it("Opens the underlying workspace file", () => {
+                    const file = items.stubService.changelists[0].files[0];
+                    const resource = findResourceForFile(
+                        items.instance.resources[1],
+                        file
+                    );
 
-                expect(execCommand.lastCall).to.be.vscodeOpenCall(
-                    perforceLocalUriMatcher(file)
-                );
+                    PerforceSCMProvider.OpenFile(resource);
+
+                    expect(execCommand.lastCall).to.be.vscodeOpenCall(file.localFile);
+                });
+                it("Can open multiple files", () => {
+                    const file1 = items.stubService.changelists[0].files[0];
+                    const resource1 = findResourceForFile(
+                        items.instance.resources[1],
+                        file1
+                    );
+
+                    const file2 = items.stubService.changelists[0].files[2];
+                    const resource2 = findResourceForFile(
+                        items.instance.resources[1],
+                        file2
+                    );
+
+                    PerforceSCMProvider.OpenFile(resource1, resource2);
+                    expect(execCommand.getCall(-2)).to.be.vscodeOpenCall(file1.localFile);
+                    expect(execCommand.lastCall).to.be.vscodeOpenCall(file2.localFile);
+                });
+            });
+            describe("When opening an scm resource", () => {
+                it("Diffs a local file against the depot file", async () => {
+                    const file = items.stubService.changelists[0].files[0];
+                    const resource = findResourceForFile(
+                        items.instance.resources[1],
+                        file
+                    );
+
+                    await PerforceSCMProvider.Open(resource);
+
+                    expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                        perforceLocalUriMatcher(file),
+                        file.localFile,
+                        path.basename(file.localFile.path) +
+                            " - Diff Workspace (right) Against Most Recent Revision (left)"
+                    );
+                    expect(items.execute).to.be.calledWithMatch(
+                        file.localFile,
+                        "print",
+                        sinon.match.any,
+                        '-q "' + file.localFile.fsPath + '"'
+                    );
+                });
+                it("Can open multiple resources", async () => {
+                    const file1 = items.stubService.changelists[0].files[0];
+                    const resource1 = findResourceForFile(
+                        items.instance.resources[1],
+                        file1
+                    );
+
+                    const file2 = items.stubService.changelists[0].files[1];
+                    const resource2 = findResourceForFile(
+                        items.instance.resources[1],
+                        file2
+                    );
+
+                    await PerforceSCMProvider.Open(resource1, resource2);
+                    expect(execCommand.getCall(-2)).to.be.vscodeDiffCall(
+                        perforceLocalUriMatcher(file1),
+                        file1.localFile,
+                        path.basename(file1.localFile.path) +
+                            " - Diff Workspace (right) Against Most Recent Revision (left)"
+                    );
+                    expect(items.execute).to.be.calledWithMatch(
+                        file1.localFile,
+                        "print",
+                        sinon.match.any,
+                        '-q "' + file1.localFile.fsPath + '"'
+                    );
+                    expect(execCommand.lastCall).to.be.vscodeOpenCall(
+                        perforceLocalUriMatcher(file2)
+                    );
+                });
+                it("Displays the depot version of a deleted file", () => {
+                    const file = items.stubService.changelists[0].files[1];
+                    const resource = findResourceForFile(
+                        items.instance.resources[1],
+                        file
+                    );
+
+                    PerforceSCMProvider.Open(resource);
+
+                    expect(execCommand.lastCall).to.be.vscodeOpenCall(
+                        perforceLocalUriMatcher(file)
+                    );
+                });
+                it("Diffs a new file against an empty file", () => {
+                    const file = items.stubService.changelists[0].files[2];
+                    const resource = findResourceForFile(
+                        items.instance.resources[1],
+                        file
+                    );
+
+                    PerforceSCMProvider.Open(resource);
+
+                    expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                        vscode.Uri.parse("perforce:EMPTY"),
+                        file.localFile,
+                        path.basename(file.localFile.path) +
+                            " - Diff Workspace (right) Against Most Recent Revision (left)"
+                    );
+                });
+                it("Diffs a moved file against the original file", async () => {
+                    const file = items.stubService.changelists[0].files[3];
+                    const resource = findResourceForFile(
+                        items.instance.resources[1],
+                        file
+                    );
+
+                    await PerforceSCMProvider.Open(resource);
+
+                    expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                        perforceFromFileUriMatcher(file),
+                        file.localFile,
+                        path.basename(file.localFile.path) +
+                            " - Diff Workspace (right) Against Most Recent Revision (left)"
+                    );
+                    expect(items.execute).to.be.calledWithMatch(
+                        sinon.match({ fsPath: workspaceUri.fsPath }),
+                        "print",
+                        sinon.match.any,
+                        '-q "' + file.resolveFromDepotPath + '"'
+                    );
+                });
+                it("Displays the depot version for a move / delete", () => {
+                    const file = items.stubService.changelists[0].files[4];
+                    const resource = findResourceForFile(
+                        items.instance.resources[1],
+                        file
+                    );
+
+                    PerforceSCMProvider.Open(resource);
+                });
+                it("Diffs a file opened for branch against an empty file", () => {
+                    const file = items.stubService.changelists[0].files[5];
+                    const resource = findResourceForFile(
+                        items.instance.resources[1],
+                        file
+                    );
+
+                    PerforceSCMProvider.Open(resource);
+
+                    expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                        vscode.Uri.parse("perforce:EMPTY"),
+                        file.localFile,
+                        path.basename(file.localFile.path) +
+                            " - Diff Workspace (right) Against Most Recent Revision (left)"
+                    );
+                });
+                it("Diffs an integration/merge against the target depot file", async () => {
+                    const file = items.stubService.changelists[0].files[6];
+                    const resource = findResourceForFile(
+                        items.instance.resources[1],
+                        file
+                    );
+
+                    await PerforceSCMProvider.Open(resource);
+
+                    expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                        perforceLocalUriMatcher(file),
+                        file.localFile,
+                        path.basename(file.localFile.path) +
+                            " - Diff Workspace (right) Against Most Recent Revision (left)"
+                    );
+
+                    expect(items.execute).to.be.calledWithMatch(
+                        file.localFile,
+                        "print",
+                        sinon.match.any,
+                        '-q "' + file.localFile.fsPath + '"'
+                    );
+                });
+                it("Diffs a shelved file against the depot file", async () => {
+                    const file = items.stubService.changelists[0].shelvedFiles[0];
+                    const resource = findResourceForShelvedFile(
+                        items.instance.resources[1],
+                        file
+                    );
+
+                    await PerforceSCMProvider.Open(resource);
+
+                    expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                        perforceDepotUriMatcher(file),
+                        perforceShelvedUriMatcher(file, "1"),
+                        path.basename(file.localFile.path) +
+                            " - Diff Shelve (right) Against Depot Version (left)"
+                    );
+                    expect(items.execute).to.be.calledWithMatch(
+                        { fsPath: workspaceUri.fsPath },
+                        "print",
+                        sinon.match.any,
+                        '-q "' + file.depotPath + '@=1"'
+                    );
+                    expect(items.execute).to.be.calledWithMatch(
+                        { fsPath: workspaceUri.fsPath },
+                        "print",
+                        sinon.match.any,
+                        '-q "' + file.depotPath + '"'
+                    );
+                });
+                it("Can diff a local file against the shelved file (from the shelved file)", async () => {
+                    const file = items.stubService.changelists[0].shelvedFiles[0];
+                    const resource = findResourceForShelvedFile(
+                        items.instance.resources[1],
+                        file
+                    );
+
+                    await PerforceSCMProvider.OpenvShelved(resource);
+
+                    expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                        perforceShelvedUriMatcher(file, "1"),
+                        file.localFile,
+                        path.basename(file.localFile.path) +
+                            " - Diff Workspace (right) Against Shelved Version (left)"
+                    );
+                    expect(items.execute).to.be.calledWithMatch(
+                        { fsPath: workspaceUri.fsPath },
+                        "print",
+                        sinon.match.any,
+                        '-q "' + file.depotPath + '@=1"'
+                    );
+                });
+                it("Can diff a local file against the shelved file (from the local file)", async () => {
+                    const file = items.stubService.changelists[0].files[0];
+                    const resource = findResourceForFile(
+                        items.instance.resources[1],
+                        file
+                    );
+
+                    await PerforceSCMProvider.OpenvShelved(resource);
+
+                    expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                        perforceLocalShelvedUriMatcher(file, "1"),
+                        file.localFile,
+                        path.basename(file.localFile.path) +
+                            " - Diff Workspace (right) Against Shelved Version (left)"
+                    );
+                    expect(items.execute).to.be.calledWithMatch(
+                        file.localFile,
+                        "print",
+                        sinon.match.any,
+                        '-q "' + file.localFile.fsPath + '@=1"'
+                    );
+                });
+                it("Displays the depot version for a shelved deletion", async () => {
+                    const file = items.stubService.changelists[0].files[1];
+                    const resource = findResourceForFile(
+                        items.instance.resources[1],
+                        file
+                    );
+
+                    await PerforceSCMProvider.Open(resource);
+
+                    expect(execCommand.lastCall).to.be.vscodeOpenCall(
+                        perforceLocalUriMatcher(file)
+                    );
+                });
             });
         });
     });

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -37,6 +37,12 @@ interface TestItems {
     refresh: sinon.SinonSpy;
 }
 
+function timeout(ms: number) {
+    return new Promise(res => {
+        setTimeout(() => res(), ms);
+    });
+}
+
 describe("Model & ScmProvider modules (integration)", () => {
     const workspaceUri = vscode.workspace.workspaceFolders[0].uri;
 
@@ -146,6 +152,9 @@ describe("Model & ScmProvider modules (integration)", () => {
             stubService.stubExecute();
 
             workspaceConfig = new WorkspaceConfigAccessor(workspaceUri);
+
+            // save time on refresh function calls
+            sinon.stub(workspaceConfig, "refreshDebounceTime").get(() => 100);
 
             instance = new PerforceSCMProvider(
                 config,
@@ -822,6 +831,8 @@ describe("Model & ScmProvider modules (integration)", () => {
             ];
             const execute = stubService.stubExecute();
             const workspaceConfig = new WorkspaceConfigAccessor(workspaceUri);
+            sinon.stub(workspaceConfig, "refreshDebounceTime").get(() => 0);
+
             const instance = new PerforceSCMProvider(
                 config,
                 workspaceUri,
@@ -863,6 +874,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     workspaceUri,
                     "shelve"
                 );
+                await timeout(1);
                 expect(items.refresh).not.to.have.been.called;
             });
 
@@ -877,6 +889,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(items.showMessage).to.have.been.calledOnceWith(
                     "Changelist shelved"
                 );
+                await timeout(1);
                 expect(items.refresh).to.have.been.calledOnce;
             });
 
@@ -899,6 +912,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(items.showMessage).to.have.been.calledOnceWith(
                     "Changelist shelved"
                 );
+                await timeout(1);
                 expect(items.refresh).to.have.been.calledOnce;
             });
 
@@ -914,6 +928,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(items.showImportantError).to.have.been.calledOnceWith(
                     "my shelve error"
                 );
+                await timeout(1);
                 expect(items.refresh).to.have.been.calledOnce;
             });
 
@@ -935,6 +950,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     workspaceUri,
                     "revert"
                 );
+                await timeout(1);
                 expect(items.refresh).to.have.been.calledOnce;
             });
         });
@@ -951,6 +967,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(items.showMessage).to.have.been.calledOnceWith(
                     "Changelist unshelved"
                 );
+                await timeout(1);
                 expect(items.refresh).to.have.been.calledOnce;
             });
 
@@ -962,6 +979,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     workspaceUri,
                     "unshelve"
                 );
+                await timeout(1);
                 expect(items.refresh).not.to.have.been.called;
             });
 
@@ -977,6 +995,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(items.showImportantError).to.have.been.calledOnceWith(
                     "my unshelve error"
                 );
+                await timeout(1);
                 expect(items.refresh).not.to.have.been.called;
             });
         });
@@ -993,6 +1012,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 );
 
                 expect(warn).to.have.been.calledOnce;
+                await timeout(1);
                 expect(items.refresh).to.have.been.calledOnce;
                 expect(items.execute).to.have.been.calledWithMatch(
                     workspaceUri,
@@ -1013,6 +1033,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 );
 
                 expect(warn).to.have.been.calledOnce;
+                await timeout(1);
                 expect(items.refresh).not.to.have.been.called;
                 expect(items.execute).not.to.have.been.calledWithMatch(
                     workspaceUri,
@@ -1040,6 +1061,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(items.showImportantError).to.have.been.calledOnceWith(
                     "my shelve error"
                 );
+                await timeout(1);
                 expect(items.refresh).not.to.have.been.called;
             });
 
@@ -1055,6 +1077,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     workspaceUri,
                     "shelve"
                 );
+                await timeout(1);
                 expect(items.refresh).not.to.have.been.called;
             });
         });

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -1152,18 +1152,18 @@ describe("Model & ScmProvider modules (integration)", () => {
             });
 
             describe("When opening a file", () => {
-                it("Opens the underlying workspace file", () => {
+                it("Opens the underlying workspace file", async () => {
                     const file = items.stubService.changelists[0].files[0];
                     const resource = findResourceForFile(
                         items.instance.resources[1],
                         file
                     );
 
-                    PerforceSCMProvider.OpenFile(resource);
+                    await PerforceSCMProvider.OpenFile(resource);
 
                     expect(execCommand.lastCall).to.be.vscodeOpenCall(file.localFile);
                 });
-                it("Can open multiple files", () => {
+                it("Can open multiple files", async () => {
                     const file1 = items.stubService.changelists[0].files[0];
                     const resource1 = findResourceForFile(
                         items.instance.resources[1],
@@ -1176,7 +1176,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                         file2
                     );
 
-                    PerforceSCMProvider.OpenFile(resource1, resource2);
+                    await PerforceSCMProvider.OpenFile(resource1, resource2);
                     expect(execCommand.getCall(-2)).to.be.vscodeOpenCall(file1.localFile);
                     expect(execCommand.lastCall).to.be.vscodeOpenCall(file2.localFile);
                 });
@@ -1205,6 +1205,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     );
                 });
                 it("Can open multiple resources", async () => {
+                    const td = sinon.stub(vscode.window, "showTextDocument");
                     const file1 = items.stubService.changelists[0].files[0];
                     const resource1 = findResourceForFile(
                         items.instance.resources[1],
@@ -1218,7 +1219,8 @@ describe("Model & ScmProvider modules (integration)", () => {
                     );
 
                     await PerforceSCMProvider.Open(resource1, resource2);
-                    expect(execCommand.getCall(-2)).to.be.vscodeDiffCall(
+
+                    expect(execCommand.getCall(-1)).to.be.vscodeDiffCall(
                         perforceLocalUriMatcher(file1),
                         file1.localFile,
                         path.basename(file1.localFile.path) +
@@ -1230,31 +1232,33 @@ describe("Model & ScmProvider modules (integration)", () => {
                         sinon.match.any,
                         '-q "' + file1.localFile.fsPath + '"'
                     );
-                    expect(execCommand.lastCall).to.be.vscodeOpenCall(
+                    expect(td.lastCall.args[0]).to.be.p4Uri(
                         perforceLocalUriMatcher(file2)
                     );
                 });
-                it("Displays the depot version of a deleted file", () => {
+                it("Displays the depot version of a deleted file", async () => {
+                    const td = sinon.stub(vscode.window, "showTextDocument");
+
                     const file = items.stubService.changelists[0].files[1];
                     const resource = findResourceForFile(
                         items.instance.resources[1],
                         file
                     );
 
-                    PerforceSCMProvider.Open(resource);
+                    await PerforceSCMProvider.Open(resource);
 
-                    expect(execCommand.lastCall).to.be.vscodeOpenCall(
+                    expect(td.lastCall.args[0]).to.be.p4Uri(
                         perforceLocalUriMatcher(file)
                     );
                 });
-                it("Diffs a new file against an empty file", () => {
+                it("Diffs a new file against an empty file", async () => {
                     const file = items.stubService.changelists[0].files[2];
                     const resource = findResourceForFile(
                         items.instance.resources[1],
                         file
                     );
 
-                    PerforceSCMProvider.Open(resource);
+                    await PerforceSCMProvider.Open(resource);
 
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         vscode.Uri.parse("perforce:EMPTY"),
@@ -1285,23 +1289,29 @@ describe("Model & ScmProvider modules (integration)", () => {
                         '-q "' + file.resolveFromDepotPath + '"'
                     );
                 });
-                it("Displays the depot version for a move / delete", () => {
+                it("Displays the depot version for a move / delete", async () => {
+                    const td = sinon.stub(vscode.window, "showTextDocument");
+
                     const file = items.stubService.changelists[0].files[4];
                     const resource = findResourceForFile(
                         items.instance.resources[1],
                         file
                     );
 
-                    PerforceSCMProvider.Open(resource);
+                    await PerforceSCMProvider.Open(resource);
+
+                    expect(td.lastCall.args[0]).to.be.p4Uri(
+                        perforceLocalUriMatcher(file)
+                    );
                 });
-                it("Diffs a file opened for branch against an empty file", () => {
+                it("Diffs a file opened for branch against an empty file", async () => {
                     const file = items.stubService.changelists[0].files[5];
                     const resource = findResourceForFile(
                         items.instance.resources[1],
                         file
                     );
 
-                    PerforceSCMProvider.Open(resource);
+                    await PerforceSCMProvider.Open(resource);
 
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         vscode.Uri.parse("perforce:EMPTY"),
@@ -1406,6 +1416,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     );
                 });
                 it("Displays the depot version for a shelved deletion", async () => {
+                    const td = sinon.stub(vscode.window, "showTextDocument");
                     const file = items.stubService.changelists[0].files[1];
                     const resource = findResourceForFile(
                         items.instance.resources[1],
@@ -1414,7 +1425,7 @@ describe("Model & ScmProvider modules (integration)", () => {
 
                     await PerforceSCMProvider.Open(resource);
 
-                    expect(execCommand.lastCall).to.be.vscodeOpenCall(
+                    expect(td.lastCall.args[0]).to.be.p4Uri(
                         perforceLocalUriMatcher(file)
                     );
                 });

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -194,7 +194,7 @@ describe("Model & ScmProvider modules", () => {
 
         await promise;
 
-        subscriptions.push(instance.onDidChange(refresh));
+        subscriptions.push(instance.onRefreshStarted(refresh));
     });
     afterEach(async () => {
         await vscode.commands.executeCommand("workbench.action.closeAllEditors");

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -540,7 +540,37 @@ describe("Model & ScmProvider modules (integration)", () => {
                 basicFiles.add
             ]);
         });
-        it("Can be refreshed multiple times without duplication");
+        it("Can be refreshed multiple times without duplication", async () => {
+            stubService.changelists = [
+                {
+                    chnum: "default",
+                    description: "n/a",
+                    files: [basicFiles.edit]
+                },
+                {
+                    chnum: "1",
+                    description: "changelist 1",
+                    files: [basicFiles.add]
+                }
+            ];
+
+            await instance.Initialize();
+            await Promise.all([
+                PerforceSCMProvider.RefreshAll(),
+                PerforceSCMProvider.RefreshAll()
+            ]);
+            expect(instance.resources).to.have.lengthOf(2);
+            expect(instance.resources[0].id).to.equal("default");
+            expect(instance.resources[0].label).to.equal("Default Changelist");
+            expect(instance.resources[0].resourceStates).to.be.resources([
+                basicFiles.edit
+            ]);
+            expect(instance.resources[1].id).to.equal("pending:1");
+            expect(instance.resources[1].label).to.equal("#1: changelist 1");
+            expect(instance.resources[1].resourceStates).to.be.resources([
+                basicFiles.add
+            ]);
+        });
     });
     describe("Actions", function() {
         beforeEach(async function() {

--- a/src/test/suite/unit/CommandLimiter.test.ts
+++ b/src/test/suite/unit/CommandLimiter.test.ts
@@ -1,0 +1,252 @@
+import { expect } from "chai";
+
+import * as chai from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+import * as sinonChai from "sinon-chai";
+
+import * as sinon from "sinon";
+import { Queue, CommandLimiter } from "../../../CommandLimiter";
+
+chai.use(sinonChai);
+chai.use(chaiAsPromised);
+
+type Hello = { hello: string };
+
+describe("Command Limiter (unit)", () => {
+    describe("Queue", () => {
+        const obj1 = { hello: "world" };
+        const obj2 = { hello: "this" };
+        const obj3 = { hello: "is a test" };
+        it("Returns undefined when dequeuing from an empty queue", () => {
+            const queue = new Queue<number>();
+            expect(queue).to.have.lengthOf(0);
+            expect(queue.dequeue()).to.be.undefined;
+        });
+        it("Returns the same object that was queued", () => {
+            const queue = new Queue<Hello>();
+            queue.enqueue(obj1);
+            expect(queue).to.have.lengthOf(1);
+            expect(queue.dequeue()).to.equal(obj1);
+            expect(queue).to.have.lengthOf(0);
+        });
+        it("Dequeues objects in the order they were entered", () => {
+            const queue = new Queue<Hello>();
+            expect(queue).to.have.lengthOf(0);
+            queue.enqueue(obj1);
+            expect(queue).to.have.lengthOf(1);
+            queue.enqueue(obj2);
+            expect(queue).to.have.lengthOf(2);
+            queue.enqueue(obj3);
+            expect(queue).to.have.lengthOf(3);
+
+            expect(queue.dequeue()).to.equal(obj1);
+            expect(queue).to.have.lengthOf(2);
+            expect(queue.dequeue()).to.equal(obj2);
+            expect(queue).to.have.lengthOf(1);
+            expect(queue.dequeue()).to.equal(obj3);
+            expect(queue).to.have.lengthOf(0);
+            expect(queue.dequeue()).to.be.undefined;
+        });
+        it("Can enqueue after emptying", () => {
+            const queue = new Queue<Hello>();
+
+            queue.enqueue(obj2);
+            queue.enqueue(obj1);
+            expect(queue.dequeue()).to.equal(obj2);
+            expect(queue.dequeue()).to.equal(obj1);
+            expect(queue.dequeue()).to.be.undefined;
+
+            queue.enqueue(obj3);
+            queue.enqueue(obj1);
+            expect(queue.dequeue()).to.equal(obj3);
+            expect(queue.dequeue()).to.equal(obj1);
+        });
+        it("Can enqueue after partial emptying", () => {
+            const queue = new Queue<Hello>();
+
+            queue.enqueue(obj1);
+            queue.enqueue(obj2);
+            queue.enqueue(obj3);
+            expect(queue.dequeue()).to.equal(obj1);
+            expect(queue.dequeue()).to.equal(obj2);
+            expect(queue).to.have.lengthOf(1);
+            queue.enqueue(obj1);
+            expect(queue).to.have.lengthOf(2);
+            expect(queue.dequeue()).to.equal(obj3);
+            expect(queue.dequeue()).to.equal(obj1);
+            expect(queue).to.have.lengthOf(0);
+        });
+        it("Can enqueue the same object n times in a row", () => {
+            const queue = new Queue<Hello>();
+
+            queue.enqueue(obj1);
+            queue.enqueue(obj1);
+            queue.enqueue(obj1);
+            expect(queue.dequeue()).to.equal(obj1);
+            expect(queue.dequeue()).to.equal(obj1);
+            expect(queue.dequeue()).to.equal(obj1);
+            expect(queue.dequeue()).to.be.undefined;
+        });
+        it("Can enqueue / dequeue a large number of objects", () => {
+            const queue = new Queue<Hello>();
+
+            const items: Hello[] = [];
+            for (let i = 0; i < 50000; ++i) {
+                const item = { hello: "number " + i };
+                items.push(item);
+                queue.enqueue(item);
+            }
+
+            expect(queue).to.have.lengthOf(50000);
+            items.forEach(item => expect(queue.dequeue()).to.equal(item));
+            expect(queue).to.have.lengthOf(0);
+        });
+    });
+
+    describe("Limiter", () => {
+        let cbs: sinon.SinonStub[];
+        beforeEach(() => {
+            cbs = [
+                sinon.stub().callsArg(0),
+                sinon.stub().callsArg(0),
+                sinon.stub().callsArg(0),
+                sinon.stub().callsArg(0)
+            ];
+        });
+        it("Starts with empty queue and running count", () => {
+            const cl = new CommandLimiter(1);
+            expect(cl.queueLength).to.equal(0);
+            expect(cl.runningCount).to.equal(0);
+        });
+        it("Runs the command as a callback", async () => {
+            const cl = new CommandLimiter(1);
+            const promise = cl.submit(cbs[0], "1");
+            expect(cl).to.include({ queueLength: 0, runningCount: 1 });
+            expect(cbs[0]).not.to.have.been.called;
+            await promise;
+            expect(cl).to.include({ queueLength: 0, runningCount: 0 });
+            expect(cbs[0]).to.have.been.calledOnce;
+        });
+        it("Queues while maxConcurrent commands are running (1)", async () => {
+            const cl = new CommandLimiter(1);
+
+            const p1 = cl.submit(cbs[0], "1");
+            expect(cl).to.include({ queueLength: 0, runningCount: 1 });
+            const p2 = cl.submit(cbs[1], "2");
+            expect(cl).to.include({ queueLength: 1, runningCount: 1 });
+            const p3 = cl.submit(cbs[2], "3");
+            expect(cl).to.include({ queueLength: 2, runningCount: 1 });
+
+            expect(cbs[0]).not.to.have.been.called;
+            await p1;
+            expect(cl).to.include({ queueLength: 1, runningCount: 1 });
+            expect(cbs[0]).to.have.been.calledOnce;
+
+            expect(cbs[1]).not.to.have.been.called;
+            await p2;
+            expect(cl).to.include({ queueLength: 0, runningCount: 1 });
+            expect(cbs[1]).to.have.been.calledOnce;
+
+            expect(cbs[2]).not.to.have.been.called;
+            await p3;
+            expect(cl).to.include({ queueLength: 0, runningCount: 0 });
+            expect(cbs[2]).to.have.been.calledOnce;
+        });
+        it("Queues while maxConcurrent commands are running (2)", async () => {
+            const cl = new CommandLimiter(2);
+
+            const p1 = cl.submit(cbs[0], "1");
+            expect(cl).to.include({ queueLength: 0, runningCount: 1 });
+            const p2 = cl.submit(cbs[1], "2");
+            expect(cl).to.include({ queueLength: 0, runningCount: 2 });
+            const p3 = cl.submit(cbs[2], "3");
+            expect(cl).to.include({ queueLength: 1, runningCount: 2 });
+
+            expect(cbs[0]).not.to.have.been.called;
+            expect(cbs[1]).not.to.have.been.called;
+            expect(cbs[2]).not.to.have.been.called;
+
+            await p1;
+            expect(cl).to.include({ queueLength: 0, runningCount: 2 });
+            expect(cbs[0]).to.have.been.calledOnce;
+
+            await p2;
+            expect(cl).to.include({ queueLength: 0, runningCount: 1 });
+            expect(cbs[1]).to.have.been.calledOnce;
+
+            await p3;
+            expect(cl).to.include({ queueLength: 0, runningCount: 0 });
+            expect(cbs[2]).to.have.been.calledOnce;
+        });
+        it("Runs jobs asyncronously", async () => {
+            const cl = new CommandLimiter(2);
+
+            const p1 = cl.submit(
+                c =>
+                    setTimeout(() => {
+                        cbs[0](c);
+                    }, 20),
+                "1"
+            );
+
+            expect(cl).to.include({ queueLength: 0, runningCount: 1 });
+
+            const p2 = cl.submit(
+                c =>
+                    setTimeout(() => {
+                        cbs[1](c);
+                    }, 5),
+                "2"
+            );
+
+            expect(cl).to.include({ queueLength: 0, runningCount: 2 });
+
+            expect(cbs[0]).not.to.have.been.called;
+            expect(cbs[1]).not.to.have.been.called;
+
+            await p2;
+            expect(cbs[0]).not.to.have.been.called;
+            expect(cbs[1]).to.have.been.calledOnce;
+
+            expect(cl).to.include({ queueLength: 0, runningCount: 1 });
+
+            await p1;
+            expect(cbs[0]).to.have.been.calledOnce;
+
+            expect(cl).to.include({ queueLength: 0, runningCount: 0 });
+        });
+        it("Does not queue when maxConcurrent is 0", async () => {
+            const cl = new CommandLimiter(0);
+
+            cl.submit(cbs[0], "1");
+            cl.submit(cbs[1], "2");
+            const p3 = cl.submit(cbs[2], "3");
+            expect(cl).to.include({ queueLength: 0, runningCount: 3 });
+
+            expect(cbs[0]).not.to.have.been.called;
+            expect(cbs[1]).not.to.have.been.called;
+            expect(cbs[2]).not.to.have.been.called;
+
+            await p3;
+
+            expect(cbs[0]).to.have.been.calledOnce;
+            expect(cbs[1]).to.have.been.calledOnce;
+            expect(cbs[2]).to.have.been.calledOnce;
+        });
+        it("Immediately completes jobs that throw an error", async () => {
+            const cl = new CommandLimiter(1);
+            const thrower = sinon.fake.throws(new Error("an error"));
+            const p1 = cl.submit(thrower, "1");
+            const p2 = cl.submit(cbs[0], "2");
+            expect(cl).to.include({ queueLength: 1, runningCount: 1 });
+            expect(thrower).not.to.have.been.called;
+
+            await expect(p1).to.eventually.be.rejectedWith("an error");
+
+            expect(cl).to.include({ queueLength: 0, runningCount: 1 });
+
+            await p2;
+            expect(cbs[0]).to.have.been.calledOnce;
+        });
+    });
+});

--- a/src/test/suite/unit/CommandLimiter.test.ts
+++ b/src/test/suite/unit/CommandLimiter.test.ts
@@ -185,14 +185,17 @@ describe("Command Limiter (unit)", () => {
             expect(cl).to.include({ queueLength: 0, runningCount: 0 });
             expect(cbs[2]).to.have.been.calledOnce;
         });
-        it("Runs jobs asyncronously", async () => {
+        it("Runs jobs asynchronously", async () => {
             const cl = new CommandLimiter(2);
+
+            const c1 = sinon.stub().callsFake(c => c());
+            const c2 = sinon.stub().callsFake(c => c());
 
             const p1 = cl.submit(
                 c =>
                     setTimeout(() => {
-                        cbs[0](c);
-                    }, 20),
+                        c1(c);
+                    }, 40),
                 "1"
             );
 
@@ -201,24 +204,24 @@ describe("Command Limiter (unit)", () => {
             const p2 = cl.submit(
                 c =>
                     setTimeout(() => {
-                        cbs[1](c);
+                        c2(c);
                     }, 5),
                 "2"
             );
 
             expect(cl).to.include({ queueLength: 0, runningCount: 2 });
 
-            expect(cbs[0]).not.to.have.been.called;
-            expect(cbs[1]).not.to.have.been.called;
+            expect(c1).not.to.have.been.called;
+            expect(c2).not.to.have.been.called;
 
             await p2;
-            expect(cbs[0]).not.to.have.been.called;
-            expect(cbs[1]).to.have.been.calledOnce;
+            expect(c1).not.to.have.been.called;
+            expect(c2).to.have.been.calledOnce;
 
             expect(cl).to.include({ queueLength: 0, runningCount: 1 });
 
             await p1;
-            expect(cbs[0]).to.have.been.calledOnce;
+            expect(c1).to.have.been.calledOnce;
 
             expect(cl).to.include({ queueLength: 0, runningCount: 0 });
         });

--- a/src/test/suite/unit/CommandLimiter.test.ts
+++ b/src/test/suite/unit/CommandLimiter.test.ts
@@ -108,9 +108,16 @@ describe("Command Limiter (unit)", () => {
         beforeEach(() => {
             cbs = [
                 sinon.stub().callsArg(0),
-                sinon.stub().callsArg(0),
-                sinon.stub().callsArg(0),
-                sinon.stub().callsArg(0)
+                sinon.stub().callsFake(c =>
+                    setTimeout(() => {
+                        c();
+                    }, 2)
+                ),
+                sinon.stub().callsFake(c =>
+                    setTimeout(() => {
+                        c();
+                    }, 4)
+                )
             ];
         });
         it("Starts with empty queue and running count", () => {

--- a/src/test/suite/unit/Debounce.test.ts
+++ b/src/test/suite/unit/Debounce.test.ts
@@ -1,0 +1,134 @@
+import { expect } from "chai";
+
+import * as chai from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+import * as sinonChai from "sinon-chai";
+
+import * as sinon from "sinon";
+import { debounce, DebouncedFunction } from "../../../Debounce";
+
+chai.use(sinonChai);
+chai.use(chaiAsPromised);
+
+function timeout(ms: number) {
+    return new Promise(res => {
+        setTimeout(() => {
+            res();
+        }, ms);
+    });
+}
+
+describe("Debounce", () => {
+    let callee: sinon.SinonSpy;
+    let debounced: DebouncedFunction<any[], any>;
+
+    beforeEach(() => {
+        callee = sinon.stub().returnsArg(0);
+        debounced = debounce(callee, 10);
+    });
+    afterEach(() => {
+        if (debounced) {
+            debounced.dispose();
+        }
+        sinon.restore();
+    });
+    it("Calls the function on the leading edge with supplied params", async () => {
+        debounced("param");
+        await timeout(0);
+        expect(callee).to.have.been.calledOnce;
+        expect(callee).to.have.returned("param");
+    });
+    it("Calls the function on the trailing edge if called again within `time` ms", async () => {
+        const p1 = debounced("1");
+        const p2 = debounced("2");
+
+        expect(await p1).to.equal("1");
+        expect(callee).to.have.been.calledOnce;
+
+        expect(await p2).to.equal("2");
+        expect(callee).to.have.been.calledTwice;
+    });
+    it("Uses the last call's args when multiple calls are delayed", async () => {
+        const p1 = debounced("1");
+        const p2 = debounced("2");
+        expect(debounced("3")).to.equal(p2);
+        expect(debounced("4")).to.equal(p2);
+
+        expect(await p1).to.equal("1");
+        expect(await p2).to.equals("4");
+        expect(callee).to.not.have.been.calledWith("2");
+        expect(callee).to.not.have.been.calledWith("3");
+        expect(callee).to.have.been.calledTwice;
+    });
+    it("Resets behaviour when time ms has elapsed, after first call with no delayed calls", async () => {
+        debounced("1");
+        await timeout(20);
+
+        expect(callee).to.have.returned("1");
+
+        const p2 = debounced("2");
+        const p3 = debounced("3");
+
+        expect(debounced("4")).to.equal(p3);
+        expect(await p2).to.equal("2");
+        expect(await p3).to.equal("4");
+    });
+    it("Resets behaviour when time ms has elapsed, after the last delayed call", async () => {
+        debounced("1");
+        expect(await debounced("2")).to.equal("2");
+
+        const p3 = debounced("3");
+        const p4 = debounced("4");
+
+        expect(debounced("5")).to.equal(p4);
+        expect(await p3).to.equal("3");
+        expect(await p4).to.equal("5");
+    });
+    it("Can omit the leading call", async () => {
+        debounced.withoutLeadingCall("nolead");
+        await timeout(0);
+        expect(callee).not.to.have.been.called;
+        await timeout(10);
+        expect(callee).to.have.been.called;
+        expect(callee).to.have.returned("nolead");
+    });
+    it("Can't omit a leading call that has already been made, but continues as normal", async () => {
+        const p1 = debounced("withlead");
+        debounced.withoutLeadingCall("nolead");
+        debounced.withoutLeadingCall("nolead-2");
+        expect(callee).to.have.been.calledOnce;
+        expect(await p1).to.equal("withlead");
+        await timeout(10);
+        expect(callee).to.have.been.calledTwice;
+        expect(callee).to.have.returned("nolead-2");
+    });
+    it("Resolves initial function when disposed in the same frame", async () => {
+        const p1 = debounced("1");
+        debounced.dispose();
+        expect(await p1).to.equal("1");
+    });
+    it("Rejects outstanding promises when disposed in the same frame", async () => {
+        const p1 = debounced("1");
+        const p2 = debounced("2");
+        debounced.dispose();
+        expect(await p1).to.equal("1");
+        await expect(p2).to.eventually.be.rejectedWith("Debounced function cancelled");
+    });
+    it("Rejects outstanding promises when disposed during wait", async () => {
+        const p1 = debounced("1");
+        const p2 = debounced("2");
+        expect(await p1).to.equal("1");
+        debounced.dispose();
+        await expect(p2).to.eventually.be.rejectedWith("Debounced function cancelled");
+    });
+    it("Can be disposed multiple times without error", async () => {
+        const p1 = debounced("1");
+        const p2 = debounced("2");
+        debounced.dispose();
+        debounced.dispose();
+        expect(await p1).to.equal("1");
+        debounced.dispose();
+        debounced.dispose();
+        await expect(p2).to.eventually.be.rejectedWith("Debounced function cancelled");
+    });
+});

--- a/src/test/suite/unit/index.ts
+++ b/src/test/suite/unit/index.ts
@@ -1,0 +1,37 @@
+import * as path from "path";
+import * as Mocha from "mocha";
+import * as glob from "glob";
+
+export function run(): Promise<void> {
+    // Create the mocha test
+    const mocha = new Mocha({
+        ui: "bdd"
+    });
+    mocha.useColors(true);
+
+    const testsRoot = __dirname;
+
+    return new Promise((c, e) => {
+        glob("**/**.test.js", { cwd: testsRoot }, (err, files) => {
+            if (err) {
+                return e(err);
+            }
+
+            // Add files to the test suite
+            files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+
+            try {
+                // Run the mocha test
+                mocha.run(failures => {
+                    if (failures > 0) {
+                        e(new Error(`${failures} tests failed.`));
+                    } else {
+                        c();
+                    }
+                });
+            } catch (err) {
+                e(err);
+            }
+        });
+    });
+}

--- a/test-fixtures/core/.vscode/settings.json
+++ b/test-fixtures/core/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "perforce.client": "",
-    "perforce.user": ""
+    "perforce.user": "",
+    "perforce.bottleneck.maxConcurrent": 1000
 }


### PR DESCRIPTION
Fixes #12 

Improves refresh performance in a few ways:

- Runs a single describe to get the list of shelved files for all changelists, instead of running one for each changelist in turn
- Runs a single fstat to get the details for shelved files, instead of running one for each changelist in turn (may be split into chunks)
- Gets the shelved and open files using Promise.all so that they can run asynchronously
- P4 info is only used to get the client name in case the client is being defaulted and is not explicitly defined. Generally, this could probably be done once, though there is potential for the client returned by p4 info to change during run time.
For now, I've changed it so that it only checks again when manually refreshing, and not when a user action like shelve or edit has been run, on the assumption that it is very unlikely to have changed if you have just performed a successful action.

Code restructuring brings it closer to a functional style. Previously there was a lot of mutation of member variables, which was quite hard to follow. That is now constrained to a small location when we have determined the full set of changelists and changes

Things that could still be improved:

- Tests for refresh - there aren't any.
- If a p4 client is explicitly specified, can probably get away without ever using p4 info for refreshing.