### PR TITLE
Move to new changelist

### DIFF
--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -36,6 +36,12 @@ export class PerforceSCMProvider {
     dispose(): void {
         this.disposables.forEach(d => d.dispose());
         this.disposables = [];
+        const pos = PerforceSCMProvider.instances.findIndex(
+            instance => instance === this
+        );
+        if (pos >= 0) {
+            PerforceSCMProvider.instances.splice(pos, 1);
+        }
     }
 
     private static instances: PerforceSCMProvider[] = [];
@@ -307,11 +313,11 @@ export class PerforceSCMProvider {
         provider._model.Info();
     }
 
-    public static ProcessChangelist(sourceControl: SourceControl) {
+    public static async ProcessChangelist(sourceControl: SourceControl) {
         const provider = PerforceSCMProvider.GetInstance(
             sourceControl ? sourceControl.rootUri : null
         );
-        provider._model.ProcessChangelist();
+        await provider._model.ProcessChangelist();
     }
 
     public static async EditChangelist(input: SourceControlResourceGroup) {

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -728,6 +728,11 @@ export class Model implements Disposable {
     }
 
     public async ReopenFile(resources: Resource[]): Promise<void> {
+        if (resources.some(r => r.isShelved)) {
+            Display.showImportantError("Cannot reopen a shelved file");
+            throw new Error("Cannot reopen shelved file");
+        }
+
         const loggedin = await Utils.isLoggedIn(
             this._workspaceUri,
             this._compatibilityMode

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -41,7 +41,7 @@ async function main() {
             extensionTestsEnv: env
         });
     } catch (err) {
-        console.error("Failed to run tests");
+        console.error("Failed to run tests: " + err);
         process.exit(1);
     }
 }

--- a/src/test/suite/StubPerforceService.ts
+++ b/src/test/suite/StubPerforceService.ts
@@ -221,7 +221,7 @@ export const makeResponses = (
                               : changelist.description) +
                           "\n\n";
 
-                      if (changelist.files.length > 0) {
+                      if (changelist?.files.length > 0) {
                           ret +=
                               "Files:\n\t" +
                               changelist.files

--- a/src/test/suite/StubPerforceService.ts
+++ b/src/test/suite/StubPerforceService.ts
@@ -14,6 +14,7 @@ type PerforceCommand =
     | "opened"
     | "describe"
     | "open"
+    | "reopen"
     | "shelve"
     | "unshelve"
     | "revert"
@@ -232,7 +233,6 @@ export const makeResponses = (
                                   )
                                   .join("\n\t");
                       }
-                      console.log(ret);
                       return stdout(ret);
                   } else if (args.startsWith("-i")) {
                       service.lastChangeInput = input.split("\n\n").reduce((all, cur) => {
@@ -315,9 +315,8 @@ export const makeResponses = (
 
                   return joinStds(allStds, "\n\n");
               },
-              open: () => {
-                  return stdout("open not implemented");
-              },
+              open: returnStdOut("open not implemented"),
+              reopen: returnStdOut("reopen not implemented"),
               shelve: (service, ...rest) => {
                   const ret = service.runChangelistBehaviour("shelve", "c", ...rest);
                   return ret ?? stdout("shelve not implemented");

--- a/src/test/suite/StubPerforceService.ts
+++ b/src/test/suite/StubPerforceService.ts
@@ -10,6 +10,7 @@ type PerforceCommand =
     | "login"
     | "info"
     | "changes"
+    | "change"
     | "opened"
     | "describe"
     | "open"
@@ -28,6 +29,25 @@ type PerforceCommandCallback = (
 ) => [string, string]; // return [stdout, stderr]
 
 type PerforceResponses = Record<PerforceCommand, PerforceCommandCallback | null>;
+
+const changelistHeader =
+    "#  Change:      The change number. 'new' on a new changelist.\n\
+#  Date:        The date this specification was last modified.\n\
+#  Client:      The client on which the changelist was created.  Read-only.\n\
+#  User:        The user who created the changelist.\n\
+#  Status:      Either 'pending' or 'submitted'. Read-only.\n\
+#  Type:        Either 'public' or 'restricted'. Default is 'public'.\n\
+#  Description: Comments about the changelist.  Required.\n\
+#  ImportedBy:  The user who fetched or pushed this change to this server.\n\
+#  Identity:    Identifier for this change.\n\
+#  Jobs:        What opened jobs are to be closed by this changelist.\n\
+#               You may delete jobs from this list.  (New changelists only.)\n\
+#  Stream:      What opened stream is to be added to this changelist.\n\
+#               You may remove an opened stream from this list.\n\
+#  Files:       What opened files from the default changelist are to be added\n\
+#               to this changelist.  You may delete files from this list.\n\
+#               (New changelists only.)\n\
+";
 
 interface StubChangelist {
     chnum: string;
@@ -174,6 +194,60 @@ export const makeResponses = (
                       .join("\n");
                   return stdout(ret);
               },
+              change: (service, _resource, args, _directoryOverride, input) => {
+                  if (args.startsWith("-o")) {
+                      const change = args.split(" ")[1] || "default";
+                      const changelist = service.changelists.find(
+                          c => c.chnum === change
+                      );
+                      let ret = changelistHeader;
+                      ret += "\n\n";
+                      ret +=
+                          "Change:\t" +
+                          (change === "default" ? "new" : changelist.chnum) +
+                          "\n\n";
+
+                      ret += "Client:\tcli\n\n";
+                      ret += "User:\tuser\n\n";
+                      ret +=
+                          "Status:\t" +
+                          (change === "default" ? "new" : "pending") +
+                          "\n\n";
+                      ret +=
+                          "Description:\n\t" +
+                          (change === "default"
+                              ? "<enter description here>"
+                              : changelist.description) +
+                          "\n\n";
+
+                      if (changelist.files.length > 0) {
+                          ret +=
+                              "Files:\n\t" +
+                              changelist.files
+                                  .map(
+                                      file =>
+                                          file.depotPath +
+                                          "\t# " +
+                                          getStatusText(file.operation ?? Status.EDIT)
+                                  )
+                                  .join("\n\t");
+                      }
+                      console.log(ret);
+                      return stdout(ret);
+                  } else if (args.startsWith("-i")) {
+                      service.lastChangeInput = input.split("\n\n").reduce((all, cur) => {
+                          if (!cur.startsWith("#")) {
+                              const colPos = cur.indexOf(":");
+                              all[cur.slice(0, colPos)] = cur.slice(colPos + 1);
+                          }
+                          return all;
+                      }, {});
+                      // not very accurate - doesn't account for updated, or the number of files included
+                      return stdout("Change 99 created.");
+                  } else {
+                      throw new Error("'change' args " + args + " not supported");
+                  }
+              },
               opened: (service, resource, args) => {
                   if (args) {
                       throw new Error("'opened' with args not implemented");
@@ -287,6 +361,7 @@ export function getLocalFile(workspace: vscode.Uri, ...relativePath: string[]) {
 
 export class StubPerforceService {
     public changelists: StubChangelist[];
+    public lastChangeInput: {};
 
     constructor(private _responses?: PerforceResponses) {
         this.changelists = [];

--- a/src/test/suite/StubPerforceService.ts
+++ b/src/test/suite/StubPerforceService.ts
@@ -238,7 +238,9 @@ export const makeResponses = (
                       service.lastChangeInput = input.split("\n\n").reduce((all, cur) => {
                           if (!cur.startsWith("#")) {
                               const colPos = cur.indexOf(":");
-                              all[cur.slice(0, colPos)] = cur.slice(colPos + 1);
+                              all[cur.slice(0, colPos)] = cur
+                                  .slice(colPos + 1)
+                                  .replace(/^\n/, "");
                           }
                           return all;
                       }, {});

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -142,8 +142,10 @@ describe("Model & ScmProvider modules (integration)", () => {
         }
     };
 
+    const localDir = Utils.normalize(workspaceUri.fsPath) + "/";
+
     const config: IPerforceConfig = {
-        localDir: workspaceUri.fsPath + "/",
+        localDir,
         p4Client: "cli",
         p4User: "user"
     };

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -1463,15 +1463,30 @@ describe("Model & ScmProvider modules (integration)", () => {
                 ];
                 await PerforceSCMProvider.ProcessChangelist(items.instance.sourceControl);
                 expect(items.stubService.lastChangeInput).to.include({
-                    Description: "\n\tMy new changelist",
+                    Description: "\tMy new changelist",
                     Files:
-                        "\n\t" +
+                        "\t" +
                         basicFiles.add.depotPath +
                         "\t# add" +
                         "\n\t" +
                         basicFiles.edit.depotPath +
                         "\t# edit"
                 });
+            });
+            it("Can save from an empty default changelist", async () => {
+                items.instance.sourceControl.inputBox.value = "My new changelist";
+                items.stubService.changelists = [
+                    {
+                        chnum: "default",
+                        files: [],
+                        description: "n/a"
+                    }
+                ];
+                await PerforceSCMProvider.ProcessChangelist(items.instance.sourceControl);
+                expect(items.stubService.lastChangeInput).to.include({
+                    Description: "\tMy new changelist"
+                });
+                expect(items.stubService.lastChangeInput).not.to.have.any.keys("Files");
             });
             it("Can change the description of an existing changelist", async () => {
                 items.instance.sourceControl.inputBox.value = "#1\nMy updated changelist";
@@ -1484,15 +1499,30 @@ describe("Model & ScmProvider modules (integration)", () => {
                 ];
                 await PerforceSCMProvider.ProcessChangelist(items.instance.sourceControl);
                 expect(items.stubService.lastChangeInput).to.include({
-                    Description: "\n\tMy updated changelist",
+                    Description: "\tMy updated changelist",
                     Files:
-                        "\n\t" +
+                        "\t" +
                         basicFiles.add.depotPath +
                         "\t# add" +
                         "\n\t" +
                         basicFiles.edit.depotPath +
                         "\t# edit"
                 });
+            });
+            it("Can change the description of an empty changelist", async () => {
+                items.instance.sourceControl.inputBox.value = "#1\nMy updated changelist";
+                items.stubService.changelists = [
+                    {
+                        chnum: "1",
+                        files: [],
+                        description: "changelist 1"
+                    }
+                ];
+                await PerforceSCMProvider.ProcessChangelist(items.instance.sourceControl);
+                expect(items.stubService.lastChangeInput).to.include({
+                    Description: "\tMy updated changelist"
+                });
+                expect(items.stubService.lastChangeInput).not.to.have.any.keys("Files");
             });
         });
         describe("Move files to a changelist", () => {

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -1453,7 +1453,8 @@ describe("Model & ScmProvider modules (integration)", () => {
         });
         describe("Save a changelist", () => {
             it("Can save the default changelist", async () => {
-                items.instance.sourceControl.inputBox.value = "My new changelist";
+                items.instance.sourceControl.inputBox.value =
+                    "My new changelist\nline 2\nline 3";
                 items.stubService.changelists = [
                     {
                         chnum: "default",
@@ -1463,7 +1464,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 ];
                 await PerforceSCMProvider.ProcessChangelist(items.instance.sourceControl);
                 expect(items.stubService.lastChangeInput).to.include({
-                    Description: "\tMy new changelist",
+                    Description: "\tMy new changelist\n\tline 2\n\tline 3",
                     Files:
                         "\t" +
                         basicFiles.add.depotPath +
@@ -1611,7 +1612,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 });
                 sinon
                     .stub(vscode.window, "showInputBox")
-                    .resolves("My selective changelist");
+                    .resolves("My selective changelist\nLine 2\nLine 3");
                 const resource1 = findResourceForFile(
                     items.instance.resources[1],
                     basicFiles.edit
@@ -1624,7 +1625,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 await PerforceSCMProvider.ReopenFile(resource1 as Resource, resource2);
 
                 expect(items.stubService.lastChangeInput).to.include({
-                    Description: "\tMy selective changelist"
+                    Description: "\tMy selective changelist\n\tLine 2\n\tLine 3"
                 });
 
                 // TODO this shouldn't need to be many commands

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -1634,6 +1634,27 @@ describe("Model & ScmProvider modules (integration)", () => {
                     sinon.match.any,
                     '-c 99 "' + basicFiles.edit.localFile.fsPath + '"'
                 );
+
+                expect(items.execute).to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "reopen",
+                    sinon.match.any,
+                    '-c 99 "' + basicFiles.add.localFile.fsPath + '"'
+                );
+            });
+            it("Cannot move shelved files", async () => {
+                const resource1 = findResourceForFile(
+                    items.instance.resources[1],
+                    basicFiles.edit
+                );
+                const resource2 = findResourceForShelvedFile(
+                    items.instance.resources[1],
+                    basicFiles.shelveEdit
+                );
+
+                await expect(
+                    PerforceSCMProvider.ReopenFile(resource1 as Resource, resource2)
+                ).to.eventually.be.rejectedWith("Cannot reopen shelved files");
             });
         });
     });

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -43,6 +43,25 @@ function timeout(ms: number) {
     });
 }
 
+function findResourceForShelvedFile(
+    group: vscode.SourceControlResourceGroup,
+    file: StubFile
+) {
+    return group.resourceStates.find(
+        resource =>
+            (resource as Resource).isShelved &&
+            Utils.getDepotPathFromDepotUri(resource.resourceUri) === file.depotPath
+    );
+}
+
+function findResourceForFile(group: vscode.SourceControlResourceGroup, file: StubFile) {
+    return group.resourceStates.find(
+        resource =>
+            !(resource as Resource).isShelved &&
+            (resource as Resource).resourceUri.fsPath === file.localFile.fsPath
+    );
+}
+
 describe("Model & ScmProvider modules (integration)", () => {
     const workspaceUri = vscode.workspace.workspaceFolders[0].uri;
 
@@ -124,7 +143,7 @@ describe("Model & ScmProvider modules (integration)", () => {
     };
 
     const config: IPerforceConfig = {
-        localDir: workspaceUri.fsPath,
+        localDir: workspaceUri.fsPath + "/",
         p4Client: "cli",
         p4User: "user"
     };
@@ -1083,30 +1102,6 @@ describe("Model & ScmProvider modules (integration)", () => {
         });
 
         describe("Opening", () => {
-            function findResourceForShelvedFile(
-                group: vscode.SourceControlResourceGroup,
-                file: StubFile
-            ) {
-                return group.resourceStates.find(
-                    resource =>
-                        (resource as Resource).isShelved &&
-                        Utils.getDepotPathFromDepotUri(resource.resourceUri) ===
-                            file.depotPath
-                );
-            }
-
-            function findResourceForFile(
-                group: vscode.SourceControlResourceGroup,
-                file: StubFile
-            ) {
-                return group.resourceStates.find(
-                    resource =>
-                        !(resource as Resource).isShelved &&
-                        (resource as Resource).resourceUri.fsPath ===
-                            file.localFile.fsPath
-                );
-            }
-
             /**
              * Matches against a perforce URI, containing a local file's path
              * @param file
@@ -1176,7 +1171,7 @@ describe("Model & ScmProvider modules (integration)", () => {
 
             describe("When opening a file", () => {
                 it("Opens the underlying workspace file", async () => {
-                    const file = items.stubService.changelists[0].files[0];
+                    const file = basicFiles.edit;
                     const resource = findResourceForFile(
                         items.instance.resources[1],
                         file
@@ -1187,13 +1182,13 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeOpenCall(file.localFile);
                 });
                 it("Can open multiple files", async () => {
-                    const file1 = items.stubService.changelists[0].files[0];
+                    const file1 = basicFiles.edit;
                     const resource1 = findResourceForFile(
                         items.instance.resources[1],
                         file1
                     );
 
-                    const file2 = items.stubService.changelists[0].files[2];
+                    const file2 = basicFiles.add;
                     const resource2 = findResourceForFile(
                         items.instance.resources[1],
                         file2
@@ -1206,7 +1201,7 @@ describe("Model & ScmProvider modules (integration)", () => {
             });
             describe("When opening an scm resource", () => {
                 it("Diffs a local file against the depot file", async () => {
-                    const file = items.stubService.changelists[0].files[0];
+                    const file = basicFiles.edit;
                     const resource = findResourceForFile(
                         items.instance.resources[1],
                         file
@@ -1229,13 +1224,13 @@ describe("Model & ScmProvider modules (integration)", () => {
                 });
                 it("Can open multiple resources", async () => {
                     const td = sinon.stub(vscode.window, "showTextDocument");
-                    const file1 = items.stubService.changelists[0].files[0];
+                    const file1 = basicFiles.edit;
                     const resource1 = findResourceForFile(
                         items.instance.resources[1],
                         file1
                     );
 
-                    const file2 = items.stubService.changelists[0].files[1];
+                    const file2 = basicFiles.delete;
                     const resource2 = findResourceForFile(
                         items.instance.resources[1],
                         file2
@@ -1262,7 +1257,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 it("Displays the depot version of a deleted file", async () => {
                     const td = sinon.stub(vscode.window, "showTextDocument");
 
-                    const file = items.stubService.changelists[0].files[1];
+                    const file = basicFiles.delete;
                     const resource = findResourceForFile(
                         items.instance.resources[1],
                         file
@@ -1275,7 +1270,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     );
                 });
                 it("Diffs a new file against an empty file", async () => {
-                    const file = items.stubService.changelists[0].files[2];
+                    const file = basicFiles.add;
                     const resource = findResourceForFile(
                         items.instance.resources[1],
                         file
@@ -1291,7 +1286,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     );
                 });
                 it("Diffs a moved file against the original file", async () => {
-                    const file = items.stubService.changelists[0].files[3];
+                    const file = basicFiles.moveAdd;
                     const resource = findResourceForFile(
                         items.instance.resources[1],
                         file
@@ -1315,7 +1310,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 it("Displays the depot version for a move / delete", async () => {
                     const td = sinon.stub(vscode.window, "showTextDocument");
 
-                    const file = items.stubService.changelists[0].files[4];
+                    const file = basicFiles.moveDelete;
                     const resource = findResourceForFile(
                         items.instance.resources[1],
                         file
@@ -1328,7 +1323,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     );
                 });
                 it("Diffs a file opened for branch against an empty file", async () => {
-                    const file = items.stubService.changelists[0].files[5];
+                    const file = basicFiles.branch;
                     const resource = findResourceForFile(
                         items.instance.resources[1],
                         file
@@ -1344,7 +1339,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     );
                 });
                 it("Diffs an integration/merge against the target depot file", async () => {
-                    const file = items.stubService.changelists[0].files[6];
+                    const file = basicFiles.integrate;
                     const resource = findResourceForFile(
                         items.instance.resources[1],
                         file
@@ -1367,7 +1362,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     );
                 });
                 it("Diffs a shelved file against the depot file", async () => {
-                    const file = items.stubService.changelists[0].shelvedFiles[0];
+                    const file = basicFiles.shelveEdit;
                     const resource = findResourceForShelvedFile(
                         items.instance.resources[1],
                         file
@@ -1395,7 +1390,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     );
                 });
                 it("Can diff a local file against the shelved file (from the shelved file)", async () => {
-                    const file = items.stubService.changelists[0].shelvedFiles[0];
+                    const file = basicFiles.shelveEdit;
                     const resource = findResourceForShelvedFile(
                         items.instance.resources[1],
                         file
@@ -1417,7 +1412,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     );
                 });
                 it("Can diff a local file against the shelved file (from the local file)", async () => {
-                    const file = items.stubService.changelists[0].files[0];
+                    const file = basicFiles.shelveEdit;
                     const resource = findResourceForFile(
                         items.instance.resources[1],
                         file
@@ -1440,7 +1435,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 });
                 it("Displays the depot version for a shelved deletion", async () => {
                     const td = sinon.stub(vscode.window, "showTextDocument");
-                    const file = items.stubService.changelists[0].files[1];
+                    const file = basicFiles.shelveDelete;
                     const resource = findResourceForFile(
                         items.instance.resources[1],
                         file
@@ -1452,6 +1447,128 @@ describe("Model & ScmProvider modules (integration)", () => {
                         perforceLocalUriMatcher(file)
                     );
                 });
+            });
+        });
+        describe("Save a changelist", () => {
+            it("Can save the default changelist", async () => {
+                items.instance.sourceControl.inputBox.value = "My new changelist";
+                items.stubService.changelists = [
+                    {
+                        chnum: "default",
+                        files: [basicFiles.add, basicFiles.edit],
+                        description: "n/a"
+                    }
+                ];
+                await PerforceSCMProvider.ProcessChangelist(items.instance.sourceControl);
+                expect(items.stubService.lastChangeInput).to.include({
+                    Description: "\n\tMy new changelist",
+                    Files:
+                        "\n\t" +
+                        basicFiles.add.depotPath +
+                        "\t# add" +
+                        "\n\t" +
+                        basicFiles.edit.depotPath +
+                        "\t# edit"
+                });
+            });
+            it("Can change the description of an existing changelist", async () => {
+                items.instance.sourceControl.inputBox.value = "#1\nMy updated changelist";
+                items.stubService.changelists = [
+                    {
+                        chnum: "1",
+                        files: [basicFiles.add, basicFiles.edit],
+                        description: "changelist 1"
+                    }
+                ];
+                await PerforceSCMProvider.ProcessChangelist(items.instance.sourceControl);
+                expect(items.stubService.lastChangeInput).to.include({
+                    Description: "\n\tMy updated changelist",
+                    Files:
+                        "\n\t" +
+                        basicFiles.add.depotPath +
+                        "\t# add" +
+                        "\n\t" +
+                        basicFiles.edit.depotPath +
+                        "\t# edit"
+                });
+            });
+        });
+        describe("Move files to a changelist", () => {
+            it("Displays a selection of changelists to choose from", async () => {
+                const quickPick = sinon
+                    .stub(vscode.window, "showQuickPick")
+                    .resolves(undefined);
+                const resource = findResourceForFile(
+                    items.instance.resources[1],
+                    basicFiles.edit
+                );
+
+                await PerforceSCMProvider.ReopenFile(resource as Resource);
+
+                const itemArg = quickPick.lastCall.args[0];
+                expect(itemArg).to.have.lengthOf(3);
+                expect(itemArg[0]).to.include({ label: "Default Changelist" });
+                expect(itemArg[1]).to.include({
+                    label: "#1",
+                    description: "Changelist 1"
+                });
+                expect(itemArg[2]).to.include({
+                    label: "#2",
+                    description: "Changelist 2"
+                });
+
+                expect(items.execute).not.to.have.been.calledWith(
+                    sinon.match.any,
+                    "reopen"
+                );
+            });
+            it("Can move files to a changelist", async () => {
+                sinon.stub(vscode.window, "showQuickPick").callsFake(items => {
+                    return Promise.resolve(items[2]);
+                });
+                const resource1 = findResourceForFile(
+                    items.instance.resources[1],
+                    basicFiles.edit
+                );
+                const resource2 = findResourceForFile(
+                    items.instance.resources[1],
+                    basicFiles.add
+                );
+
+                await PerforceSCMProvider.ReopenFile(resource1 as Resource, resource2);
+
+                // TODO this shouldn't need to be many commands!!
+                expect(items.execute).to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "reopen",
+                    sinon.match.any,
+                    '-c 2 "' + basicFiles.edit.localFile.fsPath + '"'
+                );
+                expect(items.execute).to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "reopen",
+                    sinon.match.any,
+                    '-c 2 "' + basicFiles.add.localFile.fsPath + '"'
+                );
+            });
+            it("Can move files to the default changelist", async () => {
+                sinon.stub(vscode.window, "showQuickPick").callsFake(items => {
+                    return Promise.resolve(items[0]);
+                });
+                const resource1 = findResourceForFile(
+                    items.instance.resources[1],
+                    basicFiles.edit
+                );
+
+                await PerforceSCMProvider.ReopenFile(resource1 as Resource);
+
+                // TODO this shouldn't need to be many commands
+                expect(items.execute).to.have.been.calledWithMatch(
+                    workspaceUri,
+                    "reopen",
+                    sinon.match.any,
+                    '-c default "' + basicFiles.edit.localFile.fsPath + '"'
+                );
             });
         });
     });


### PR DESCRIPTION
Fixes #4 

Refactors SaveToChangelist into smaller units and implements a new option to move to a "New changelist..." in the dropdown when selecting the changelist to move to.