### PR TITLE
Add command to submit selected files from the default changelist

### DIFF
--- a/package.json
+++ b/package.json
@@ -306,12 +306,12 @@
             {
                 "command": "perforce.submitSelectedFiles",
                 "title": "Submit selected files...",
-                "category": "perforce"
+                "category": "Perforce"
             },
             {
                 "command": "perforce.submitSingle",
                 "title": "Submit the currently open file...",
-                "category": "perforce"
+                "category": "Perforce"
             },
             {
                 "command": "perforce.openResource",

--- a/package.json
+++ b/package.json
@@ -309,6 +309,11 @@
                 "category": "perforce"
             },
             {
+                "command": "perforce.submitSingle",
+                "title": "Submit the currently open file...",
+                "category": "perforce"
+            },
+            {
                 "command": "perforce.openResource",
                 "title": "Open changes",
                 "category": "Perforce"

--- a/package.json
+++ b/package.json
@@ -304,6 +304,11 @@
                 }
             },
             {
+                "command": "perforce.submitSelectedFiles",
+                "title": "Submit selected files...",
+                "category": "perforce"
+            },
+            {
                 "command": "perforce.openResource",
                 "title": "Open changes",
                 "category": "Perforce"
@@ -431,6 +436,10 @@
             "commandPalette": [
                 {
                     "command": "perforce.submitChangelist",
+                    "when": "0"
+                },
+                {
+                    "command": "perforce.submitSelectedFiles",
                     "when": "0"
                 },
                 {
@@ -675,6 +684,11 @@
                     "command": "perforce.reopenFile",
                     "when": "scmProvider == perforce",
                     "group": "1_modification@3"
+                },
+                {
+                    "command": "perforce.submitSelectedFiles",
+                    "when": "scmProvider == perforce && scmResourceGroup == default",
+                    "group": "1_modification@4"
                 },
                 {
                     "command": "perforce.shelveunshelve",

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -19,6 +19,7 @@ import { PerforceService } from "./PerforceService";
 import * as p4 from "./api/PerforceApi";
 import { Display } from "./Display";
 import { Utils } from "./Utils";
+import { PerforceSCMProvider } from "./ScmProvider";
 
 // TODO resolve
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -28,6 +29,7 @@ export namespace PerforceCommands {
         commands.registerCommand("perforce.edit", editOpenFile);
         commands.registerCommand("perforce.delete", deleteOpenFile);
         commands.registerCommand("perforce.revert", revert);
+        commands.registerCommand("perforce.submitSingle", submitSingle);
         commands.registerCommand("perforce.diff", diff);
         commands.registerCommand("perforce.diffRevision", diffRevision);
         commands.registerCommand("perforce.annotate", annotate);
@@ -169,6 +171,38 @@ export namespace PerforceCommands {
             args,
             directoryOverride
         );
+    }
+
+    async function submitSingle() {
+        const file = window.activeTextEditor?.document.uri;
+        if (!file || file.scheme !== "file") {
+            Display.showError("No open file to submit");
+            return;
+        }
+
+        if (window.activeTextEditor?.document.isDirty) {
+            Display.showModalMessage(
+                "The active document has unsaved changes. Save the file first!"
+            );
+        }
+        const description = await window.showInputBox({
+            prompt:
+                "Enter a changelist description to submit '" +
+                Path.basename(file.fsPath) +
+                "'",
+            validateInput: input => {
+                if (!input.trim()) {
+                    return "Description must not be empty";
+                }
+            }
+        });
+        if (!description) {
+            return;
+        }
+
+        const output = await p4.submitChangelist(file, { description, file });
+        PerforceSCMProvider.RefreshAll();
+        Display.showMessage("Changelist " + output.chnum + " submitted");
     }
 
     export async function diff(revision?: number) {
@@ -510,6 +544,10 @@ export namespace PerforceCommands {
             description: "Discard changes from an opened file"
         });
         items.push({
+            label: "submit single file",
+            description: "Submit the open file, ONLY if it is in the default changelist"
+        });
+        items.push({
             label: "diff",
             description: "Display diff of client file with depot file"
         });
@@ -547,6 +585,9 @@ export namespace PerforceCommands {
                         break;
                     case "revert":
                         revert();
+                        break;
+                    case "submit single file":
+                        submitSingle();
                         break;
                     case "diff":
                         diff();

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -173,7 +173,7 @@ export namespace PerforceCommands {
         );
     }
 
-    async function submitSingle() {
+    export async function submitSingle() {
         const file = window.activeTextEditor?.document.uri;
         if (!file || file.scheme !== "file") {
             Display.showError("No open file to submit");
@@ -184,6 +184,7 @@ export namespace PerforceCommands {
             Display.showModalMessage(
                 "The active document has unsaved changes. Save the file first!"
             );
+            return;
         }
         const description = await window.showInputBox({
             prompt:

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -167,6 +167,10 @@ export class PerforceSCMProvider {
             PerforceSCMProvider.Submit.bind(this)
         );
         commands.registerCommand(
+            "perforce.submitSelectedFiles",
+            PerforceSCMProvider.SubmitSelectedFiles.bind(this)
+        );
+        commands.registerCommand(
             "perforce.revertChangelist",
             PerforceSCMProvider.Revert.bind(this)
         );
@@ -336,6 +340,13 @@ export class PerforceSCMProvider {
         if (model) {
             await model.Submit(input);
         }
+    }
+
+    public static async SubmitSelectedFiles(
+        ...resourceStates: SourceControlResourceState[]
+    ) {
+        const resources = resourceStates.filter(s => s instanceof Resource) as Resource[];
+        await resources[0].model.SubmitSelectedFile(resources);
     }
 
     public static async Revert(

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -103,7 +103,13 @@ export namespace Utils {
         prefixArgs?: string[];
         gOpts?: string;
         input?: string;
-        hideStdErr?: boolean; // just from the status bar - not from the log output
+        /**
+         * hides std-err from the status bar (not from the log output)
+         */
+        hideStdErr?: boolean;
+        /**
+         * When set to true, will not reject if stderr is present
+         */
         stdErrIsOk?: boolean;
     }
 

--- a/src/api/PerforceApi.ts
+++ b/src/api/PerforceApi.ts
@@ -234,19 +234,35 @@ const openedFlags = flagMapper<OpenedFileOptions>([["c", "chnum"]]);
 const opened = makeSimpleCommand(
     "opened",
     openedFlags,
-    fixedParams({ stdErrIsOk: true }) // stderr when no files are opened
+    fixedParams({ stdErrIsOk: true, hideStdErr: true }) // stderr when no files are opened
 );
 
 export const getOpenedFiles = asyncOuputHandler(opened, parseOpenedOutput);
 
-export type SubmitChangelistOptions = { chnum?: string; description?: string };
+export type SubmitChangelistOptions = {
+    chnum?: string;
+    description?: string;
+};
 
 const submitFlags = flagMapper<SubmitChangelistOptions>([
     ["c", "chnum"],
     ["d", "description"]
 ]);
 
-export const submitChangelist = makeSimpleCommand("submit", submitFlags);
+const submitChangelistCommand = makeSimpleCommand("submit", submitFlags);
+
+function parseSubmitOutput(output: string) {
+    const matches = /Change (\d+) submitted/.exec(output);
+    return {
+        rawOutput: output,
+        chnum: matches?.[1]
+    };
+}
+
+export const submitChangelist = asyncOuputHandler(
+    submitChangelistCommand,
+    parseSubmitOutput
+);
 
 export interface RevertOptions {
     paths: PerforceFile[];

--- a/src/api/PerforceApi.ts
+++ b/src/api/PerforceApi.ts
@@ -242,12 +242,16 @@ export const getOpenedFiles = asyncOuputHandler(opened, parseOpenedOutput);
 export type SubmitChangelistOptions = {
     chnum?: string;
     description?: string;
+    file?: PerforceFile;
 };
 
-const submitFlags = flagMapper<SubmitChangelistOptions>([
-    ["c", "chnum"],
-    ["d", "description"]
-]);
+const submitFlags = flagMapper<SubmitChangelistOptions>(
+    [
+        ["c", "chnum"],
+        ["d", "description"]
+    ],
+    "file"
+);
 
 const submitChangelistCommand = makeSimpleCommand("submit", submitFlags);
 

--- a/src/test/helpers/StubPerforceModel.ts
+++ b/src/test/helpers/StubPerforceModel.ts
@@ -116,7 +116,10 @@ export class StubPerforceModel {
         this.reopenFiles = sinon.stub(p4, "reopenFiles").resolves("reopened");
         this.revert = sinon.stub(p4, "revert").resolves("reverted");
         this.shelve = sinon.stub(p4, "shelve").resolves("shelved");
-        this.submitChangelist = sinon.stub(p4, "submitChangelist").resolves("submitted");
+        this.submitChangelist = sinon.stub(p4, "submitChangelist").resolves({
+            rawOutput: "submitting...\n change 250 submitted",
+            chnum: "250"
+        });
         this.sync = sinon.stub(p4, "sync").resolves("synced");
         this.unshelve = sinon.stub(p4, "unshelve").resolves("unshelved");
         this.inputChangeSpec = sinon

--- a/src/test/suite/perforceApi.test.ts
+++ b/src/test/suite/perforceApi.test.ts
@@ -392,10 +392,27 @@ describe("Perforce API", () => {
         });
     });
     describe("submit", () => {
-        it("uses the correct arguments", async () => {
+        it("Returns the new changelist number and the raw output", async () => {
+            const output =
+                "Submitting change 76." +
+                "Locking 1 files ..." +
+                "edit //depot/testArea/a file#4" +
+                "Change 76 submitted.";
+            execute.callsFake(execWithStdOut(output));
+
             await expect(
                 p4.submitChangelist(ws, { chnum: "1", description: "my description" })
-            ).to.eventually.equal("submit -c 1 -d my description");
+            ).to.eventually.eql({
+                rawOutput: output,
+                chnum: "76"
+            });
+
+            expect(execute).to.have.been.calledWith(ws, "submit", sinon.match.any, [
+                "-c",
+                "1",
+                "-d",
+                "my description"
+            ]);
         });
     });
     describe("revert", () => {

--- a/src/test/suite/perforceApi.test.ts
+++ b/src/test/suite/perforceApi.test.ts
@@ -414,6 +414,18 @@ describe("Perforce API", () => {
                 "my description"
             ]);
         });
+        it("Can submit a single specified file", async () => {
+            await p4.submitChangelist(ws, {
+                description: "my description",
+                file: { fsPath: "C:\\MyFile.txt" }
+            });
+
+            expect(execute).to.have.been.calledWith(ws, "submit", sinon.match.any, [
+                "-d",
+                "my description",
+                "C:\\MyFile.txt"
+            ]);
+        });
     });
     describe("revert", () => {
         it("uses the correct arguments", async () => {

--- a/src/test/suite/perforceCommands.test.ts
+++ b/src/test/suite/perforceCommands.test.ts
@@ -94,7 +94,19 @@ describe("Perforce Command Module (integration)", () => {
                 "workbench.action.revertAndCloseActiveEditor"
             );
         });
-        it("Does not submit files that have a different scheme");
+        it("Does not submit files that have a different scheme", async () => {
+            const showError = sinon.stub(Display, "showError");
+
+            const localFile = getLocalFile(workspaceUri, "testFolder", "a.txt");
+            await vscode.window.showTextDocument(
+                Utils.makePerforceDocUri(localFile, "print", "-q").with({
+                    fragment: "5"
+                })
+            );
+
+            await PerforceCommands.submitSingle();
+            expect(showError).to.have.been.calledWithMatch("No open file");
+        });
         it("Requests a description", async () => {
             const input = sinon.stub(vscode.window, "showInputBox").resolves(undefined);
 

--- a/src/test/suite/perforceCommands.test.ts
+++ b/src/test/suite/perforceCommands.test.ts
@@ -6,7 +6,7 @@ import * as sinonChai from "sinon-chai";
 import * as vscode from "vscode";
 
 import * as sinon from "sinon";
-import { stubExecute } from "../helpers/StubPerforceModel";
+import { stubExecute, StubPerforceModel } from "../helpers/StubPerforceModel";
 import p4Commands from "../helpers/p4Commands";
 import { PerforceCommands } from "../../PerforceCommands";
 import { Utils } from "../../Utils";
@@ -26,6 +26,8 @@ describe("Perforce Command Module (integration)", () => {
     let execCommand: sinon.SinonSpy<[string, ...any[]], Thenable<unknown>>;
     const subscriptions: vscode.Disposable[] = [];
 
+    let stubModel: StubPerforceModel;
+
     const doc = new PerforceContentProvider();
 
     before(async () => {
@@ -38,9 +40,11 @@ describe("Perforce Command Module (integration)", () => {
     beforeEach(() => {
         Display.initialize(subscriptions);
         stubExecute();
+        stubModel = new StubPerforceModel();
         execCommand = sinon.spy(vscode.commands, "executeCommand");
     });
-    afterEach(() => {
+    afterEach(async () => {
+        await vscode.commands.executeCommand("workbench.action.files.revert");
         sinon.restore();
         subscriptions.forEach(sub => sub.dispose());
     });
@@ -68,6 +72,60 @@ describe("Perforce Command Module (integration)", () => {
                 localFile,
                 "new.txt#5 vs new.txt (workspace)"
             );
+        });
+    });
+    describe("Submit single", () => {
+        it("Does not submit if the file has dirty changes", async () => {
+            const warn = sinon.stub(Display, "showModalMessage");
+            const localFile = getLocalFile(workspaceUri, "testFolder", "a.txt");
+            const editor = await vscode.window.showTextDocument(localFile, {
+                preview: false
+            });
+            await editor.edit(editBuilder =>
+                editBuilder.insert(new vscode.Position(0, 0), "hello")
+            );
+            expect(vscode.window.activeTextEditor).to.equal(editor);
+            expect(editor.document.isDirty).to.be.true;
+
+            await PerforceCommands.submitSingle();
+            expect(warn).to.have.been.calledWithMatch("unsaved");
+            expect(stubModel.submitChangelist).not.to.have.been.called;
+            await vscode.commands.executeCommand(
+                "workbench.action.revertAndCloseActiveEditor"
+            );
+        });
+        it("Does not submit files that have a different scheme");
+        it("Requests a description", async () => {
+            const input = sinon.stub(vscode.window, "showInputBox").resolves(undefined);
+
+            const localFile = getLocalFile(workspaceUri, "testFolder", "a.txt");
+            await vscode.window.showTextDocument(localFile, {
+                preview: false
+            });
+
+            await PerforceCommands.submitSingle();
+
+            expect(input).to.have.been.called;
+            expect(stubModel.submitChangelist).not.to.have.been.called;
+        });
+        it("Submits the file with the description", async () => {
+            const input = sinon
+                .stub(vscode.window, "showInputBox")
+                .resolves("new changelist description");
+
+            const localFile = getLocalFile(workspaceUri, "testFolder", "a.txt");
+            await vscode.window.showTextDocument(localFile, {
+                preview: false
+            });
+
+            await PerforceCommands.submitSingle();
+
+            expect(input).to.have.been.called;
+            expect(stubModel.submitChangelist).to.have.been.calledWithMatch(localFile, {
+                file: { fsPath: localFile.fsPath },
+                description: "new changelist description",
+                chnum: undefined
+            });
         });
     });
 });


### PR DESCRIPTION
Adds a "Submit selected files..." context menu item for files in the default changelist only, to submit them in a new changelist

Not ready for merge yet - also want to add a command to the command palette / status bar menu to submit a single file to the default changelist

Fixes #20 