### PR TITLE
Add watchintegration-linux command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,15 @@ There are two types of test:
   * Running the integration tests also includes the unit tests
   * A single run of the integration tests can be started using `npm run integrationtest`, however a launch configuration is provided to run the tests in the debugger. Run the `Launch Extension` configuration and it will compile the typescript and open up vscode to run the tests (using the `vscode-test` package).
   * You should leave the window alone while the tests run. If run from the debugger, the results will appear in the DEBUG CONSOLE view.
+  * You can run a watch build of the integration tests using `watchintegration-linux`
+    * This requires a display server, e.g. Xvfb running on display 99, and as such only works on linux.
+    * To run,
+      1. install Xvfb,
+      2. start the server, e.g.
+         `Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &`
+      3. Run `npm run watchintegration-linux`
   * Note that the integration tests stub the perforce command line. There can ocassionally be some 'interference' where error messages appear in the debug log, due to the extension reacting to events / editor windows opened by the test, between tests and after the stub has been destroyed. These can generally be ignored as long as they do not cause test failures and the errors do not show up repeatedly.
+
 
 Note that all of the tests use tsc directly instead of webpack, as the tests are not included in the webpack build.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "perforce",
-    "version": "3.3.2",
+    "version": "3.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -700,6 +700,7 @@
         "integrationtest-nocompile": "node ./out/test/runTest.js",
         "unittest": "npm run pretest && npm run unittest-nocompile",
         "integrationtest": "npm run pretest && npm run integrationtest-nocompile",
-        "watchunit": "tsc-watch -p ./ --onSuccess \"npm run unittest-nocompile\""
+        "watchunit": "tsc-watch -p ./ --onSuccess \"npm run unittest-nocompile\"",
+        "watchintegration-linux": "tsc-watch -p ./ --onSuccess \"npm run integrationtest-nocompile -- --display=:99\""
     }
 }

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -14,12 +14,31 @@ async function main() {
 
         const testWorkspace = path.resolve(__dirname, "../../test-fixtures/core/");
 
+        const params = process.argv.slice(2).reduce((all, cur) => {
+            const [name, val] = cur.split("=");
+            const finalVal = val ? val : true;
+            all[name] = finalVal;
+            return all;
+        }, {});
+
+        const env = {};
+        if (params["--display"]) {
+            env["DISPLAY"] = params["--display"];
+            console.log(
+                "\nRUNNING WITH DISPLAY: " +
+                    params["--display"] +
+                    "\n\tNb: Before running with this mode, you should have run Xvfb, e.g.\n" +
+                    "\tXvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &\n\n"
+            );
+        }
+
         // Download VS Code, unzip it and run the integration test
         await runTests({
             version: "insiders",
             extensionDevelopmentPath,
             extensionTestsPath,
-            launchArgs: [testWorkspace]
+            launchArgs: [testWorkspace],
+            extensionTestsEnv: env
         });
     } catch (err) {
         console.error("Failed to run tests");


### PR DESCRIPTION
This allows a watch-build of the integration tests using a virtual display on linux