### PR TITLE
Delete with wildcard when folder delete event is received

### DIFF
--- a/src/ConfigService.ts
+++ b/src/ConfigService.ts
@@ -40,6 +40,22 @@ export class ConfigAccessor {
     public get refreshDebounceTime(): number {
         return 1000;
     }
+
+    public get editOnFileSave(): boolean {
+        return this.getConfigItem("editOnFileSave") ?? false;
+    }
+
+    public get editOnFileModified(): boolean {
+        return this.getConfigItem("editOnFileModified") ?? false;
+    }
+
+    public get addOnFileCreate(): boolean {
+        return this.getConfigItem("addOnFileCreate") ?? false;
+    }
+
+    public get deleteOnFileDelete(): boolean {
+        return this.getConfigItem("deleteOnFileDelete") ?? false;
+    }
 }
 
 export class WorkspaceConfigAccessor extends ConfigAccessor {

--- a/src/FileSystemActions.ts
+++ b/src/FileSystemActions.ts
@@ -5,11 +5,12 @@ import {
     workspace,
     Disposable,
     FileCreateEvent,
-    FileDeleteEvent,
     TextDocument,
     TextDocumentChangeEvent,
     Uri,
-    TextDocumentSaveReason
+    TextDocumentSaveReason,
+    FileType,
+    FileWillDeleteEvent
 } from "vscode";
 
 import * as micromatch from "micromatch";
@@ -17,6 +18,14 @@ import * as micromatch from "micromatch";
 import { Display } from "./Display";
 import { PerforceCommands } from "./PerforceCommands";
 import { PerforceSCMProvider } from "./ScmProvider";
+import { ConfigAccessor } from "./ConfigService";
+
+export interface FileSystemEventProvider {
+    onWillSaveTextDocument: typeof workspace.onWillSaveTextDocument;
+    onDidChangeTextDocument: typeof workspace.onDidChangeTextDocument;
+    onDidCreateFiles: typeof workspace.onDidCreateFiles;
+    onWillDeleteFiles: typeof workspace.onWillDeleteFiles;
+}
 
 export default class FileSystemActions {
     private static _eventRegistered: boolean = false;
@@ -24,48 +33,71 @@ export default class FileSystemActions {
     private static _lastSavedFileUri?: Uri = undefined;
 
     private _disposable: Disposable;
+    private static _eventsDisposable: Disposable;
 
-    constructor() {
+    constructor(workspace: FileSystemEventProvider, config: ConfigAccessor) {
         const subscriptions: Disposable[] = [];
+
         window.onDidChangeActiveTextEditor(Display.updateEditor, this, subscriptions);
 
-        const config = workspace.getConfiguration("perforce");
-
-        if (config && PerforceCommands.checkFolderOpened()) {
-            if (!FileSystemActions._eventRegistered) {
-                if (config["editOnFileSave"]) {
-                    workspace.onWillSaveTextDocument(e => {
-                        e.waitUntil(
-                            FileSystemActions.onWillSaveFile(e.document, e.reason)
-                        );
-                    });
-                }
-
-                if (config["editOnFileModified"]) {
-                    workspace.onDidChangeTextDocument(
-                        FileSystemActions.onFileModified.bind(this)
-                    );
-                }
-
-                if (config["addOnFileCreate"]) {
-                    workspace.onDidCreateFiles(FileSystemActions.onFilesAdded.bind(this));
-                }
-
-                if (config["deleteOnFileDelete"]) {
-                    workspace.onDidDeleteFiles(
-                        FileSystemActions.onFilesDeleted.bind(this)
-                    );
-                }
-
-                FileSystemActions._eventRegistered = true;
-            }
+        if (PerforceCommands.checkFolderOpened()) {
+            FileSystemActions.registerEvents(workspace, config);
         }
 
         this._disposable = Disposable.from.apply(this, subscriptions);
     }
 
+    private static registerEvents(
+        workspace: FileSystemEventProvider,
+        config: ConfigAccessor
+    ) {
+        if (!FileSystemActions._eventRegistered) {
+            FileSystemActions._eventsDisposable?.dispose();
+
+            const eventSubscriptions: Disposable[] = [];
+
+            if (config.editOnFileSave) {
+                workspace.onWillSaveTextDocument(e => {
+                    e.waitUntil(FileSystemActions.onWillSaveFile(e.document, e.reason));
+                }, eventSubscriptions);
+            }
+
+            if (config.editOnFileModified) {
+                workspace.onDidChangeTextDocument(
+                    FileSystemActions.onFileModified.bind(this),
+                    eventSubscriptions
+                );
+            }
+
+            if (config.addOnFileCreate) {
+                workspace.onDidCreateFiles(
+                    FileSystemActions.onFilesAdded.bind(this),
+                    eventSubscriptions
+                );
+            }
+
+            if (config.deleteOnFileDelete) {
+                workspace.onWillDeleteFiles(
+                    FileSystemActions.onFilesDeleted.bind(this),
+                    eventSubscriptions
+                );
+            }
+
+            FileSystemActions._eventRegistered = true;
+            FileSystemActions._eventsDisposable = Disposable.from.apply(
+                this,
+                eventSubscriptions
+            );
+        }
+    }
+
     public dispose() {
         this._disposable.dispose();
+    }
+
+    public static disposeEvents() {
+        this._eventRegistered = false;
+        this._eventsDisposable.dispose();
     }
 
     private static onWillSaveFile(
@@ -129,21 +161,45 @@ export default class FileSystemActions {
         }
     }
 
-    private static async onFilesDeleted(filesDeleted: FileDeleteEvent) {
-        for (const uri of filesDeleted.files) {
-            const fileExcludes = Object.keys(workspace.getConfiguration("files").exclude);
-
-            const shouldIgnore: boolean = micromatch.isMatch(uri.fsPath, fileExcludes, {
-                dot: true
-            });
-            if (!shouldIgnore) {
-                // revert before delete in case it's optn for add/edit.  At
-                // come point maybe dialog to warn user but this does
-                // match logic in PerforceCommands
-                await PerforceCommands.p4revert(uri);
-                await PerforceCommands.p4delete(uri);
-            }
+    private static async isDirectory(uri: Uri) {
+        try {
+            const stat = await workspace.fs.stat(uri);
+            return stat.type === FileType.Directory;
+        } catch (err) {
+            // still try to revert
+            Display.channel.appendLine(err);
         }
+        return false;
+    }
+
+    private static async revertAndDelete(uri: Uri) {
+        await PerforceCommands.p4revert(uri);
+        await PerforceCommands.p4delete(uri);
+    }
+
+    private static async deleteFileOrDirectory(uri: Uri) {
+        const isDirectory = await FileSystemActions.isDirectory(uri);
+
+        const fullUri = isDirectory ? uri.with({ path: uri.path + "/..." }) : uri;
+
+        // DO NOT AWAIT the revert, because we are holding up the deletion
+        FileSystemActions.revertAndDelete(fullUri);
+    }
+
+    private static shouldExclude(uri: Uri): boolean {
+        const fileExcludes = Object.keys(workspace.getConfiguration("files").exclude);
+
+        return micromatch.isMatch(uri.fsPath, fileExcludes, {
+            dot: true
+        });
+    }
+
+    private static onFilesDeleted(filesDeleted: FileWillDeleteEvent) {
+        const promises = filesDeleted.files
+            .filter(uri => !FileSystemActions.shouldExclude(uri))
+            .map(uri => FileSystemActions.deleteFileOrDirectory(uri));
+
+        filesDeleted.waitUntil(Promise.all(promises));
     }
 
     private static onFilesAdded(filesAdded: FileCreateEvent) {

--- a/src/FileSystemActions.ts
+++ b/src/FileSystemActions.ts
@@ -172,18 +172,13 @@ export default class FileSystemActions {
         return false;
     }
 
-    private static async revertAndDelete(uri: Uri) {
-        await PerforceCommands.p4revert(uri);
-        await PerforceCommands.p4delete(uri);
-    }
-
     private static async deleteFileOrDirectory(uri: Uri) {
         const isDirectory = await FileSystemActions.isDirectory(uri);
 
         const fullUri = isDirectory ? uri.with({ path: uri.path + "/..." }) : uri;
 
         // DO NOT AWAIT the revert, because we are holding up the deletion
-        FileSystemActions.revertAndDelete(fullUri);
+        PerforceCommands.p4revertAndDelete(fullUri);
     }
 
     private static shouldExclude(uri: Uri): boolean {

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -153,6 +153,11 @@ export namespace PerforceCommands {
         }
     }
 
+    export async function p4revertAndDelete(uri: Uri) {
+        await PerforceCommands.p4revert(uri);
+        await PerforceCommands.p4delete(uri);
+    }
+
     export async function submitSingle() {
         const file = window.activeTextEditor?.document.uri;
         if (!file || file.scheme !== "file") {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,7 +74,7 @@ function TryCreateP4(uri: vscode.Uri): Promise<boolean> {
             const scm = new PerforceSCMProvider(config, wksUri, workspaceConfig);
             scm.Initialize();
             _disposable.push(scm);
-            _disposable.push(new FileSystemActions());
+            _disposable.push(new FileSystemActions(vscode.workspace, workspaceConfig));
 
             doOneTimeRegistration();
 

--- a/src/test/suite/fileSystemActions.test.ts
+++ b/src/test/suite/fileSystemActions.test.ts
@@ -89,15 +89,13 @@ describe("File System Actions", () => {
     let eventProvider: ReturnType<typeof makeStubEvents>;
     let workspaceConfig: WorkspaceConfigAccessor;
     let actions: FileSystemActions | undefined;
-    let del: sinon.SinonStub<any>;
-    let revert: sinon.SinonStub<any>;
+    let revertAndDelete: sinon.SinonStub<any>;
     let add: sinon.SinonStub<any>;
     const assignActions = () => {
         actions = new FileSystemActions(eventProvider, workspaceConfig);
     };
     beforeEach(() => {
-        del = sinon.stub(PerforceCommands, "p4delete").resolves();
-        revert = sinon.stub(PerforceCommands, "p4revert").resolves();
+        revertAndDelete = sinon.stub(PerforceCommands, "p4revertAndDelete").resolves();
         add = sinon.stub(PerforceCommands, "p4add").resolves();
         eventProvider = makeStubEvents();
         workspaceConfig = new WorkspaceConfigAccessor(workspaceUri);
@@ -142,10 +140,8 @@ describe("File System Actions", () => {
 
             await fireDeleteEvent(file, file2);
 
-            expect(revert).to.have.been.calledWith(file);
-            expect(del).to.have.been.calledWith(file);
-            expect(revert).to.have.been.calledWith(file2);
-            expect(del).to.have.been.calledWith(file2);
+            expect(revertAndDelete).to.have.been.calledWith(file);
+            expect(revertAndDelete).to.have.been.calledWith(file2);
         });
         it("Reverts folders using a wildcard", async () => {
             stubWatcherConfig(workspaceConfig, { deleteOnFileDelete: true });
@@ -157,8 +153,7 @@ describe("File System Actions", () => {
 
             const folderMatch = folder.with({ path: folder.path + "/..." });
 
-            expect(revert).to.have.been.calledWithMatch(folderMatch);
-            expect(del).to.have.been.calledWith(folderMatch);
+            expect(revertAndDelete).to.have.been.calledWithMatch(folderMatch);
         });
         it("Ignores fstat errors", async () => {
             stubWatcherConfig(workspaceConfig, { deleteOnFileDelete: true });
@@ -168,8 +163,7 @@ describe("File System Actions", () => {
 
             await fireDeleteEvent(unknown);
 
-            expect(revert).to.have.been.calledWithMatch(unknown);
-            expect(del).to.have.been.calledWith(unknown);
+            expect(revertAndDelete).to.have.been.calledWithMatch(unknown);
         });
         it("Does not try to delete excluded files", async () => {
             stubWatcherConfig(workspaceConfig, { deleteOnFileDelete: true });
@@ -180,8 +174,7 @@ describe("File System Actions", () => {
 
             await fireDeleteEvent(excluded);
 
-            expect(revert).not.to.have.been.called;
-            expect(del).not.to.have.been.called;
+            expect(revertAndDelete).not.to.have.been.called;
         });
     });
     describe("Add on file create", () => {

--- a/src/test/suite/fileSystemActions.test.ts
+++ b/src/test/suite/fileSystemActions.test.ts
@@ -1,0 +1,219 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { expect } from "chai";
+import * as chai from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+import * as sinonChai from "sinon-chai";
+
+import * as vscode from "vscode";
+
+import * as sinon from "sinon";
+import p4Commands from "../helpers/p4Commands";
+import { PerforceCommands } from "../../PerforceCommands";
+import { WorkspaceConfigAccessor } from "../../ConfigService";
+
+import { getLocalFile, getWorkspaceUri } from "../helpers/testUtils";
+import FileSystemActions from "../../FileSystemActions";
+
+chai.use(sinonChai);
+chai.use(p4Commands);
+chai.use(chaiAsPromised);
+
+const basicFiles = {
+    edit: ["testFolder", "a.txt"],
+    subFolder: ["testFolder", "subFolder"],
+    subFolderFile: ["testFolder", "subFolder", "subFile"],
+    unknownFile: ["testFolder", "noexist"],
+    unknownFile2: ["testFolder", "newfile"],
+    excluded: ["testFolder", "excluded"]
+};
+
+const workspaceUri = getWorkspaceUri();
+
+function getFile(file: keyof typeof basicFiles): vscode.Uri {
+    return getLocalFile(workspaceUri, ...basicFiles[file]);
+}
+
+function stubEvent<T>() {
+    type EventAttrs = {
+        spy?: sinon.SinonSpy<[T], any>;
+        fire?: (e: T) => any;
+        registered: boolean;
+    };
+    const attrs: EventAttrs = {
+        registered: false
+    };
+
+    const func = (
+        listener: (e: T) => any,
+        thisArg?: any,
+        subscriptions?: vscode.Disposable[]
+    ) => {
+        attrs.registered = true;
+        attrs.spy = sinon.spy(listener);
+        attrs.fire = (e: T) => listener.call(thisArg, e);
+
+        const disposable = { dispose: () => {} };
+        subscriptions?.push(disposable);
+        return disposable;
+    };
+
+    func.attrs = attrs;
+
+    return func;
+}
+
+type WatcherConfig = {
+    editOnFileSave?: boolean;
+    editOnFileModified?: boolean;
+    addOnFileCreate?: boolean;
+    deleteOnFileDelete?: boolean;
+};
+
+function stubWatcherConfig(config: WorkspaceConfigAccessor, values: WatcherConfig) {
+    sinon.stub(config, "editOnFileSave").get(() => !!values.editOnFileSave);
+    sinon.stub(config, "editOnFileModified").get(() => !!values.editOnFileModified);
+    sinon.stub(config, "addOnFileCreate").get(() => !!values.addOnFileCreate);
+    sinon.stub(config, "deleteOnFileDelete").get(() => !!values.deleteOnFileDelete);
+}
+
+function makeStubEvents() {
+    return {
+        onDidChangeTextDocument: stubEvent<vscode.TextDocumentChangeEvent>(),
+        onDidCreateFiles: stubEvent<vscode.FileCreateEvent>(),
+        onWillDeleteFiles: stubEvent<vscode.FileWillDeleteEvent>(),
+        onWillSaveTextDocument: stubEvent<vscode.TextDocumentWillSaveEvent>()
+    };
+}
+
+describe("File System Actions", () => {
+    let eventProvider: ReturnType<typeof makeStubEvents>;
+    let workspaceConfig: WorkspaceConfigAccessor;
+    let actions: FileSystemActions | undefined;
+    let del: sinon.SinonStub<any>;
+    let revert: sinon.SinonStub<any>;
+    let add: sinon.SinonStub<any>;
+    const assignActions = () => {
+        actions = new FileSystemActions(eventProvider, workspaceConfig);
+    };
+    beforeEach(() => {
+        del = sinon.stub(PerforceCommands, "p4delete").resolves();
+        revert = sinon.stub(PerforceCommands, "p4revert").resolves();
+        add = sinon.stub(PerforceCommands, "p4add").resolves();
+        eventProvider = makeStubEvents();
+        workspaceConfig = new WorkspaceConfigAccessor(workspaceUri);
+    });
+    afterEach(() => {
+        FileSystemActions.disposeEvents();
+        actions?.dispose();
+        actions = undefined;
+        sinon.restore();
+    });
+    describe("Delete on file delete", () => {
+        const fireDeleteEvent = async (...files: vscode.Uri[]) => {
+            const waitUntil = sinon.spy();
+
+            eventProvider.onWillDeleteFiles.attrs.fire?.({
+                files: files,
+                waitUntil: waitUntil
+            });
+
+            expect(waitUntil).to.have.been.called;
+            await waitUntil.lastCall.args[0];
+        };
+
+        it("Does not register for deletions when disabled", () => {
+            stubWatcherConfig(workspaceConfig, {});
+            assignActions();
+
+            expect(eventProvider.onWillDeleteFiles.attrs.registered).to.be.false;
+        });
+        it("Does register for deletions when configured", () => {
+            stubWatcherConfig(workspaceConfig, { deleteOnFileDelete: true });
+            assignActions();
+
+            expect(eventProvider.onWillDeleteFiles.attrs.registered).to.be.true;
+        });
+        it("Reverts and deletes files", async () => {
+            stubWatcherConfig(workspaceConfig, { deleteOnFileDelete: true });
+            assignActions();
+
+            const file = getFile("edit");
+            const file2 = getFile("subFolderFile");
+
+            await fireDeleteEvent(file, file2);
+
+            expect(revert).to.have.been.calledWith(file);
+            expect(del).to.have.been.calledWith(file);
+            expect(revert).to.have.been.calledWith(file2);
+            expect(del).to.have.been.calledWith(file2);
+        });
+        it("Reverts folders using a wildcard", async () => {
+            stubWatcherConfig(workspaceConfig, { deleteOnFileDelete: true });
+            assignActions();
+
+            const folder = getFile("subFolder");
+
+            await fireDeleteEvent(folder);
+
+            const folderMatch = folder.with({ path: folder.path + "/..." });
+
+            expect(revert).to.have.been.calledWithMatch(folderMatch);
+            expect(del).to.have.been.calledWith(folderMatch);
+        });
+        it("Ignores fstat errors", async () => {
+            stubWatcherConfig(workspaceConfig, { deleteOnFileDelete: true });
+            assignActions();
+
+            const unknown = getFile("unknownFile");
+
+            await fireDeleteEvent(unknown);
+
+            expect(revert).to.have.been.calledWithMatch(unknown);
+            expect(del).to.have.been.calledWith(unknown);
+        });
+        it("Does not try to delete excluded files", async () => {
+            stubWatcherConfig(workspaceConfig, { deleteOnFileDelete: true });
+            assignActions();
+
+            // files.exclude is specified in the workspace config as **/excluded
+            const excluded = getFile("excluded");
+
+            await fireDeleteEvent(excluded);
+
+            expect(revert).not.to.have.been.called;
+            expect(del).not.to.have.been.called;
+        });
+    });
+    describe("Add on file create", () => {
+        const fireAddEvent = (...files: vscode.Uri[]) => {
+            eventProvider.onDidCreateFiles.attrs.fire?.({
+                files: files
+            });
+        };
+
+        it("Does not register for additions when disabled", () => {
+            stubWatcherConfig(workspaceConfig, {});
+            assignActions();
+
+            expect(eventProvider.onWillDeleteFiles.attrs.registered).to.be.false;
+        });
+        it("Does register for additions when configured", () => {
+            stubWatcherConfig(workspaceConfig, { addOnFileCreate: true });
+            assignActions();
+
+            expect(eventProvider.onDidCreateFiles.attrs.registered).to.be.true;
+        });
+        it("Adds new files", () => {
+            stubWatcherConfig(workspaceConfig, { addOnFileCreate: true });
+            assignActions();
+
+            const file = getFile("unknownFile");
+            const file2 = getFile("unknownFile2");
+
+            fireAddEvent(file, file2);
+
+            expect(add).to.have.been.calledWith(file);
+            expect(add).to.have.been.calledWith(file2);
+        });
+    });
+});

--- a/test-fixtures/core/.vscode/settings.json
+++ b/test-fixtures/core/.vscode/settings.json
@@ -5,5 +5,13 @@
     "perforce.hideNonWorkspaceFiles": false,
     "perforce.hideShelvedFiles": false,
     "perforce.activationMode": "autodetect",
-    "perforce.promptBeforeSubmit": false
+    "perforce.promptBeforeSubmit": false,
+    "files.exclude": {
+        "**/.git": true,
+        "**/.svn": true,
+        "**/.hg": true,
+        "**/CVS": true,
+        "**/.DS_Store": true,
+        "**/excluded": true
+    }
 }

--- a/test-fixtures/core/testFolder/subFolder/subFile
+++ b/test-fixtures/core/testFolder/subFolder/subFile
@@ -1,0 +1,1 @@
+content of the sub file

--- a/test-fixtures/core/testFolder/subFolder/subFile2
+++ b/test-fixtures/core/testFolder/subFolder/subFile2
@@ -1,0 +1,1 @@
+content of the sub file 2

--- a/test-fixtures/core/testFolder/subFolder/underSubFolder/subSubFile
+++ b/test-fixtures/core/testFolder/subFolder/underSubFolder/subSubFile
@@ -1,0 +1,1 @@
+content of the sub sub file


### PR DESCRIPTION
Check whether the deleted file is a directory before deleting.
It it is a directory, use the wildcard specifier to try to revert and delete the files

* Move event configuration into the ConfigAccessor
* Add some tests for FileSystemActions (incomplete)

Fixes #60 