### PR TITLE
Correctly reject promises in content provider

### DIFF
--- a/src/ContentProvider.ts
+++ b/src/ContentProvider.ts
@@ -66,6 +66,11 @@ export class PerforceContentProvider {
             );
             throw new Error(`Can't find proper workspace for command ${command} `);
         }
-        return Utils.runCommand(resource, command, { file, revision, prefixArgs: args });
+        return Utils.runCommand(resource, command, {
+            file,
+            revision,
+            prefixArgs: args,
+            hideStdErr: true
+        });
     }
 }

--- a/src/ContentProvider.ts
+++ b/src/ContentProvider.ts
@@ -1,5 +1,5 @@
 import { window, workspace, Uri, Disposable, Event, EventEmitter } from "vscode";
-import { Utils } from "./Utils";
+import { Utils, UriArguments } from "./Utils";
 import { Display } from "./Display";
 
 export class PerforceContentProvider {
@@ -19,72 +19,53 @@ export class PerforceContentProvider {
         );
     }
 
-    public provideTextDocumentContent(uri: Uri): Promise<string> {
-        return new Promise<string>(resolve => {
-            if (uri.path === "EMPTY") {
-                resolve("");
-                return;
-            }
+    private getResourceAndFileForUri(
+        uri: Uri,
+        allArgs: UriArguments
+    ): [Uri | undefined, string | Uri | undefined] {
+        if (allArgs["depot"]) {
+            // depot-based uri should always have a path
+            const resource =
+                allArgs["workspace"] && typeof (allArgs["workspace"] === "string")
+                    ? Uri.file(allArgs["workspace"] as string)
+                    : workspace.workspaceFolders?.[0].uri;
+            const file = Utils.getDepotPathFromDepotUri(uri);
+            return [resource, file];
+        }
+        if (uri.fsPath) {
+            // a file is supplied
+            const resource = Uri.file(uri.fsPath);
+            return [resource, resource];
+        }
+        // just for printing the output of a command that doesn't relate to a specific file
+        if (window.activeTextEditor && !window.activeTextEditor.document.isUntitled) {
+            return [window.activeTextEditor.document.uri, undefined];
+        }
+        return [workspace.workspaceFolders?.[0].uri, undefined];
+    }
 
-            let revision: string = uri.fragment;
-            if (revision && !revision.startsWith("@")) {
-                revision = "#" + uri.fragment;
-            }
-
-            const allArgs = Utils.decodeUriQuery(uri.query ?? "");
-
-            const args = (allArgs["p4args"] as string) ?? "-q";
-            const command = (allArgs["command"] as string) ?? "print";
-
-            if (allArgs["depot"]) {
-                const resource =
-                    allArgs["workspace"] && typeof (allArgs["workspace"] === "string")
-                        ? Uri.file(allArgs["workspace"] as string)
-                        : workspace.workspaceFolders?.[0].uri;
-                if (!resource) {
-                    throw new Error("A resource is required");
-                }
-                Utils.runCommand(
-                    resource,
-                    command,
-                    Utils.getDepotPathFromDepotUri(uri),
-                    revision,
-                    args
-                ).then(resolve);
-                return;
-            }
-
-            const file = uri.fsPath ? Uri.file(uri.fsPath) : null;
-
-            if (!file) {
-                // Try to guess the proper workspace to use
-                if (
-                    window.activeTextEditor &&
-                    !window.activeTextEditor.document.isUntitled
-                ) {
-                    Utils.runCommand(
-                        window.activeTextEditor.document.uri,
-                        command,
-                        null,
-                        revision,
-                        args
-                    ).then(resolve);
-                } else if (workspace.workspaceFolders) {
-                    const resource = workspace.workspaceFolders[0].uri;
-                    Utils.runCommand(resource, command, null, revision, args).then(
-                        resolve
-                    );
-                } else {
-                    throw new Error(
-                        `Can't find proper workspace for command ${command} `
-                    );
-                }
-            } else {
-                Utils.runCommandForFile(command, file, revision, args).then(resolve);
-            }
-        }).catch(reason => {
-            Display.showError(reason.toString());
+    public async provideTextDocumentContent(uri: Uri): Promise<string> {
+        if (uri.path === "EMPTY") {
             return "";
-        });
+        }
+
+        let revision: string = uri.fragment;
+        if (revision && !revision.startsWith("@")) {
+            revision = "#" + uri.fragment;
+        }
+
+        const allArgs = Utils.decodeUriQuery(uri.query ?? "");
+        const args = (allArgs["p4args"] as string) ?? "-q";
+        const command = (allArgs["command"] as string) ?? "print";
+
+        const [resource, file] = this.getResourceAndFileForUri(uri, allArgs);
+
+        if (!resource) {
+            Display.channel.appendLine(
+                `Can't find proper workspace to provide content for ${uri}`
+            );
+            throw new Error(`Can't find proper workspace for command ${command} `);
+        }
+        return Utils.runCommand(resource, command, { file, revision, prefixArgs: args });
     }
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -9,7 +9,7 @@ export function mapEvent<I, O>(event: Event<I>, map: (i: I) => O): Event<O> {
         event(i => listener.call(thisArgs, map(i)), null, disposables);
 }
 
-type UriArguments = {
+export type UriArguments = {
     [key: string]: string | boolean;
 };
 
@@ -165,20 +165,25 @@ export namespace Utils {
         });
     }
 
+    export interface CommandParams {
+        file?: Uri | string;
+        revision?: string;
+        prefixArgs?: string;
+        gOpts?: string;
+        input?: string;
+    }
+
     // Get a string containing the output of the command
     export function runCommand(
         resource: Uri,
         command: string,
-        file?: Uri | string | null | undefined,
-        revision?: string | null, // must include the # or @
-        prefixArgs?: string,
-        gOpts?: string | null,
-        input?: string
+        params: CommandParams
     ): Promise<string> {
         return new Promise((resolve, reject) => {
-            let args = prefixArgs ? prefixArgs : "";
+            const { file, revision, prefixArgs, gOpts, input } = params;
+            let args = prefixArgs ?? "";
 
-            if (gOpts !== null && gOpts !== undefined) {
+            if (gOpts !== undefined) {
                 command = gOpts + " " + command;
             }
 
@@ -222,6 +227,12 @@ export namespace Utils {
         input?: string
     ): Promise<string> {
         const resource = file;
-        return runCommand(resource, command, file, revision, prefixArgs, gOpts, input);
+        return runCommand(resource, command, {
+            file,
+            revision,
+            prefixArgs,
+            gOpts,
+            input
+        });
     }
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -171,6 +171,7 @@ export namespace Utils {
         prefixArgs?: string;
         gOpts?: string;
         input?: string;
+        hideStdErr?: boolean; // just from the status bar - not from the log output
     }
 
     // Get a string containing the output of the command
@@ -180,7 +181,7 @@ export namespace Utils {
         params: CommandParams
     ): Promise<string> {
         return new Promise((resolve, reject) => {
-            const { file, revision, prefixArgs, gOpts, input } = params;
+            const { file, revision, prefixArgs, gOpts, input, hideStdErr } = params;
             let args = prefixArgs ?? "";
 
             if (gOpts !== undefined) {
@@ -201,7 +202,11 @@ export namespace Utils {
                 command,
                 (err, stdout, stderr) => {
                     err && Display.showError(err.toString());
-                    stderr && Display.showError(stderr.toString());
+                    if (stderr) {
+                        hideStdErr
+                            ? Display.channel.appendLine(stderr.toString())
+                            : Display.showError(stderr.toString());
+                    }
                     if (err) {
                         reject(err);
                     } else if (stderr) {

--- a/src/test/suite/StubPerforceService.ts
+++ b/src/test/suite/StubPerforceService.ts
@@ -21,6 +21,7 @@ type PerforceCommand =
     | "unshelve"
     | "revert"
     | "fstat"
+    | "have"
     | "print";
 type PerforceResponseCallback = (
     err: Error | null,
@@ -408,7 +409,8 @@ export const makeResponses = (
                   return [stdout.join("\n\n"), sterr.join("\n\n")];
               },
               print: returnStdOut("print not implemented"),
-              fix: returnStdOut("fix not implemented")
+              fix: returnStdOut("fix not implemented"),
+              have: returnStdOut("have not implemented")
           };
     if (responses) {
         Object.keys(responses).forEach(key => {

--- a/test-fixtures/core/.vscode/settings.json
+++ b/test-fixtures/core/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
     "perforce.client": "",
     "perforce.user": "",
-    "perforce.bottleneck.maxConcurrent": 1000
+    "perforce.bottleneck.maxConcurrent": 1000,
+    "perforce.hideNonWorkspaceFiles": false,
+    "perforce.hideShelvedFiles": false,
+    "perforce.activationMode": "autodetect"
 }


### PR DESCRIPTION
This prevents 'stuck' content providers that never resolve because perforce has no 'have' revision. This caused issues such as:

* gutter decorations would not update after submitting a new file, because it was still trying to resolve the original gutter decorations
* diffs wold sit spinning forever if there was a reason the diff was impossible, instead of showing an error message

However, the implication of fixing this is that when `provideOriginalResource` rejects (or returns undefined) - it keeps trying to get the original resource every time you change the file, which results in spamming the print command. As a result, implemented a `p4 have` check for each file before returning a resource uri. The result of the have check is cached until the next refresh, so we don't keep spamming the have command.

fixes #42 