### PR TITLE
Start improving setup experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
                 },
                 "perforce.activationMode": {
                     "type": "string",
-                    "description": "Controls when to activate the extension",
+                    "description": "Controls when to activate the extension. Requires a restart to take effect",
                     "enum": [
                         "always",
                         "autodetect",

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -14,12 +14,14 @@ export namespace Display {
 
     export const updateEditor = debounce(updateEditorImpl, 1000);
 
-    export function initialize() {
+    export function initialize(subscriptions: { dispose(): any }[]) {
         _statusBarItem = window.createStatusBarItem(
             StatusBarAlignment.Left,
             Number.MIN_VALUE
         );
         _statusBarItem.command = "perforce.menuFunctions";
+        subscriptions.push(_statusBarItem);
+        subscriptions.push(channel);
 
         updateEditor();
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -174,7 +174,10 @@ function TryCreateP4(uri: vscode.Uri): Promise<boolean> {
                         return CreateP4(config);
                     }
 
-                    Display.channel.appendLine(uri + ": Not initialising.");
+                    Display.channel.appendLine(
+                        uri +
+                            ": Not initialising.\n\nConsider setting/checking perforce.port, perforce.user, perforce.client in the extension settings"
+                    );
 
                     return false;
                 };


### PR DESCRIPTION
The log output is always initialised as long as activation mode is not set to 'off' - and additional logging is provided to describe what's happening. This might help people understand what's happening. Or at least, provides useful output for when an issue is raised.

It doesn't change any initialisation behaviour so any existing issues with the setup will still be present

The extension watches for changes to the config that might require a restart and warns the user that a restart is required. (TODO - make some of these settings actually not require a restart)

fixes #7 