### PR TITLE
Delete handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -175,9 +175,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.40.0.tgz",
-            "integrity": "sha512-5kEIxL3qVRkwhlMerxO7XuMffa+0LBl+iG2TcRa0NsdoeSFLkt/9hJ02jsi/Kvc6y8OVF2N2P2IHP5S4lWf/5w==",
+            "version": "1.42.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.42.0.tgz",
+            "integrity": "sha512-ds6TceMsh77Fs0Mq0Vap6Y72JbGWB8Bay4DrnJlf5d9ui2RSe1wis13oQm+XhguOeH1HUfLGzaDAoupTUtgabw==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4636,16 +4636,6 @@
                 "safe-buffer": "^5.1.1"
             }
         },
-        "parse-gitignore": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-0.4.0.tgz",
-            "integrity": "sha1-q/cC5LkAUk//eQK2g4YoV7Y/k/4=",
-            "dev": true,
-            "requires": {
-                "array-unique": "^0.3.2",
-                "is-glob": "^3.1.0"
-            }
-        },
         "parse-passwd": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.40.0"
+        "vscode": "^1.42.0"
     },
     "enableProposedApi": false,
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -772,7 +772,7 @@
         "@types/node": "^12.12.25",
         "@types/sinon": "^7.5.1",
         "@types/sinon-chai": "^3.2.3",
-        "@types/vscode": "^1.40.0",
+        "@types/vscode": "^1.42.0",
         "@typescript-eslint/eslint-plugin": "^2.16.0",
         "@typescript-eslint/parser": "^2.16.0",
         "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -788,7 +788,6 @@
         "micromatch": "^4.0.2",
         "mocha": "^7.1.0",
         "mocha-junit-reporter": "^1.23.3",
-        "parse-gitignore": "^0.4.0",
         "prettier": "1.19.1",
         "sinon": "^8.1.0",
         "sinon-chai": "^3.4.0",

--- a/src/FileSystemActions.ts
+++ b/src/FileSystemActions.ts
@@ -129,7 +129,7 @@ export default class FileSystemActions {
         }
     }
 
-    private static onFilesDeleted(filesDeleted: FileDeleteEvent) {
+    private static async onFilesDeleted(filesDeleted: FileDeleteEvent) {
         for (const uri of filesDeleted.files) {
             const fileExcludes = Object.keys(workspace.getConfiguration("files").exclude);
 
@@ -140,15 +140,17 @@ export default class FileSystemActions {
                 // revert before delete in case it's optn for add/edit.  At
                 // come point maybe dialog to warn user but this does
                 // match logic in PerforceCommands
-                PerforceCommands.p4revert(uri);
-                PerforceCommands.p4delete(uri);
+                await PerforceCommands.p4revert(uri);
+                await PerforceCommands.p4delete(uri);
             }
         }
+        PerforceSCMProvider.RefreshAll();
     }
 
     private static onFilesAdded(filesAdded: FileCreateEvent) {
         for (const uri of filesAdded.files) {
             PerforceCommands.p4add(uri);
         }
+        PerforceSCMProvider.RefreshAll();
     }
 }

--- a/src/FileSystemActions.ts
+++ b/src/FileSystemActions.ts
@@ -144,13 +144,11 @@ export default class FileSystemActions {
                 await PerforceCommands.p4delete(uri);
             }
         }
-        PerforceSCMProvider.RefreshAll();
     }
 
     private static onFilesAdded(filesAdded: FileCreateEvent) {
         for (const uri of filesAdded.files) {
             PerforceCommands.p4add(uri);
         }
-        PerforceSCMProvider.RefreshAll();
     }
 }

--- a/src/FileSystemActions.ts
+++ b/src/FileSystemActions.ts
@@ -21,7 +21,7 @@ import { Display } from "./Display";
 import { PerforceCommands } from "./PerforceCommands";
 import { PerforceSCMProvider } from "./ScmProvider";
 
-export default class FileSystemListener {
+export default class FileSystemActions {
     private static _eventRegistered: boolean = false;
     private static _lastCheckedFileUri?: Uri = undefined;
     private static _lastSavedFileUri?: Uri = undefined;
@@ -38,21 +38,21 @@ export default class FileSystemListener {
         const config = workspace.getConfiguration("perforce");
 
         if (config && PerforceCommands.checkFolderOpened()) {
-            if (!FileSystemListener._eventRegistered) {
+            if (!FileSystemActions._eventRegistered) {
                 if (config["editOnFileSave"]) {
                     workspace.onWillSaveTextDocument(e => {
                         e.waitUntil(
-                            FileSystemListener.onWillSaveFile(e.document, e.reason)
+                            FileSystemActions.onWillSaveFile(e.document, e.reason)
                         );
                     });
                 }
 
                 if (config["editOnFileModified"]) {
                     workspace.onDidChangeTextDocument(
-                        FileSystemListener.onFileModified.bind(this)
+                        FileSystemActions.onFileModified.bind(this)
                     );
                 }
-                FileSystemListener._eventRegistered = true;
+                FileSystemActions._eventRegistered = true;
             }
 
             if (config["addOnFileCreate"] || config["deleteOnFileDelete"]) {
@@ -113,14 +113,14 @@ export default class FileSystemListener {
         reason: TextDocumentSaveReason
     ): Promise<boolean> {
         if (
-            FileSystemListener._lastSavedFileUri?.fsPath === doc.uri.fsPath &&
+            FileSystemActions._lastSavedFileUri?.fsPath === doc.uri.fsPath &&
             reason !== TextDocumentSaveReason.Manual
         ) {
             // don't keep trying when auto-saving (e.g. if the file isn't intended for perforce)
             return Promise.resolve(true);
         } else {
-            FileSystemListener._lastSavedFileUri = doc.uri;
-            return FileSystemListener.tryEditFile(doc.uri);
+            FileSystemActions._lastSavedFileUri = doc.uri;
+            return FileSystemActions.tryEditFile(doc.uri);
         }
     }
 
@@ -133,8 +133,8 @@ export default class FileSystemListener {
 
         //If this doc has already been checked, just returned
         if (
-            FileSystemListener._lastCheckedFileUri &&
-            docUri.toString() === FileSystemListener._lastCheckedFileUri.toString()
+            FileSystemActions._lastCheckedFileUri &&
+            docUri.toString() === FileSystemActions._lastCheckedFileUri.toString()
         ) {
             return;
         }
@@ -149,8 +149,8 @@ export default class FileSystemListener {
             return;
         }
 
-        FileSystemListener._lastCheckedFileUri = docUri;
-        FileSystemListener.tryEditFile(docUri);
+        FileSystemActions._lastCheckedFileUri = docUri;
+        FileSystemActions.tryEditFile(docUri);
     }
 
     // Had to streamline this, since `onWillSaveTextDocument` allows to delay

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -28,7 +28,7 @@ export namespace PerforceCommands {
         commands.registerCommand("perforce.add", addOpenFile);
         commands.registerCommand("perforce.edit", editOpenFile);
         commands.registerCommand("perforce.delete", deleteOpenFile);
-        commands.registerCommand("perforce.revert", revert);
+        commands.registerCommand("perforce.revert", revertOpenFile);
         commands.registerCommand("perforce.submitSingle", submitSingle);
         commands.registerCommand("perforce.diff", diff);
         commands.registerCommand("perforce.diffRevision", diffRevision);
@@ -122,7 +122,7 @@ export namespace PerforceCommands {
             return false;
         }
 
-        revert();
+        revertOpenFile();
         const fileUri = editor.document.uri;
         p4delete(fileUri);
     }
@@ -142,7 +142,7 @@ export namespace PerforceCommands {
         );
     }
 
-    export function revert() {
+    export function revertOpenFile() {
         const editor = window.activeTextEditor;
         if (!checkFileSelected()) {
             return false;
@@ -585,7 +585,7 @@ export namespace PerforceCommands {
                         editOpenFile();
                         break;
                     case "revert":
-                        revert();
+                        revertOpenFile();
                         break;
                     case "submit single file":
                         submitSingle();

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -51,13 +51,13 @@ export namespace PerforceCommands {
 
         const fileUri = editor.document.uri;
         if (checkFolderOpened()) {
-            add(fileUri);
+            p4add(fileUri);
         } else {
-            add(fileUri, Path.dirname(fileUri.fsPath));
+            p4add(fileUri, Path.dirname(fileUri.fsPath));
         }
     }
 
-    export function add(fileUri: Uri, directoryOverride?: string) {
+    export function p4add(fileUri: Uri, directoryOverride?: string) {
         const args = [Utils.expansePath(fileUri.fsPath)];
         PerforceService.execute(
             fileUri,
@@ -87,13 +87,13 @@ export namespace PerforceCommands {
 
         //If folder not opened, run p4 in files folder.
         if (checkFolderOpened()) {
-            edit(fileUri);
+            p4edit(fileUri);
         } else {
-            edit(fileUri, Path.dirname(fileUri.fsPath));
+            p4edit(fileUri, Path.dirname(fileUri.fsPath));
         }
     }
 
-    export function edit(fileUri: Uri, directoryOverride?: string): Promise<boolean> {
+    export function p4edit(fileUri: Uri, directoryOverride?: string): Promise<boolean> {
         return new Promise(resolve => {
             const args = [Utils.expansePath(fileUri.fsPath)];
             PerforceService.execute(
@@ -152,12 +152,15 @@ export namespace PerforceCommands {
             return false;
         }
 
-        //If folder not opened, overrided p4 directory
         const fileUri = editor.document.uri;
-        const directoryOverride = !checkFolderOpened()
-            ? Path.dirname(fileUri.fsPath)
-            : undefined;
+        if (checkFolderOpened()) {
+            p4revert(fileUri);
+        } else {
+            p4revert(fileUri, Path.dirname(fileUri.fsPath));
+        }
+    }
 
+    export function p4revert(fileUri: Uri, directoryOverride?: string) {
         const args = [Utils.expansePath(fileUri.fsPath)];
         PerforceService.execute(
             fileUri,

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -127,19 +127,15 @@ export namespace PerforceCommands {
         p4delete(fileUri);
     }
 
-    export function p4delete(fileUri: Uri) {
-        const args = [Utils.expansePath(fileUri.fsPath)];
-        PerforceService.execute(
-            fileUri,
-            "delete",
-            (err, stdout, stderr) => {
-                PerforceService.handleCommonServiceResponse(err, stdout, stderr);
-                if (!err) {
-                    Display.showMessage("file marked for delete");
-                }
-            },
-            args
-        );
+    export async function p4delete(fileUri: Uri) {
+        const deleteOpts: p4.DeleteOptions = { paths: [fileUri] };
+        try {
+            await p4.del(fileUri, deleteOpts);
+            Display.showMessage(fileUri.fsPath + " deleted.");
+        } catch (err) {
+            // no work - just catch exception.  Error will be
+            // reported by perforce command code
+        }
     }
 
     export function revertOpenFile() {
@@ -158,8 +154,13 @@ export namespace PerforceCommands {
 
     export async function p4revert(fileUri: Uri) {
         const revertOpts: p4.RevertOptions = { paths: [fileUri] };
-        await p4.revert(fileUri, revertOpts);
-        Display.showMessage(fileUri.fsPath + " reverted.");
+        try {
+            await p4.revert(fileUri, revertOpts);
+            Display.showMessage(fileUri.fsPath + " reverted.");
+        } catch (err) {
+            // no work - just catch exception.  Error will be
+            // reported by perforce command code
+        }
     }
 
     export async function submitSingle() {

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -153,27 +153,13 @@ export namespace PerforceCommands {
         }
 
         const fileUri = editor.document.uri;
-        if (checkFolderOpened()) {
-            p4revert(fileUri);
-        } else {
-            p4revert(fileUri, Path.dirname(fileUri.fsPath));
-        }
+        p4revert(fileUri);
     }
 
-    export function p4revert(fileUri: Uri, directoryOverride?: string) {
-        const args = [Utils.expansePath(fileUri.fsPath)];
-        PerforceService.execute(
-            fileUri,
-            "revert",
-            (err, stdout, stderr) => {
-                PerforceService.handleCommonServiceResponse(err, stdout, stderr);
-                if (!err && !stderr) {
-                    Display.showMessage("file reverted");
-                }
-            },
-            args,
-            directoryOverride
-        );
+    export async function p4revert(fileUri: Uri) {
+        const revertOpts: p4.RevertOptions = { paths: [fileUri] };
+        await p4.revert(fileUri, revertOpts);
+        Display.showMessage(fileUri.fsPath + " reverted.");
     }
 
     export async function submitSingle() {

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -132,6 +132,8 @@ export namespace PerforceCommands {
         try {
             await p4.del(fileUri, deleteOpts);
             Display.showMessage(fileUri.fsPath + " deleted.");
+            Display.updateEditor();
+            PerforceSCMProvider.RefreshAll();
         } catch (err) {
             // no work - just catch exception.  Error will be
             // reported by perforce command code
@@ -157,6 +159,8 @@ export namespace PerforceCommands {
         try {
             await p4.revert(fileUri, revertOpts);
             Display.showMessage(fileUri.fsPath + " reverted.");
+            Display.updateEditor();
+            PerforceSCMProvider.RefreshAll();
         } catch (err) {
             // no work - just catch exception.  Error will be
             // reported by perforce command code

--- a/src/api/PerforceApi.ts
+++ b/src/api/PerforceApi.ts
@@ -284,6 +284,15 @@ const revertFlags = flagMapper<RevertOptions>(
 
 export const revert = makeSimpleCommand("revert", revertFlags);
 
+export interface DeleteOptions {
+    chnum?: string;
+    paths: PerforceFile[];
+}
+
+const deleteFlags = flagMapper<DeleteOptions>([["c", "chnum"]], "paths");
+
+export const del = makeSimpleCommand("delete", deleteFlags);
+
 //#region Shelving
 
 export interface ShelveOptions {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 
 import { PerforceCommands } from "./PerforceCommands";
 import { PerforceContentProvider } from "./ContentProvider";
-import FileSystemListener from "./FileSystemListener";
+import FileSystemActions from "./FileSystemActions";
 import { PerforceSCMProvider } from "./ScmProvider";
 import { IPerforceConfig, PerforceService } from "./PerforceService";
 import { Display } from "./Display";
@@ -74,7 +74,7 @@ function TryCreateP4(uri: vscode.Uri): Promise<boolean> {
             const scm = new PerforceSCMProvider(config, wksUri, workspaceConfig);
             scm.Initialize();
             _disposable.push(scm);
-            _disposable.push(new FileSystemListener(wksFolder));
+            _disposable.push(new FileSystemActions(wksFolder));
 
             doOneTimeRegistration();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,7 +74,7 @@ function TryCreateP4(uri: vscode.Uri): Promise<boolean> {
             const scm = new PerforceSCMProvider(config, wksUri, workspaceConfig);
             scm.Initialize();
             _disposable.push(scm);
-            _disposable.push(new FileSystemActions(wksFolder));
+            _disposable.push(new FileSystemActions());
 
             doOneTimeRegistration();
 


### PR DESCRIPTION
PR to fix the issue of file deletion not working properly.  It removes the file watcher and converts it to events from within the editor (either on add or delete).  Some of the functions in PerforceCommands have been renamed to be consistent.  And the revert code in PerforceCommands now uses the async/await method so that we can wait for files to be reverted before being deleted.

An enhancement would be to collect all files open for add/delete and operate on them at once