### PR TITLE
Option to prompt before submit

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ If you install this extension, please uninstall or disable `slevesque.perforce` 
 |`perforce.hideShelvedFiles`        |`boolean`  |Hide shelved files in the SCM Explorer.
 |`perforce.hideEmptyChangelists`    |`boolean`  |Hide changelists with no file in the SCM Explorer.
 |`perforce.hideSubmitIcon`          |`boolean`  |Don't show the submit icon next to the changelist description.
+|`perforce.promptBeforeSubmit`      |`boolean`  |Whether to prompt for confirmation before submitting a saved changelist.
 |&nbsp;
 |`perforce.bottleneck.maxConcurrent` |`number`  |Limit the maximum number of perforce commands running at any given time.
 

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
                 },
                 "perforce.promptBeforeSubmit": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Whether to prompt for confirmation, before submitting a saved changelist"
                 }
             }

--- a/package.json
+++ b/package.json
@@ -204,6 +204,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Don't show the submit icon next to the changelist description."
+                },
+                "perforce.promptBeforeSubmit": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to prompt for confirmation, before submitting a saved changelist"
                 }
             }
         },

--- a/src/ConfigService.ts
+++ b/src/ConfigService.ts
@@ -33,6 +33,10 @@ export class ConfigAccessor {
         return this.getConfigItem<string>("countBadge") ?? "all-but-shelved";
     }
 
+    public get promptBeforeSubmit(): boolean {
+        return this.getConfigItem("promptBeforeSubmit") ?? false;
+    }
+
     public get refreshDebounceTime(): number {
         return 1000;
     }

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -420,6 +420,17 @@ export class Model implements Disposable {
     public async Submit(input: ResourceGroup): Promise<void> {
         this.assertIsNotDefault(input);
 
+        if (this._workspaceConfig.promptBeforeSubmit) {
+            if (
+                !(await this.requestConfirmation(
+                    "Are you sure you want to submit changelist " + input.chnum + "?",
+                    "Submit changelist"
+                ))
+            ) {
+                return;
+            }
+        }
+
         await p4.submitChangelist(this._workspaceUri, { chnum: input.chnum });
         Display.showMessage("Changelist Submitted");
         this.Refresh();
@@ -765,6 +776,11 @@ export class Model implements Disposable {
         } catch (err) {
             Display.showImportantError(err.toString());
         }
+    }
+
+    private async requestConfirmation(message: string, yes: string) {
+        const result = await window.showWarningMessage(message, { modal: true }, yes);
+        return result === yes;
     }
 
     private async requestChangelistDescription() {

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -515,9 +515,7 @@ export class Model implements Disposable {
         }
 
         if (!unchanged) {
-            const yes = "Revert Changes";
-            const pick = await window.showWarningMessage(message, { modal: true }, yes);
-            if (pick !== yes) {
+            if (!(await this.requestConfirmation(message, "Revert Changes"))) {
                 return;
             }
         }
@@ -604,9 +602,7 @@ export class Model implements Disposable {
             input.chnum +
             "?";
 
-        const yes = "Delete Shelved Files";
-        const pick = await window.showWarningMessage(message, { modal: true }, yes);
-        if (pick !== yes) {
+        if (!(await this.requestConfirmation(message, "Delete Shelved Files"))) {
             return;
         }
 
@@ -664,14 +660,9 @@ export class Model implements Disposable {
             return;
         }
 
-        const yes = "Delete shelved file";
-        const answer = await window.showWarningMessage(
-            "Are you sure you want to delete the shelved file " + input.depotPath,
-            { modal: true },
-            yes
-        );
-
-        if (answer === undefined) {
+        const message =
+            "Are you sure you want to delete the shelved file " + input.depotPath;
+        if (!(await this.requestConfirmation(message, "Delete Shelved File"))) {
             return;
         }
 

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -2022,6 +2022,35 @@ describe("Model & ScmProvider modules (integration)", () => {
                     }
                 );
             });
+            it("Prompts the user first when configured to do so", async () => {
+                sinon.stub(items.workspaceConfig, "promptBeforeSubmit").get(() => true);
+                const warn = sinon
+                    .stub(vscode.window, "showWarningMessage")
+                    .resolves(undefined);
+
+                await PerforceSCMProvider.Submit(items.instance.resources[1]);
+
+                expect(warn).to.have.been.calledWithMatch("changelist 1");
+
+                expect(items.stubModel.submitChangelist).not.to.have.been.called;
+            });
+            it("Submits on confirmation", async () => {
+                sinon.stub(items.workspaceConfig, "promptBeforeSubmit").get(() => true);
+                const warn = sinon
+                    .stub(vscode.window, "showWarningMessage")
+                    .resolvesArg(2);
+
+                await PerforceSCMProvider.Submit(items.instance.resources[1]);
+
+                expect(warn).to.have.been.calledWithMatch("changelist 1");
+
+                expect(items.stubModel.submitChangelist).to.have.been.calledWith(
+                    workspaceUri,
+                    {
+                        chnum: "1"
+                    }
+                );
+            });
         });
         describe("Submit selected files", () => {
             before(() => {

--- a/test-fixtures/core/.vscode/settings.json
+++ b/test-fixtures/core/.vscode/settings.json
@@ -4,5 +4,6 @@
     "perforce.bottleneck.maxConcurrent": 1000,
     "perforce.hideNonWorkspaceFiles": false,
     "perforce.hideShelvedFiles": false,
-    "perforce.activationMode": "autodetect"
+    "perforce.activationMode": "autodetect",
+    "perforce.promptBeforeSubmit": false
 }


### PR DESCRIPTION
After merging #56 the thought occurred to me that it would still make sense to have an optional prompt to confirm that the user wants to submit a saved changelist (i.e. one that already has a changelist number) - because previously this would always try to submit without any confirmation.

Does not apply to the default changelist because we already have to prompt for a changelist description