### PR TITLE
Add context variables and commands for current file details

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,35 @@ See [Multi-root Workspaces - Settings](https://code.visualstudio.com/docs/editor
 * ![circle-slash](images/circle-slash.png) not under client's root
 
 ## SCM view
+
 ![SCM Perforce](images/scm-perforce.png)  
 
 Explore and leave your comments on [GitHub](https://github.com/mjcrouch/vscode-perforce/issues)
+
+## Command variables
+
+The extension provides a few commands and context variables relating to the file currently open in the editor. These can be used in tasks, keyboard shortcuts etc. as required, if you can find a use for them!
+
+For example, the following task prints out the changelist number, provided the current file is open in perforce:
+
+```
+    {
+        "label": "echo",
+        "type": "shell",
+        "command": "echo ${command:perforce.currentFile.changelist}"
+    }
+```
+
+In all cases, the command name and the context variable name are the same
+
+| Name                              | description
+|-----------------------------------|---------------
+| `perforce.currentFile.status`     | Whether the file is open / in the workspace. Possible values: `OPEN`, `NOT_OPEN`, `NOT_IN_WORKSPACE`
+| `perforce.currentFile.depotPath`  | The depot path of the file (**only** provided if the file is open)
+| `perforce.currentFile.revision`   | The open revision of the file (**only** provided if the file is open)
+| `perforce.currentFile.changelist` | The changelist in which the file is open
+| `perforce.currentFile.operation`  | The perforce operation for the file, e.g. `edit`, `move/add`
+| `perforce.currentFile.filetype`   | The perforce file type of the file, e.g. `text`
 
 ## Common Questions
 

--- a/src/ContextVars.ts
+++ b/src/ContextVars.ts
@@ -1,0 +1,68 @@
+import { Display, ActiveStatusEvent } from "./Display";
+import * as vscode from "vscode";
+
+const makeDefault = () => {
+    return {
+        status: "",
+        depotPath: "",
+        revision: "",
+        changelist: "",
+        operation: "",
+        filetype: "",
+        message: ""
+    };
+};
+
+type ContextVars = Record<keyof ReturnType<typeof makeDefault>, string>;
+
+export function initialize(subscriptions: vscode.Disposable[]) {
+    subscriptions.push(Display.onActiveFileStatusKnown(setContextVars));
+    subscriptions.push(Display.onActiveFileStatusCleared(clearContextVars));
+    subscriptions.push(...Object.keys(makeDefault()).map(registerContextVar));
+}
+
+function registerContextVar(name: string) {
+    return vscode.commands.registerCommand("perforce.currentFile." + name, () =>
+        getFileContext(name as keyof ContextVars)
+    );
+}
+
+let fileContext: ContextVars = makeDefault();
+
+function getFileContext(arg: keyof ContextVars) {
+    return fileContext[arg] ?? "";
+}
+
+function setContextVars(event: ActiveStatusEvent) {
+    fileContext = {
+        status: event.status.toString(),
+        depotPath: event.details?.depotPath ?? "",
+        revision: event.details?.revision ?? "",
+        changelist: event.details?.chnum ?? "",
+        operation: event.details?.operation ?? "",
+        filetype: event.details?.filetype ?? "",
+        message: event.details?.message ?? ""
+    };
+
+    Object.keys(fileContext).forEach(c => {
+        vscode.commands.executeCommand(
+            "setContext",
+            "perforce.currentFile." + c[0],
+            c[1]
+        );
+    });
+}
+
+function clearContextVars() {
+    vscode.commands.executeCommand("setContext", "perforce.currentFile.status", "");
+
+    fileContext = makeDefault();
+
+    Object.keys(fileContext).forEach(c => {
+        vscode.commands.executeCommand(
+            "setContext",
+            "perforce.currentFile." + c,
+            undefined
+        );
+    });
+}

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,6 +1,5 @@
 import { Event, Uri, workspace } from "vscode";
 import { PerforceService } from "./PerforceService";
-import { Display } from "./Display";
 
 import * as fs from "fs";
 
@@ -99,95 +98,5 @@ export namespace Utils {
         });
 
         return allArgs;
-    }
-
-    export interface CommandParams {
-        file?: Uri | string;
-        revision?: string;
-        prefixArgs?: string[];
-        gOpts?: string;
-        input?: string;
-        /**
-         * hides std-err from the status bar (not from the log output)
-         */
-        hideStdErr?: boolean;
-        /**
-         * When set to true, will not reject if stderr is present
-         */
-        stdErrIsOk?: boolean;
-    }
-
-    // Get a string containing the output of the command
-    export function runCommand(
-        resource: Uri,
-        command: string,
-        params: CommandParams
-    ): Promise<string> {
-        return new Promise((resolve, reject) => {
-            const {
-                file,
-                revision,
-                prefixArgs,
-                gOpts,
-                input,
-                hideStdErr,
-                stdErrIsOk
-            } = params;
-            const args = prefixArgs ?? [];
-
-            if (gOpts !== undefined) {
-                command = gOpts + " " + command;
-            }
-
-            const revisionString = revision ?? "";
-
-            if (file) {
-                let path = typeof file === "string" ? file : file.fsPath;
-                path = expansePath(path);
-
-                args.push(path + revisionString);
-            }
-
-            PerforceService.execute(
-                resource,
-                command,
-                (err, stdout, stderr) => {
-                    err && Display.showError(err.toString());
-                    if (stderr) {
-                        hideStdErr
-                            ? Display.channel.appendLine(stderr.toString())
-                            : Display.showError(stderr.toString());
-                    }
-                    if (err) {
-                        reject(err);
-                    } else if (stderr && !stdErrIsOk) {
-                        reject(stderr);
-                    } else {
-                        resolve(stdout);
-                    }
-                },
-                args,
-                input
-            );
-        });
-    }
-
-    // Get a string containing the output of the command specific to a file
-    export function runCommandForFile(
-        command: string,
-        file: Uri,
-        revision?: string,
-        prefixArgs?: string[],
-        gOpts?: string,
-        input?: string
-    ): Promise<string> {
-        const resource = file;
-        return runCommand(resource, command, {
-            file,
-            revision,
-            prefixArgs,
-            gOpts,
-            input
-        });
     }
 }

--- a/src/api/PerforceApi.ts
+++ b/src/api/PerforceApi.ts
@@ -212,32 +212,104 @@ export async function getFstatInfo(resource: vscode.Uri, options: FstatOptions) 
 
 //#endregion
 
-export type OpenedFileOptions = { chnum?: string };
+export type OpenedFileOptions = { chnum?: string; files?: PerforceFile[] };
 
-function parseOpenedOutput(output: string): string[] {
+export type OpenedFile = {
+    depotPath: string;
+    revision: string;
+    chnum: string;
+    operation: string;
+    filetype: string;
+    message: string;
+};
+
+export enum UnopenedFileReason {
+    NOT_OPENED,
+    NOT_IN_ROOT
+}
+
+export type UnopenedFile = {
+    filePath: string;
+    reason: UnopenedFileReason;
+    message: string;
+};
+
+function parseOpenFile(line: string): OpenedFile | undefined {
+    const matches = /(.+)#(\d+)\s-\s([\w\/]+)\s(default\schange|change\s\d+)\s\(([\w\+]+)\)/.exec(
+        line
+    );
+    if (matches) {
+        const [message, depotPath, revision, operation, chnumStr, filetype] = matches;
+        const chnum = chnumStr.startsWith("change") ? chnumStr.split(" ")[1] : "default";
+        return { depotPath, revision, operation, chnum, filetype, message };
+    }
+}
+
+function parseOpenedOutput(output: string): OpenedFile[] {
     // example:
     // //depot/testArea/stuff#1 - edit change 46 (text)
-    return output
-        .trim()
-        .split("\n")
-        .map(
-            line =>
-                /(.+)#(\d+)\s-\s([\w\/]+)\s(default\schange|change\s\d+)\s\(([\w\+]+)\)/.exec(
-                    line
-                )?.[1]
-        )
+    return splitIntoLines(output.trim())
+        .map(parseOpenFile)
         .filter(isTruthy);
 }
 
-const openedFlags = flagMapper<OpenedFileOptions>([["c", "chnum"]]);
+function parseUnopenFile(line: string): UnopenedFile | undefined {
+    // example:
+    // TestArea/newFile.txt - file(s) not opened on this client.
+    // or
+    // Path 'C:/Users/zogge\db.desc' is not under client's root 'c:\Users\zogge\Perforce\default'.
+    const matches = /(?:((.+)\s-\sfile\(s\)\snot\sopened.*)|(Path\s'(.+)'\sis\snot\sunder.*))/.exec(
+        line
+    );
 
-const opened = makeSimpleCommand(
-    "opened",
-    openedFlags,
-    fixedParams({ stdErrIsOk: true, hideStdErr: true }) // stderr when no files are opened
-);
+    if (matches) {
+        const [, unopenMessage, unopenPath, noRootMessage, noRootPath] = matches;
+        const message = unopenMessage || noRootMessage;
+        const filePath = unopenMessage ? unopenPath : noRootPath;
+        const reason = unopenMessage
+            ? UnopenedFileReason.NOT_OPENED
+            : UnopenedFileReason.NOT_IN_ROOT;
+        return { message, filePath, reason };
+    }
+}
 
-export const getOpenedFiles = asyncOuputHandler(opened, parseOpenedOutput);
+function parseOpenedErrors(output: string): UnopenedFile[] {
+    return splitIntoLines(output.trim())
+        .map(parseUnopenFile)
+        .filter(isTruthy);
+}
+
+const openedFlags = flagMapper<OpenedFileOptions>([["c", "chnum"]], "files");
+
+const opened = makeSimpleCommand("opened", openedFlags);
+
+/**
+ * Gets opened files, and if files are specified in the options, the files that are not opened or are out of worksapce from that list
+ * @param resource the resource to determine where / how to run the command
+ * @param options options for the command
+ */
+export async function getOpenedFiles(resource: vscode.Uri, options: OpenedFileOptions) {
+    const output = await opened(resource, options, {
+        stdErrIsOk: true,
+        hideStdErr: true
+    });
+    return parseOpenedOutput(output);
+}
+
+export type OpenedFileDetails = {
+    open: OpenedFile[];
+    unopen: UnopenedFile[];
+};
+
+export async function getOpenedFileDetails(
+    resource: vscode.Uri,
+    options: OpenedFileOptions
+): Promise<OpenedFileDetails> {
+    const [stdout, stderr] = await opened.raw(resource, options);
+    const open = parseOpenedOutput(stdout);
+    const unopen = parseOpenedErrors(stderr);
+    return { open, unopen };
+}
 
 export type SubmitChangelistOptions = {
     chnum?: string;

--- a/src/api/PerforceApi.ts
+++ b/src/api/PerforceApi.ts
@@ -284,7 +284,7 @@ const openedFlags = flagMapper<OpenedFileOptions>([["c", "chnum"]], "files");
 const opened = makeSimpleCommand("opened", openedFlags);
 
 /**
- * Gets opened files, and if files are specified in the options, the files that are not opened or are out of worksapce from that list
+ * Gets opened files, ignoring error messages about unopened or out of workspace files
  * @param resource the resource to determine where / how to run the command
  * @param options options for the command
  */
@@ -301,6 +301,11 @@ export type OpenedFileDetails = {
     unopen: UnopenedFile[];
 };
 
+/**
+ * Gets opened files, and if files are specified in the options, the files that are not opened or are out of workspace from that list
+ * @param resource the resource to determine where / how to run the command
+ * @param options options for the command
+ */
 export async function getOpenedFileDetails(
     resource: vscode.Uri,
     options: OpenedFileOptions

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import * as Ini from "ini";
 import { Disposable } from "vscode";
 import { WorkspaceConfigAccessor } from "./ConfigService";
 import { AnnotationProvider } from "./annotations/AnnotationProvider";
+import * as ContextVars from "./ContextVars";
 
 let _isRegistered = false;
 const _disposable: vscode.Disposable[] = [];
@@ -260,6 +261,7 @@ function doOneTimeRegistration() {
         );
 
         Display.initialize(_disposable);
+        ContextVars.initialize(_disposable);
 
         _perforceContentProvider = new PerforceContentProvider();
         _disposable.push(_perforceContentProvider);

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -1071,6 +1071,8 @@ export class Model implements Disposable {
     }
 
     private async getDepotOpenedFilePaths(): Promise<string[]> {
-        return await p4.getOpenedFiles(this._workspaceUri, {});
+        return (await p4.getOpenedFiles(this._workspaceUri, {})).map(
+            file => file.depotPath
+        );
     }
 }

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -1542,7 +1542,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                         "a.txt#4 vs a.txt (workspace)"
                     );
                     expect(items.execute).to.be.calledWithMatch(
-                        file.localFile,
+                        { fsPath: file.localFile.fsPath },
                         "print",
                         sinon.match.any,
                         ["-q", file.localFile.fsPath + "#4"]
@@ -1570,7 +1570,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                         "a.txt#4 vs a.txt"
                     );
                     expect(items.execute).to.be.calledWithMatch(
-                        file1.localFile,
+                        { fsPath: file1.localFile.fsPath },
                         "print",
                         sinon.match.any,
                         ["-q", file1.localFile.fsPath + "#4"]
@@ -1676,7 +1676,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     );
 
                     expect(items.execute).to.be.calledWithMatch(
-                        file.localFile,
+                        { fsPath: file.localFile.fsPath },
                         "print",
                         sinon.match.any,
                         ["-q", file.localFile.fsPath + "#7"]
@@ -1745,7 +1745,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                         "a.txt@=1 vs a.txt (workspace)"
                     );
                     expect(items.execute).to.be.calledWithMatch(
-                        file.localFile,
+                        { fsPath: file.localFile.fsPath },
                         "print",
                         sinon.match.any,
                         ["-q", file.localFile.fsPath + "@=1"]


### PR DESCRIPTION
Changed Display from runnng `opened` directly, to using an api call to get opened files

This required the ability to parse stderr to determine the details of not open files

Added a `raw` method to the `makeSimpleCommand` return value to support this

Removed Utils.runCommand and changed the remaining call in the ContentProvider