### PR TITLE
Add commands to attach jobs to changelists

### DIFF
--- a/package.json
+++ b/package.json
@@ -399,6 +399,16 @@
                 "category": "Perforce"
             },
             {
+                "command": "perforce.fixJob",
+                "title": "Attach job...",
+                "category": "Perforce"
+            },
+            {
+                "command": "perforce.unfixJob",
+                "title": "Remove job...",
+                "category": "Perforce"
+            },
+            {
                 "command": "perforce.describe",
                 "title": "Describe changelist",
                 "category": "Perforce"
@@ -537,9 +547,19 @@
                     "group": "2_shelving@4"
                 },
                 {
+                    "command": "perforce.fixJob",
+                    "when": "scmProvider == perforce && scmResourceGroup != default",
+                    "group": "3_job@1"
+                },
+                {
+                    "command": "perforce.unfixJob",
+                    "when": "scmProvider == perforce && scmResourceGroup != default",
+                    "group": "3_job@1"
+                },
+                {
                     "command": "perforce.describe",
                     "when": "scmProvider == perforce",
-                    "group": "3_info"
+                    "group": "4_info"
                 }
             ],
             "scm/resourceState/context": [

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -75,6 +75,10 @@ export namespace Display {
         channel.append(message);
     }
 
+    export function showModalMessage(message: string) {
+        window.showInformationMessage(message, { modal: true });
+    }
+
     export function showError(error: string) {
         window.setStatusBarMessage("Perforce: " + error, 3000);
         channel.appendLine(`ERROR: ${JSON.stringify(error)}`);

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -216,6 +216,14 @@ export class PerforceSCMProvider {
             "perforce.reopenFile",
             PerforceSCMProvider.ReopenFile.bind(this)
         );
+        commands.registerCommand(
+            "perforce.fixJob",
+            PerforceSCMProvider.FixJob.bind(this)
+        );
+        commands.registerCommand(
+            "perforce.unfixJob",
+            PerforceSCMProvider.UnfixJob.bind(this)
+        );
     }
 
     private onDidModelChange(): void {
@@ -440,6 +448,20 @@ export class PerforceSCMProvider {
         }
 
         await resources[0].model.ReopenFile(resources);
+    }
+
+    public static async FixJob(input: ResourceGroup) {
+        const model: Model = input.model;
+        if (model) {
+            await model.FixJob(input);
+        }
+    }
+
+    public static async UnfixJob(input: ResourceGroup) {
+        const model: Model = input.model;
+        if (model) {
+            await model.UnfixJob(input);
+        }
     }
 
     provideOriginalResource(uri: Uri): ProviderResult<Uri> {


### PR DESCRIPTION
fixes #3

Introduces "Attach job..." and "Remove job..." to the context menu for jobs.

* Attach job presents an input box requesting a job number
* Remove job presents a list of currently attached jobs, selecting one removes the job

