### PR TITLE
Diff against working / have revision

### DIFF
--- a/src/ContentProvider.ts
+++ b/src/ContentProvider.ts
@@ -29,9 +29,9 @@ export class PerforceContentProvider {
                 return;
             }
 
-            let revision: number | string = uri.fragment;
-            if (!revision.startsWith("@")) {
-                revision = parseInt(uri.fragment);
+            let revision: string = uri.fragment;
+            if (revision && !revision.startsWith("@")) {
+                revision = "#" + uri.fragment;
             }
 
             const allArgs = Utils.decodeUriQuery(uri.query ?? "");

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -510,7 +510,6 @@ export class PerforceSCMProvider {
 
         const left = PerforceSCMProvider.getLeftResource(resource, diffType);
         const right = PerforceSCMProvider.getRightResource(resource, diffType);
-        const title: string = PerforceSCMProvider.getTitle(resource, diffType);
 
         if (!left) {
             if (!right) {
@@ -522,10 +521,15 @@ export class PerforceSCMProvider {
             return;
         }
         if (!right) {
-            await window.showTextDocument(left);
+            await window.showTextDocument(left.uri);
             return;
         }
-        await commands.executeCommand<void>("vscode.diff", left, right, title);
+        await commands.executeCommand<void>(
+            "vscode.diff",
+            left.uri,
+            right,
+            PerforceSCMProvider.getTitle(resource, left.title, diffType)
+        );
         return;
     }
 
@@ -533,7 +537,7 @@ export class PerforceSCMProvider {
     private static getLeftResource(
         resource: Resource,
         diffType: DiffType
-    ): Uri | undefined {
+    ): { title: string; uri: Uri } | undefined {
         const args = {
             depot: resource.isShelved,
             workspace: resource.model.workspaceUri.fsPath
@@ -547,11 +551,17 @@ export class PerforceSCMProvider {
                 case Status.INTEGRATE:
                 case Status.MOVE_ADD:
                 case Status.BRANCH:
-                    return resource.resourceUri.with({
-                        scheme: "perforce",
-                        query: Utils.makePerforceUriQuery("print", "-q", args),
-                        fragment: "@=" + resource.change
-                    });
+                    return {
+                        title:
+                            Path.basename(resource.resourceUri.fsPath) +
+                            "@=" +
+                            resource.change,
+                        uri: resource.resourceUri.with({
+                            scheme: "perforce",
+                            query: Utils.makePerforceUriQuery("print", "-q", args),
+                            fragment: "@=" + resource.change
+                        })
+                    };
                 case Status.DELETE:
                 case Status.MOVE_DELETE:
             }
@@ -561,25 +571,41 @@ export class PerforceSCMProvider {
             switch (resource.status) {
                 case Status.ADD:
                 case Status.BRANCH:
-                    return emptyDoc;
+                    return {
+                        title: Path.basename(resource.resourceUri.fsPath) + "#0",
+                        uri: emptyDoc
+                    };
                 case Status.MOVE_ADD:
                     // diff against the old file if it is known (always a depot path)
-                    return resource.baseFile
-                        ? Utils.makePerforceDocUri(resource.baseFile, "print", "-q", {
-                              depot: true,
-                              workspace: resource.model.workspaceUri.fsPath
-                          }).with({ fragment: resource.baseRev })
-                        : emptyDoc;
+                    return {
+                        title: resource.baseFile
+                            ? Path.basename(resource.baseFile.fsPath) +
+                              "#" +
+                              resource.baseRev
+                            : "Depot Version",
+                        uri: resource.baseFile
+                            ? Utils.makePerforceDocUri(resource.baseFile, "print", "-q", {
+                                  depot: true,
+                                  workspace: resource.model.workspaceUri.fsPath
+                              }).with({ fragment: resource.baseRev })
+                            : emptyDoc
+                    };
                 case Status.INTEGRATE:
                 case Status.EDIT:
                 case Status.DELETE:
                 case Status.MOVE_DELETE:
-                    return Utils.makePerforceDocUri(
-                        resource.resourceUri,
-                        "print",
-                        "-q",
-                        args
-                    ).with({ fragment: resource.workingRevision });
+                    return {
+                        title:
+                            Path.basename(resource.resourceUri.fsPath) +
+                            "#" +
+                            resource.workingRevision,
+                        uri: Utils.makePerforceDocUri(
+                            resource.resourceUri,
+                            "print",
+                            "-q",
+                            args
+                        ).with({ fragment: resource.workingRevision })
+                    };
             }
         }
     }
@@ -623,20 +649,24 @@ export class PerforceSCMProvider {
         }
     }
 
-    private static getTitle(resource: Resource, diffType: DiffType): string {
+    private static getTitle(
+        resource: Resource,
+        leftTitle: string,
+        diffType: DiffType
+    ): string {
         const basename = Path.basename(resource.resourceUri.fsPath);
 
         let text = "";
         switch (diffType) {
             case DiffType.SHELVE_V_DEPOT:
-                text = "Diff Shelve (right) Against Depot Version (left)";
+                text = leftTitle + " vs " + basename + "@=" + resource.change;
                 break;
             case DiffType.WORKSPACE_V_SHELVE:
-                text = "Diff Workspace (right) Against Shelved Version (left)";
+                text = leftTitle + " vs " + basename + " (workspace)";
                 break;
             case DiffType.WORKSPACE_V_DEPOT:
-                text = "Diff Workspace (right) Against Most Recent Revision (left)";
+                text = leftTitle + " vs " + basename + " (workspace)";
         }
-        return `${basename} - ${text}`;
+        return text;
     }
 }

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -483,7 +483,7 @@ export class PerforceSCMProvider {
             return;
         }
 
-        return Utils.makePerforceDocUri(uri, "print", "-q");
+        return Utils.makePerforceDocUri(uri, "print", "-q").with({ fragment: "have" });
     }
 
     /**

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -564,11 +564,11 @@ export class PerforceSCMProvider {
                     return emptyDoc;
                 case Status.MOVE_ADD:
                     // diff against the old file if it is known (always a depot path)
-                    return resource.fromFile
-                        ? Utils.makePerforceDocUri(resource.fromFile, "print", "-q", {
+                    return resource.baseFile
+                        ? Utils.makePerforceDocUri(resource.baseFile, "print", "-q", {
                               depot: true,
                               workspace: resource.model.workspaceUri.fsPath
-                          })
+                          }).with({ fragment: resource.baseRev })
                         : emptyDoc;
                 case Status.INTEGRATE:
                 case Status.EDIT:
@@ -579,7 +579,7 @@ export class PerforceSCMProvider {
                         "print",
                         "-q",
                         args
-                    );
+                    ).with({ fragment: resource.workingRevision });
             }
         }
     }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -180,7 +180,7 @@ export namespace Utils {
         resource: Uri,
         command: string,
         file?: Uri | string | null | undefined,
-        revision?: number | string | null,
+        revision?: string | null, // must include the # or @
         prefixArgs?: string,
         gOpts?: string | null,
         input?: string
@@ -192,12 +192,7 @@ export namespace Utils {
                 command = gOpts + " " + command;
             }
 
-            let revisionString = "";
-            if (typeof revision === "string") {
-                revisionString = revision;
-            } else if (revision !== null && revision !== undefined && !isNaN(revision)) {
-                revisionString = `#${revision}`;
-            }
+            const revisionString = revision ?? "";
 
             if (file) {
                 let path = typeof file === "string" ? file : file.fsPath;
@@ -231,7 +226,7 @@ export namespace Utils {
     export function runCommandForFile(
         command: string,
         file: Uri,
-        revision?: number | string,
+        revision?: string,
         prefixArgs?: string,
         gOpts?: string,
         input?: string

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -24,7 +24,7 @@ function isResourceGroup(arg: any): arg is SourceControlResourceGroup {
     return arg.id !== undefined;
 }
 
-type FstatInfo = {
+export type FstatInfo = {
     depotFile: string;
     [key: string]: string;
 };
@@ -1041,9 +1041,7 @@ export class Model implements Disposable {
         const action = fstatInfo["action"];
         const headType = fstatInfo["headType"];
         const depotPath = Uri.file(fstatInfo["depotFile"]);
-        const fromFile = fstatInfo["resolveFromFile0"]
-            ? Uri.file(fstatInfo["resolveFromFile0"])
-            : undefined;
+
         const uri = Uri.file(clientFile);
         if (this._workspaceConfig.hideNonWorkspaceFiles) {
             const workspaceFolder = workspace.getWorkspaceFolder(uri);
@@ -1058,7 +1056,7 @@ export class Model implements Disposable {
             change,
             false,
             action,
-            fromFile,
+            fstatInfo,
             headType
         );
 
@@ -1167,9 +1165,6 @@ export class Model implements Disposable {
 
     private getResourceForShelvedFile(chnum: string, fstatInfo: FstatInfo) {
         const underlyingUri = Uri.file(fstatInfo["clientFile"]);
-        const fromFile = fstatInfo["resolveFromFile0"]
-            ? Uri.file(fstatInfo["resolveFromFile0"])
-            : undefined;
 
         const resource: Resource = new Resource(
             this,
@@ -1178,7 +1173,7 @@ export class Model implements Disposable {
             chnum,
             true,
             fstatInfo["action"],
-            fromFile
+            fstatInfo
         );
         return resource;
     }

--- a/src/test/suite/StubPerforceService.ts
+++ b/src/test/suite/StubPerforceService.ts
@@ -78,9 +78,10 @@ export interface StubFile {
     depotPath: string;
     depotRevision: number;
     behaviours?: StubFileBehaviours;
-    operation?: Status;
+    operation: Status;
     fileType?: string;
-    resolveFromDepotPath?: string;
+    resolveBaseDepotPath?: string;
+    resolveBaseRev?: number;
 }
 
 /**
@@ -519,10 +520,13 @@ export class StubPerforceService {
                 depotFile: depotPath,
                 clientFile: file.localFile.fsPath,
                 isMapped: true,
+                haveRev: file.depotRevision,
                 headType: file.fileType ?? "text",
                 action: getStatusText(file.operation ?? Status.EDIT),
+                workRev: file.depotRevision?.toString(),
                 change: cl?.chnum,
-                resolveFromFile0: file.resolveFromDepotPath
+                resolveBaseFile0: file.resolveBaseDepotPath,
+                resolveBaseRev0: file.resolveBaseRev?.toString()
             };
             return Object.keys(props)
                 .filter(

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -17,7 +17,6 @@ import {
 } from "./StubPerforceService";
 import { Display } from "../../Display";
 import { Utils } from "../../Utils";
-import * as path from "path";
 import { Resource } from "../../scm/Resource";
 import { Status } from "../../scm/Status";
 import p4Commands from "../helpers/p4Commands";
@@ -85,7 +84,7 @@ describe("Model & ScmProvider modules (integration)", () => {
         edit: {
             localFile: getLocalFile(workspaceUri, "testFolder", "a.txt"),
             depotPath: "//depot/testArea/testFolder/a.txt",
-            depotRevision: 1,
+            depotRevision: 4,
             operation: Status.EDIT
         },
         delete: {
@@ -1370,14 +1369,13 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         perforceLocalUriMatcher(file),
                         file.localFile,
-                        path.basename(file.localFile.path) +
-                            " - Diff Workspace (right) Against Most Recent Revision (left)"
+                        "a.txt#4 vs a.txt (workspace)"
                     );
                     expect(items.execute).to.be.calledWithMatch(
                         file.localFile,
                         "print",
                         sinon.match.any,
-                        '-q "' + file.localFile.fsPath + '#1"'
+                        '-q "' + file.localFile.fsPath + '#4"'
                     );
                 });
                 it("Can open multiple resources", async () => {
@@ -1399,14 +1397,13 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.getCall(-1)).to.be.vscodeDiffCall(
                         perforceLocalUriMatcher(file1),
                         file1.localFile,
-                        path.basename(file1.localFile.path) +
-                            " - Diff Workspace (right) Against Most Recent Revision (left)"
+                        "a.txt#4 vs a.txt"
                     );
                     expect(items.execute).to.be.calledWithMatch(
                         file1.localFile,
                         "print",
                         sinon.match.any,
-                        '-q "' + file1.localFile.fsPath + '#1"'
+                        '-q "' + file1.localFile.fsPath + '#4"'
                     );
                     expect(td.lastCall.args[0]).to.be.p4Uri(
                         perforceLocalUriMatcher(file2)
@@ -1439,8 +1436,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         vscode.Uri.parse("perforce:EMPTY"),
                         file.localFile,
-                        path.basename(file.localFile.path) +
-                            " - Diff Workspace (right) Against Most Recent Revision (left)"
+                        "new.txt#0 vs new.txt (workspace)"
                     );
                 });
                 it("Diffs a moved file against the original file", async () => {
@@ -1455,8 +1451,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         perforceFromFileUriMatcher(file),
                         file.localFile,
-                        path.basename(file.localFile.path) +
-                            " - Diff Workspace (right) Against Most Recent Revision (left)"
+                        "movedFrom.txt#4 vs moved.txt (workspace)"
                     );
                     expect(items.execute).to.be.calledWithMatch(
                         sinon.match({ fsPath: workspaceUri.fsPath }),
@@ -1492,8 +1487,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         vscode.Uri.parse("perforce:EMPTY"),
                         file.localFile,
-                        path.basename(file.localFile.path) +
-                            " - Diff Workspace (right) Against Most Recent Revision (left)"
+                        "branched.txt#0 vs branched.txt (workspace)"
                     );
                 });
                 it("Diffs an integration/merge against the target depot file", async () => {
@@ -1508,8 +1502,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         perforceLocalUriMatcher(file),
                         file.localFile,
-                        path.basename(file.localFile.path) +
-                            " - Diff Workspace (right) Against Most Recent Revision (left)"
+                        "integrated.txt#7 vs integrated.txt (workspace)"
                     );
 
                     expect(items.execute).to.be.calledWithMatch(
@@ -1531,8 +1524,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         perforceDepotUriMatcher(file),
                         perforceShelvedUriMatcher(file, "1"),
-                        path.basename(file.localFile.path) +
-                            " - Diff Shelve (right) Against Depot Version (left)"
+                        "a.txt#1 vs a.txt@=1"
                     );
                     expect(items.execute).to.be.calledWithMatch(
                         { fsPath: workspaceUri.fsPath },
@@ -1559,8 +1551,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         perforceShelvedUriMatcher(file, "1"),
                         file.localFile,
-                        path.basename(file.localFile.path) +
-                            " - Diff Workspace (right) Against Shelved Version (left)"
+                        "a.txt@=1 vs a.txt (workspace)"
                     );
                     expect(items.execute).to.be.calledWithMatch(
                         { fsPath: workspaceUri.fsPath },
@@ -1581,8 +1572,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         perforceLocalShelvedUriMatcher(file, "1"),
                         file.localFile,
-                        path.basename(file.localFile.path) +
-                            " - Diff Workspace (right) Against Shelved Version (left)"
+                        "a.txt@=1 vs a.txt (workspace)"
                     );
                     expect(items.execute).to.be.calledWithMatch(
                         file.localFile,

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -911,6 +911,29 @@ describe("Model & ScmProvider modules (integration)", () => {
             sinon.restore();
         });
 
+        describe("Provide original resource", () => {
+            it("Diffs against the have revision", async () => {
+                const out = await items.instance.provideOriginalResource(
+                    basicFiles.add.localFile
+                );
+
+                expect(out).to.deep.equal(
+                    basicFiles.add.localFile.with({
+                        scheme: "perforce",
+                        fragment: "have",
+                        query: "p4args=-q&command=print"
+                    })
+                );
+            });
+            it("Does not diff non-file resources", async () => {
+                const inUri = Utils.makePerforceDocUri(
+                    basicFiles.edit.localFile,
+                    "print"
+                );
+                const out = await items.instance.provideOriginalResource(inUri);
+                expect(out).to.be.undefined;
+            });
+        });
         describe("Shelving a changelist", () => {
             it("Cannot shelve the default changelist", async () => {
                 await expect(


### PR DESCRIPTION
- The gutter decorations for diffing have been corrected when a revision other than the latest is open for edit
- Diffing from the scm view is against the working revision instead of the latest revision. For moved files, it is against the working revision of the moved-from file
- The diff titles are updated to much more concise versions

Also prevents spurious output during test runs (at least some of it, if not all), by stubbing the refresh function


Fixes #6 
Fixes #26 