### PR TITLE
Fix failure to load files when there are no changelists

### DIFF
--- a/src/api/PerforceApi.ts
+++ b/src/api/PerforceApi.ts
@@ -420,7 +420,13 @@ function parseShelvedDescribeOuput(output: string): ShelvedChangeInfo[] {
         .filter(c => c.paths.length > 0);
 }
 
-export async function getShelvedFiles(resource: vscode.Uri, options: GetShelvedOptions) {
+export async function getShelvedFiles(
+    resource: vscode.Uri,
+    options: GetShelvedOptions
+): Promise<ShelvedChangeInfo[]> {
+    if (options.chnums.length === 0) {
+        return [];
+    }
     const output = await describe(resource, {
         chnums: options.chnums,
         omitDiffs: true,

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -962,7 +962,7 @@ export class Model implements Disposable {
     }
 
     private async getAllShelvedResources(changes: ChangeInfo[]): Promise<Resource[]> {
-        if (this._workspaceConfig.hideShelvedFiles) {
+        if (this._workspaceConfig.hideShelvedFiles || changes.length === 0) {
             return [];
         }
         const allFileInfo = await p4.getShelvedFiles(this._workspaceUri, {

--- a/src/test/suite/perforceApi.test.ts
+++ b/src/test/suite/perforceApi.test.ts
@@ -58,7 +58,9 @@ describe("Perforce API", () => {
         execute = sinon.stub(PerforceService, "execute").callsFake(basicExecuteStub);
     });
     afterEach(() => {
-        expect(execute).to.always.have.been.calledWith(ws);
+        if (execute.getCalls().length > 0) {
+            expect(execute).to.always.have.been.calledWith(ws);
+        }
         sinon.restore();
     });
     describe("Flag mapper", () => {
@@ -508,6 +510,10 @@ describe("Perforce API", () => {
         });
     });
     describe("getShelvedFiles", () => {
+        it("Returns an empty list when no changelists are specified", async () => {
+            await expect(p4.getShelvedFiles(ws, { chnums: [] })).to.eventually.eql([]);
+            expect(execute).not.to.have.been.called;
+        });
         it("Returns the list of shelved files", async () => {
             execute.callsFake(
                 execWithStdOut(


### PR DESCRIPTION
When there are no changelists, it was attempting to run describe without any arguments