### PR TITLE
Handle shelved files without clientFile mapping

### DIFF
--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -1015,7 +1015,9 @@ export class Model implements Disposable {
     }
 
     private makeResourceForShelvedFile(chnum: string, fstatInfo: FstatInfo) {
-        const underlyingUri = Uri.file(fstatInfo["clientFile"]);
+        const underlyingUri = fstatInfo["clientFile"]
+            ? Uri.file(fstatInfo["clientFile"])
+            : undefined;
 
         const resource: Resource = new Resource(
             this,

--- a/src/test/helpers/StubPerforceModel.ts
+++ b/src/test/helpers/StubPerforceModel.ts
@@ -29,6 +29,7 @@ export interface StubChangelist {
 
 export interface StubFile {
     localFile: vscode.Uri;
+    suppressFstatClientFile?: boolean;
     depotPath: string;
     depotRevision: number;
     operation: Status;
@@ -212,7 +213,9 @@ export class StubPerforceModel {
         if (file) {
             return {
                 depotFile: depotPath,
-                clientFile: file.localFile.fsPath,
+                clientFile: file.suppressFstatClientFile
+                    ? undefined
+                    : file.localFile.fsPath,
                 isMapped: "true",
                 haveRev: file.depotRevision.toString(),
                 headType: file.fileType ?? "text",

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -169,6 +169,7 @@ describe("Model & ScmProvider modules (integration)", () => {
             return {
                 depotPath: "//depot/testArea/testFolder/none.txt",
                 localFile: getLocalFile(workspaceUri, "testFolder", "none.txt"),
+                suppressFstatClientFile: true,
                 depotRevision: 1,
                 operation: Status.ADD
             };


### PR DESCRIPTION
The code to find the underlying file for a shelved file assumed there is always a `clientFile` property in the fstat output, which is not the case if the shelved file is for a path that is not in the client view

fixes #50 