### PR TITLE
Edit on file mod / save - don't open already open files

### DIFF
--- a/src/Debounce.ts
+++ b/src/Debounce.ts
@@ -104,12 +104,15 @@ export type DebouncedFunction<P extends any[], T> = {
  */
 export function debounce<P extends any[], T>(
     func: (...rest: P) => T,
-    time: number
+    time: number,
+    onCall?: (...args: P) => void
 ): DebouncedFunction<P, T> {
     let lastDebounced: DebouncedCall<P, T> | undefined;
 
     const ret = (...args: P): Promise<T> => {
         const now = Date.now();
+
+        onCall?.(...args);
 
         if (!lastDebounced || !lastDebounced.canExecute) {
             lastDebounced = new DebouncedCall(func, now, time);
@@ -121,6 +124,8 @@ export function debounce<P extends any[], T>(
 
     ret.withoutLeadingCall = (...args: P): Promise<T> => {
         const now = Date.now();
+
+        onCall?.(...args);
 
         if (!lastDebounced || !lastDebounced.canExecute) {
             lastDebounced = new DebouncedCall(func, now, time);

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -15,15 +15,19 @@ export namespace Display {
     export const updateEditor = debounce(updateEditorImpl, 1000);
 
     export function initialize(subscriptions: { dispose(): any }[]) {
+        initializeChannel(subscriptions);
         _statusBarItem = window.createStatusBarItem(
             StatusBarAlignment.Left,
             Number.MIN_VALUE
         );
         _statusBarItem.command = "perforce.menuFunctions";
         subscriptions.push(_statusBarItem);
-        subscriptions.push(channel);
 
         updateEditor();
+    }
+
+    export function initializeChannel(subscriptions: { dispose(): any }[]) {
+        subscriptions.push(channel);
     }
 
     function updateEditorImpl() {
@@ -74,7 +78,7 @@ export namespace Display {
 
     export function showMessage(message: string) {
         window.setStatusBarMessage("Perforce: " + message, 3000);
-        channel.append(message);
+        channel.append(message + "\n");
     }
 
     export function showModalMessage(message: string) {

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -33,7 +33,12 @@ export namespace Display {
     const _onActiveFileStatusKnown = new EventEmitter<ActiveStatusEvent>();
     export const onActiveFileStatusKnown = _onActiveFileStatusKnown.event;
 
-    export const updateEditor = debounce(updateEditorImpl, 1000);
+    export const updateEditor = debounce(updateEditorImpl, 1000, () => {
+        if (_statusBarItem) {
+            _statusBarItem.text = "P4: $(sync)";
+            _statusBarItem.tooltip = "Checking file status";
+        }
+    });
 
     export function initialize(subscriptions: { dispose(): any }[]) {
         initializeChannel(subscriptions);

--- a/src/FileSystemListener.ts
+++ b/src/FileSystemListener.ts
@@ -143,7 +143,10 @@ export default class FileSystemListener {
     // in future releases.
     // https://github.com/stef-levesque/vscode-perforce/issues/110
     private static tryEditFile(uri: Uri): Promise<boolean> {
-        if (PerforceSCMProvider.hasOpenFile(uri)) {
+        if (
+            PerforceSCMProvider.hasOpenFile(uri) &&
+            !PerforceSCMProvider.mayHaveConflictForFile(uri)
+        ) {
             return Promise.resolve(true);
         } else {
             return PerforceCommands.edit(uri);

--- a/src/FileSystemListener.ts
+++ b/src/FileSystemListener.ts
@@ -18,7 +18,7 @@ const parseignore = require("parse-gitignore"); // (this module should be remove
 
 import { Display } from "./Display";
 import { PerforceCommands } from "./PerforceCommands";
-import { PerforceService } from "./PerforceService";
+import { PerforceSCMProvider } from "./ScmProvider";
 
 export default class FileSystemListener {
     private static _eventRegistered: boolean = false;
@@ -111,6 +111,10 @@ export default class FileSystemListener {
     private static onFileModified(docChange: TextDocumentChangeEvent) {
         const docUri = docChange.document.uri;
 
+        if (docUri.scheme !== "file") {
+            return;
+        }
+
         //If this doc has already been checked, just returned
         if (
             FileSystemListener._lastCheckedFileUri &&
@@ -139,7 +143,12 @@ export default class FileSystemListener {
     // in future releases.
     // https://github.com/stef-levesque/vscode-perforce/issues/110
     private static tryEditFile(uri: Uri): Promise<boolean> {
-        return PerforceCommands.edit(uri);
+        if (PerforceSCMProvider.hasOpenFile(uri)) {
+            return Promise.resolve(true);
+        } else {
+            return PerforceCommands.edit(uri);
+        }
+
         // return new Promise((resolve) => {
         //     //Check if this file is in client root first
         //     FileSystemListener.fileInClientRoot(uri).then((inClientRoot) => {
@@ -185,40 +194,5 @@ export default class FileSystemListener {
         if (editor && editor.document && editor.document.uri.fsPath === uri.fsPath) {
             PerforceCommands.add(uri);
         }
-    }
-
-    private static fileInClientRoot(uri: Uri): Promise<boolean> {
-        const docPath = uri.fsPath;
-        return new Promise((resolve, reject) => {
-            PerforceService.getClientRoot(uri)
-                .then(clientRoot => {
-                    //Convert to lower and Strip newlines from paths
-                    clientRoot = clientRoot.toLowerCase().replace(/(\r\n|\n|\r)/gm, "");
-                    const filePath = docPath.toLowerCase().replace(/(\r\n|\n|\r)/gm, "");
-
-                    //Check if p4 Client Root is in uri's path
-                    if (filePath.includes(clientRoot)) {
-                        resolve(true);
-                    } else {
-                        resolve(false);
-                    }
-                })
-                .catch(err => {
-                    reject(err);
-                });
-        });
-    }
-
-    private static fileIsOpened(fileUri: Uri): Promise<boolean> {
-        return new Promise(resolve => {
-            //opened stdout is set if file open, stderr set if not opened
-            PerforceService.executeAsPromise(fileUri, "opened", fileUri.fsPath)
-                .then(() => {
-                    resolve(true);
-                })
-                .catch(() => {
-                    resolve(false);
-                });
-        });
     }
 }

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -162,7 +162,7 @@ export namespace PerforceCommands {
             "revert",
             (err, stdout, stderr) => {
                 PerforceService.handleCommonServiceResponse(err, stdout, stderr);
-                if (!err) {
+                if (!err && !stderr) {
                     Display.showMessage("file reverted");
                 }
             },

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -99,7 +99,7 @@ export namespace PerforceCommands {
                 "edit",
                 (err, stdout, stderr) => {
                     PerforceService.handleCommonServiceResponse(err, stdout, stderr);
-                    if (!err) {
+                    if (!err && !stderr) {
                         Display.showMessage("file opened for edit");
                     }
                     resolve(!err);
@@ -608,7 +608,7 @@ export namespace PerforceCommands {
 
     export function checkFolderOpened() {
         if (workspace.workspaceFolders === undefined) {
-            Display.showMessage("No folder selected\n");
+            Display.showMessage("No folder selected");
             return false;
         }
 

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -253,7 +253,7 @@ export namespace PerforceService {
         stdout: string,
         stderr: string
     ) {
-        if (err) {
+        if (err || stderr) {
             Display.showError(stderr.toString());
         } else {
             Display.channel.append(stdout.toString());

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -498,6 +498,10 @@ export class PerforceSCMProvider {
         return Utils.makePerforceDocUri(uri, "print", "-q").with({ fragment: "have" });
     }
 
+    public static hasOpenFile(uri: Uri) {
+        return this.instances.some(inst => inst._model.getOpenResource(uri));
+    }
+
     /**
      * This is the default action when an resource is clicked in the viewlet.
      * For ADD, AND UNDELETE just show the local file.

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -49,10 +49,6 @@ export class PerforceSCMProvider {
         return mapEvent(this._model.onDidChange, () => this);
     }
 
-    get onRefreshStarted(): Event<this> {
-        return mapEvent(this._model.onRefreshStarted, () => this);
-    }
-
     public get resources(): ResourceGroup[] {
         return this._model.ResourceGroups;
     }
@@ -500,6 +496,10 @@ export class PerforceSCMProvider {
 
     public static hasOpenFile(uri: Uri) {
         return this.instances.some(inst => inst._model.getOpenResource(uri));
+    }
+
+    public static mayHaveConflictForFile(uri: Uri) {
+        return this.instances.some(inst => inst._model.mayHaveConflictForFile(uri));
     }
 
     /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -226,7 +226,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
         return;
     }
 
-    Display.initialize(ctx.subscriptions);
+    Display.initializeChannel(_disposable);
 
     ctx.subscriptions.push(
         new vscode.Disposable(() => Disposable.from(..._disposable).dispose())
@@ -256,6 +256,8 @@ function doOneTimeRegistration() {
         Display.channel.appendLine(
             "Performing one-time registration of perforce commands"
         );
+
+        Display.initialize(_disposable);
 
         _disposable.push(new PerforceContentProvider());
 

--- a/src/test/suite/unit/Debounce.test.ts
+++ b/src/test/suite/unit/Debounce.test.ts
@@ -131,4 +131,36 @@ describe("Debounce", () => {
         debounced.dispose();
         await expect(p2).to.eventually.be.rejectedWith("Debounced function cancelled");
     });
+    it("Calls the onCall event immediately for every normal call", async () => {
+        const spy = sinon.spy();
+        const db2 = debounce(callee, 10, spy);
+
+        db2("1");
+        db2("2");
+        const prom = db2("3");
+
+        expect(spy).to.have.been.calledWith("1");
+        expect(spy).to.have.been.calledWith("2");
+        expect(spy).to.have.been.calledWith("3");
+        await prom;
+        expect(callee).to.have.been.calledWith("1");
+        expect(callee).not.to.have.been.calledWith("2");
+        expect(callee).to.have.been.calledWith("3");
+    });
+    it("Calls the onCall event immediately for without-leading call", async () => {
+        const spy = sinon.spy();
+        const db2 = debounce(callee, 10, spy);
+
+        db2.withoutLeadingCall("1");
+        db2.withoutLeadingCall("2");
+        const prom = db2.withoutLeadingCall("3");
+
+        expect(spy).to.have.been.calledWith("1");
+        expect(spy).to.have.been.calledWith("2");
+        expect(spy).to.have.been.calledWith("3");
+        await prom;
+        expect(callee).not.to.have.been.calledWith("1");
+        expect(callee).not.to.have.been.calledWith("2");
+        expect(callee).to.have.been.calledWith("3");
+    });
 });


### PR DESCRIPTION
Originally, when edit on file modify / save was enabled, the extension contained some code to run commands and check perforce before opening the file for edit. This was removed due to https://github.com/stef-levesque/vscode-perforce/issues/110 - however, we do have the information about what's open and can avoid opening the file if we already have it open.

Potentially this means we may not open a file for edit if it has been submitted externally and the user tries to modify it again. This can be resolved with a manual refresh (or really any other operation that results in a refresh) or by just manually using the "edit" command from the p4 command menu.

This seems like an acceptable trade-off.

Could consider refreshing the scm provider automatically if a conflict is detected when the "opened" command is run on switching editor - e.g. the opened command says the file is not open, but the scm provider says it is, but need to make sure this doesn't continually refresh if there is a good reason for that conflict

* Previously, with auto save it could p4 edit after every change, resulting in a refresh for every change
* Checks the scm provider to see if the file is already open before trying to open again
* Also checks that scheme is 'file' first (prevents trying to open the log output or a diff, and against trying to edit again because of switching to a diff and back)
* fix bug where status bar item was always inited
* don't show "opened for edit" when stderr was returned

fixes #39