### PR TITLE
Always run in the directory of the file when no workspace

### DIFF
--- a/src/Display.ts
+++ b/src/Display.ts
@@ -2,13 +2,10 @@ import {
     window,
     StatusBarAlignment,
     StatusBarItem,
-    workspace,
     EventEmitter,
     Uri,
     commands
 } from "vscode";
-
-import * as Path from "path";
 
 import { PerforceService } from "./PerforceService";
 import { Utils } from "./Utils";
@@ -79,12 +76,6 @@ export namespace Display {
 
         const doc = editor.document;
 
-        //If no folder is open, override the perforce directory to the files
-        let directoryOverride;
-        if (workspace.workspaceFolders === undefined) {
-            directoryOverride = Path.dirname(doc.uri.fsPath);
-        }
-
         if (!doc.isUntitled) {
             const args = [Utils.expansePath(doc.uri.fsPath)];
             PerforceService.execute(
@@ -111,8 +102,7 @@ export namespace Display {
 
                     _onActiveFileStatusKnown.fire({ file: doc.uri, status: active });
                 },
-                args,
-                directoryOverride
+                args
             );
             _statusBarItem.show();
         } else {

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -49,15 +49,10 @@ export namespace PerforceCommands {
             return false;
         }
 
-        const fileUri = editor.document.uri;
-        if (checkFolderOpened()) {
-            p4add(fileUri);
-        } else {
-            p4add(fileUri, Path.dirname(fileUri.fsPath));
-        }
+        p4add(editor.document.uri);
     }
 
-    export function p4add(fileUri: Uri, directoryOverride?: string) {
+    export function p4add(fileUri: Uri) {
         const args = [Utils.expansePath(fileUri.fsPath)];
         PerforceService.execute(
             fileUri,
@@ -68,8 +63,7 @@ export namespace PerforceCommands {
                     Display.showMessage("file opened for add");
                 }
             },
-            args,
-            directoryOverride
+            args
         );
     }
 
@@ -83,17 +77,10 @@ export namespace PerforceCommands {
             return false;
         }
 
-        const fileUri = editor.document.uri;
-
-        //If folder not opened, run p4 in files folder.
-        if (checkFolderOpened()) {
-            p4edit(fileUri);
-        } else {
-            p4edit(fileUri, Path.dirname(fileUri.fsPath));
-        }
+        p4edit(editor.document.uri);
     }
 
-    export function p4edit(fileUri: Uri, directoryOverride?: string): Promise<boolean> {
+    export function p4edit(fileUri: Uri): Promise<boolean> {
         return new Promise(resolve => {
             const args = [Utils.expansePath(fileUri.fsPath)];
             PerforceService.execute(
@@ -106,8 +93,7 @@ export namespace PerforceCommands {
                     }
                     resolve(!err);
                 },
-                args,
-                directoryOverride
+                args
             );
         });
     }

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -218,7 +218,7 @@ export namespace PerforceService {
     ): void {
         const wksFolder = workspace.getWorkspaceFolder(resource);
         const config = wksFolder ? getConfig(wksFolder.uri.fsPath) : null;
-        const wksPath = wksFolder ? wksFolder.uri.fsPath : "";
+        const wksPath = wksFolder?.uri.fsPath;
         const cmd = getPerforceCmdPath();
 
         const allArgs: string[] = getPerforceCmdParams(resource);
@@ -232,11 +232,7 @@ export namespace PerforceService {
             allArgs.push(...args);
         }
 
-        const cwd = config
-            ? config.localDir
-            : wksPath
-            ? wksPath
-            : Path.dirname(resource.fsPath);
+        const cwd = config?.localDir ?? wksPath ?? Path.dirname(resource.fsPath);
         const env = { ...process.env, PWD: cwd };
         const spawnArgs: CP.SpawnOptions = { cwd, env };
         spawnPerforceCommand(cmd, allArgs, spawnArgs, responseCallback, input);

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -7,6 +7,7 @@ import { PerforceSCMProvider } from "./ScmProvider";
 import * as CP from "child_process";
 import * as spawn from "cross-spawn";
 import { CommandLimiter } from "./CommandLimiter";
+import * as Path from "path";
 
 // eslint-disable-next-line @typescript-eslint/interface-name-prefix
 export interface IPerforceConfig {
@@ -162,14 +163,12 @@ export namespace PerforceService {
         command: string,
         responseCallback: (err: Error | null, stdout: string, stderr: string) => void,
         args?: string[],
-        directoryOverride?: string | null,
         input?: string
     ): void {
         if (debugModeActive && !debugModeSetup) {
             limiter.debugMode = true;
             debugModeSetup = true;
         }
-        //execCommand(resource, command, responseCallback, args, directoryOverride, input);
         limiter.submit(onDone => {
             execCommand(
                 resource,
@@ -180,7 +179,6 @@ export namespace PerforceService {
                     responseCallback(...rest);
                 },
                 args,
-                directoryOverride,
                 input
             );
         }, `<JOB_ID:${++id}:${command}>`);
@@ -190,7 +188,6 @@ export namespace PerforceService {
         resource: Uri,
         command: string,
         args?: string[],
-        directoryOverride?: string,
         input?: string
     ): Promise<string> {
         return new Promise((resolve, reject) => {
@@ -207,7 +204,6 @@ export namespace PerforceService {
                     }
                 },
                 args,
-                directoryOverride,
                 input
             );
         });
@@ -218,7 +214,6 @@ export namespace PerforceService {
         command: string,
         responseCallback: (err: Error | null, stdout: string, stderr: string) => void,
         args?: string[],
-        directoryOverride?: string | null,
         input?: string
     ): void {
         const wksFolder = workspace.getWorkspaceFolder(resource);
@@ -227,9 +222,6 @@ export namespace PerforceService {
         const cmd = getPerforceCmdPath();
 
         const allArgs: string[] = getPerforceCmdParams(resource);
-        if (directoryOverride !== null && directoryOverride !== undefined) {
-            allArgs.push("-d", directoryOverride);
-        }
         allArgs.push(command);
 
         if (args !== undefined) {
@@ -240,7 +232,13 @@ export namespace PerforceService {
             allArgs.push(...args);
         }
 
-        const spawnArgs: CP.SpawnOptions = { cwd: config ? config.localDir : wksPath };
+        const cwd = config
+            ? config.localDir
+            : wksPath
+            ? wksPath
+            : Path.dirname(resource.fsPath);
+        const env = { ...process.env, PWD: cwd };
+        const spawnArgs: CP.SpawnOptions = { cwd, env };
         spawnPerforceCommand(cmd, allArgs, spawnArgs, responseCallback, input);
     }
 
@@ -251,7 +249,7 @@ export namespace PerforceService {
         responseCallback: (err: Error | null, stdout: string, stderr: string) => void,
         input?: string
     ) {
-        logExecutedCommand(cmd, allArgs);
+        logExecutedCommand(cmd, allArgs, spawnArgs);
         const child = spawn(cmd, allArgs, spawnArgs);
 
         let called = false;
@@ -276,13 +274,13 @@ export namespace PerforceService {
         });
     }
 
-    function logExecutedCommand(cmd: string, args: string[]) {
+    function logExecutedCommand(cmd: string, args: string[], spawnArgs: CP.SpawnOptions) {
         // not necessarily using these escaped values, because cross-spawn does its own escaping,
         // but no sensible way of logging the unescaped array for a user. The output command line
         // should at least be copy-pastable and work
         const escapedArgs = args.map(arg => `'${arg.replace(/'/g, `'\\''`)}'`);
         const loggedCommand = [cmd].concat(escapedArgs);
-        Display.channel.appendLine(loggedCommand.join(" "));
+        Display.channel.appendLine(spawnArgs.cwd + ": " + loggedCommand.join(" "));
     }
 
     async function getResults(child: CP.ChildProcess): Promise<string[]> {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -163,7 +163,6 @@ export namespace Utils {
                     }
                 },
                 args,
-                null,
                 input
             );
         });

--- a/src/test/helpers/StubPerforceModel.ts
+++ b/src/test/helpers/StubPerforceModel.ts
@@ -47,7 +47,6 @@ function executeStub(
     command: string,
     responseCallback: PerforceResponseCallback,
     _args?: string[],
-    _directoryOverride?: string | null,
     _input?: string
 ) {
     setImmediate(() => {

--- a/src/test/suite/perforceApi.test.ts
+++ b/src/test/suite/perforceApi.test.ts
@@ -18,7 +18,6 @@ function basicExecuteStub(
     command: string,
     responseCallback: (err: Error | null, stdout: string, stderr: string) => void,
     args?: string[],
-    _directoryOverride?: string | null,
     _input?: string
 ) {
     let out = command;
@@ -166,7 +165,6 @@ describe("Perforce API", () => {
                 "change",
                 sinon.match.any,
                 ["-i"],
-                null,
                 "Change:\tnew\n\n" +
                     "Description:\tmy change spec\n\there it is\n\n" +
                     "Files:\t//depot/testArea/myFile.txt\t# add"
@@ -195,7 +193,6 @@ describe("Perforce API", () => {
                 "change",
                 sinon.match.any,
                 ["-i"],
-                null,
                 "Change:\t1234\n\n" +
                     "Description:\ta spec\n\n" +
                     "Files:\t//depot/testArea/myEdit.txt\t# edit\n\n" +
@@ -222,7 +219,6 @@ describe("Perforce API", () => {
                 "change",
                 sinon.match.any,
                 ["-i"],
-                null,
                 "Change:\t1234\n\n" +
                     "Files:\t//depot/testArea/myEdit.txt\t# edit\n\n" +
                     "Description:\toverride"
@@ -717,7 +713,6 @@ describe("Perforce API", () => {
                 "login",
                 sinon.match.any,
                 [],
-                null,
                 "hunter2"
             );
         });


### PR DESCRIPTION
This slightly improves the `directoryOverride` by centralizing the logic, without having it spread over multiple places.

There were only a few usages of directoryOverride and they were all doing the same thing - if and only if there were no workspace folders, it was adding the -d option to commands, using the directory of the relevant file (this is a very difficult situation to get into, as the extension does not activate if there is no folder opened)

Perforce uses -d to override the cwd / PWD environment - so instead we can just spawn the process in the right place with the right environment. Tested working on linux; I still need to test this on windows.

Now, it always uses the directory if there is no workspace for the file, i.e. if you open a file that is not in your workspace, you should still be able to perform perforce commands on it, if a default p4 command would work in that directory.

The existing behaviour for working out where to run commands is not ideal - it looks for a configuration assigned to a workspace, meaning that multiple p4 configurations in a single workspace is not necessarily working - see issue #41

This does not attempt to resolve that, just deals with removing the directoryOverride option