### PR TITLE
Adds `perforce.hideSubmitIcon` setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,6 +199,11 @@
                 "perforce.swarmHost": {
                     "type": "string",
                     "description": "Specifies the host of the Swarm server for annotation links"
+                },
+                "perforce.hideSubmitIcon": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Don't show the submit icon next to the changelist description."
                 }
             }
         },
@@ -565,12 +570,12 @@
             "scm/resourceGroup/context": [
                 {
                     "command": "perforce.submitDefault",
-                    "when": "scmProvider == perforce && scmResourceGroup == default",
+                    "when": "scmProvider == perforce && scmResourceGroup == default && config.perforce.hideSubmitIcon == false",
                     "group": "inline@1"
                 },
                 {
                     "command": "perforce.submitChangelist",
-                    "when": "scmProvider == perforce && scmResourceGroup != default",
+                    "when": "scmProvider == perforce && scmResourceGroup != default && config.perforce.hideSubmitIcon == false",
                     "group": "inline@1"
                 },
                 {


### PR DESCRIPTION
Allows users to conditionally hide the submit icon next to the change-list descriptions. Makes it a bit tougher to accidentally submit a changelist.

See examples below:

`hideSubmitIcon == true` - context menu option still exists, button does not display next to CL description.
![image](https://user-images.githubusercontent.com/248680/76131901-23ada500-5fc5-11ea-9932-1bab22a399bb.png)

`hideSubmitIcon == false`
![image](https://user-images.githubusercontent.com/248680/76131885-198ba680-5fc5-11ea-86c1-349b398d08fa.png)
