### PR TITLE
Fix issue with windows line endings

### DIFF
--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -341,7 +341,9 @@ export namespace PerforceService {
                     }
 
                     //Resolve with client root as string
-                    resolve(stdout.substring(clientRootIndex, endClientRootIndex));
+                    resolve(
+                        stdout.substring(clientRootIndex, endClientRootIndex).trimRight()
+                    );
                 })
                 .catch(err => {
                     reject(err);
@@ -368,7 +370,7 @@ export namespace PerforceService {
                     }
 
                     //Resolve with p4 config filename as string
-                    resolve(stdout.substring(configIndex, endConfigIndex));
+                    resolve(stdout.substring(configIndex, endConfigIndex).trimRight());
                 })
                 .catch(err => {
                     reject(err);


### PR DESCRIPTION
* Perforce server on windows returns \r\n line endings in p4 info
* The parsed client root incorrectly ended in \r