### PR TITLE
Delete shelved file

### DIFF
--- a/package.json
+++ b/package.json
@@ -399,6 +399,11 @@
                 "category": "Perforce"
             },
             {
+                "command": "perforce.deleteShelvedFile",
+                "title": "Delete shelved file",
+                "category": "Perforce"
+            },
+            {
                 "command": "perforce.fixJob",
                 "title": "Attach job...",
                 "category": "Perforce"
@@ -611,7 +616,12 @@
                 {
                     "command": "perforce.shelveunshelve",
                     "when": "scmProvider == perforce && scmResourceGroup != default",
-                    "group": "1_modification@4"
+                    "group": "2_shelve@1"
+                },
+                {
+                    "command": "perforce.deleteShelvedFile",
+                    "when": "scmProvider == perforce",
+                    "group": "2_shelve@2"
                 }
             ]
         },

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -205,6 +205,10 @@ export class PerforceSCMProvider {
             PerforceSCMProvider.ShelveOrUnshelve.bind(this)
         );
         commands.registerCommand(
+            "perforce.deleteShelvedFile",
+            PerforceSCMProvider.DeleteShelvedFile.bind(this)
+        );
+        commands.registerCommand(
             "perforce.revertFile",
             PerforceSCMProvider.Revert.bind(this)
         );
@@ -410,6 +414,16 @@ export class PerforceSCMProvider {
         const selection = resourceStates.filter(s => s instanceof Resource) as Resource[];
         const promises = selection.map(resource =>
             resource.model.ShelveOrUnshelve(resource)
+        );
+        await Promise.all(promises);
+    }
+
+    public static async DeleteShelvedFile(
+        ...resourceStates: SourceControlResourceState[]
+    ): Promise<void> {
+        const selection = resourceStates.filter(s => s instanceof Resource) as Resource[];
+        const promises = selection.map(resource =>
+            resource.model.DeleteShelvedFile(resource)
         );
         await Promise.all(promises);
     }

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -529,6 +529,10 @@ export class Model implements Disposable {
             });
     }
 
+    private hasShelvedFiles(group: SourceControlResourceGroup) {
+        return group.resourceStates.some(resource => (resource as Resource).isShelved);
+    }
+
     public async Revert(
         input: Resource | SourceControlResourceGroup,
         unchanged?: boolean
@@ -584,7 +588,7 @@ export class Model implements Disposable {
             });
 
         // delete changelist after
-        if (isResourceGroup(input)) {
+        if (isResourceGroup(input) && !this.hasShelvedFiles(input)) {
             const command = "change";
             const id = input.id;
             const chnum = id.substr(id.indexOf(":") + 1);


### PR DESCRIPTION
Fixes #17 

Allows a single shelved file to be deleted from a changelist.
Also prevents "revert file" from being used on a shelved file