### PR TITLE
Add edit and save command

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,6 +248,11 @@
                 "category": "Perforce"
             },
             {
+                "command": "perforce.editAndSave",
+                "title": "Edit and Save - Open the current file for edit, and then save it",
+                "category": "Perforce"
+            },
+            {
                 "command": "perforce.delete",
                 "title": "Delete - Delete the current file",
                 "category": "Perforce"

--- a/src/ContextVars.ts
+++ b/src/ContextVars.ts
@@ -44,7 +44,7 @@ function setContextVars(event: ActiveStatusEvent) {
         message: event.details?.message ?? ""
     };
 
-    Object.keys(fileContext).forEach(c => {
+    Object.entries(fileContext).forEach(c => {
         vscode.commands.executeCommand(
             "setContext",
             "perforce.currentFile." + c[0],

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -1,6 +1,14 @@
 "use strict";
 
-import { commands, workspace, window, Uri, QuickPickItem, Disposable } from "vscode";
+import {
+    commands,
+    workspace,
+    window,
+    Uri,
+    QuickPickItem,
+    Disposable,
+    ProgressLocation
+} from "vscode";
 
 import * as Path from "path";
 
@@ -88,7 +96,13 @@ export namespace PerforceCommands {
             await commands.executeCommand("workbench.action.files.save");
         } else {
             try {
-                await p4edit(activeFile.uri);
+                await window.withProgress(
+                    {
+                        location: ProgressLocation.Notification,
+                        title: "Perforce: Opening file for edit"
+                    },
+                    () => p4edit(activeFile.uri)
+                );
             } catch (err) {
                 // ensure save always happens even if something goes wrong
                 Display.showError(err);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -225,6 +225,9 @@ function TryCreateP4(uri: vscode.Uri): Promise<boolean> {
 }
 
 export function activate(ctx: vscode.ExtensionContext): void {
+    // ALWAYS register the edit and save command
+    PerforceCommands.registerImportantCommands(_disposable);
+
     if (vscode.workspace.getConfiguration("perforce").get("activationMode") === "off") {
         return;
     }


### PR DESCRIPTION
Adds a command that edits and saves the currently opened file.
Will fall back to the standard save command if there is no open editor (not sure that it *does* anything, but it will run it!)
Will always save the file even if the edit command fails
The command is always registered, in case of a workspace where activation mode is set to never

Also fixes an issue where recently added context variables didn't work!

fixes #72