### PR TITLE
Diff next and previous

### DIFF
--- a/package.json
+++ b/package.json
@@ -281,13 +281,15 @@
                 "command": "perforce.diffPrevious",
                 "title": "Diff against the previous revision",
                 "icon": "$(arrow-left)",
-                "category": "Perforce"
+                "category": "Perforce",
+                "enablement": "perforce.currentFile.canDiffPrev"
             },
             {
                 "command": "perforce.diffNext",
                 "title": "Diff against the next revision",
                 "icon": "$(arrow-right)",
-                "category": "Perforce"
+                "category": "Perforce",
+                "enablement": "perforce.currentFile.canDiffNext"
             },
             {
                 "command": "perforce.annotate",
@@ -768,12 +770,12 @@
                 {
                     "command": "perforce.diffPrevious",
                     "group": "navigation@-10",
-                    "when": "perforce.currentFile.isDiffable" 
+                    "when": "perforce.currentFile.showDiffPrev"
                 },
                 {
                     "command": "perforce.diffNext",
                     "group": "navigation@-9",
-                    "when": "perforce.currentFile.isDiffable" 
+                    "when": "perforce.currentFile.showDiffNext"
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -278,6 +278,18 @@
                 "category": "Perforce"
             },
             {
+                "command": "perforce.diffPrevious",
+                "title": "Diff against the previous revision",
+                "icon": "$(arrow-left)",
+                "category": "Perforce"
+            },
+            {
+                "command": "perforce.diffNext",
+                "title": "Diff against the next revision",
+                "icon": "$(arrow-right)",
+                "category": "Perforce"
+            },
+            {
                 "command": "perforce.annotate",
                 "title": "Annotate - Print file lines and their revisions in the gutter",
                 "category": "Perforce"
@@ -750,6 +762,16 @@
                     "command": "perforce.deleteShelvedFile",
                     "when": "scmProvider == perforce",
                     "group": "2_shelve@2"
+                }
+            ],
+            "editor/title": [
+                {
+                    "command": "perforce.diffPrevious",
+                    "group": "navigation@-10"
+                },
+                {
+                    "command": "perforce.diffNext",
+                    "group": "navigation@-9"
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -767,11 +767,13 @@
             "editor/title": [
                 {
                     "command": "perforce.diffPrevious",
-                    "group": "navigation@-10"
+                    "group": "navigation@-10",
+                    "when": "perforce.currentFile.isDiffable" 
                 },
                 {
                     "command": "perforce.diffNext",
-                    "group": "navigation@-9"
+                    "group": "navigation@-9",
+                    "when": "perforce.currentFile.isDiffable" 
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -213,6 +213,16 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Whether to prompt for confirmation, before submitting a saved changelist"
+                },
+                "perforce.editorButtons.diffPrevAndNext": {
+                    "type": "string",
+                    "enum": [
+                        "All diffable files",
+                        "Only on diffs",
+                        "Never"
+                    ],
+                    "default": "All diffable files",
+                    "description": "When to show buttons on the editor title menu for diffing the next / previous revision"
                 }
             }
         },
@@ -770,11 +780,21 @@
                 {
                     "command": "perforce.diffPrevious",
                     "group": "navigation@-10",
-                    "when": "perforce.currentFile.showDiffPrev"
+                    "when": "perforce.currentFile.showDiffPrev && config.perforce.editorButtons.diffPrevAndNext =~ /All/ || perforce.currentFile.showDiffPrev && config.perforce.editorButtons.diffPrevAndNext =~ /Only/ && perforce.currentFile.isPerforceOrDiff"
                 },
                 {
                     "command": "perforce.diffNext",
                     "group": "navigation@-9",
+                    "when": "perforce.currentFile.showDiffNext && config.perforce.editorButtons.diffPrevAndNext =~ /All/ || perforce.currentFile.showDiffPrev && config.perforce.editorButtons.diffPrevAndNext =~ /Only/ && perforce.currentFile.isPerforceOrDiff"
+                },
+                {
+                    "command": "perforce.diffPrevious",
+                    "group": "perforce@1",
+                    "when": "perforce.currentFile.showDiffPrev"
+                },
+                {
+                    "command": "perforce.diffNext",
+                    "group": "perforce@2",
                     "when": "perforce.currentFile.showDiffNext"
                 }
             ]

--- a/src/ContextVars.ts
+++ b/src/ContextVars.ts
@@ -14,7 +14,8 @@ const makeDefault = () => {
         showDiffPrev: false,
         showDiffNext: false,
         canDiffPrev: false,
-        canDiffNext: false
+        canDiffNext: false,
+        isPerforceOrDiff: false
     };
 };
 
@@ -61,6 +62,8 @@ function calculateDiffOptions(file?: vscode.Uri, status?: ActiveEditorStatus) {
     const isRightWindow = isRightDiffWindow(file);
     // show diff buttons for all perforce files, all diff windows and anything that is NOT 'not in workspace'
 
+    const isPerforceOrDiff = isRightWindow || isPerforceDoc(file);
+
     const isNotUnknown =
         status === ActiveEditorStatus.NOT_OPEN || status === ActiveEditorStatus.OPEN;
     const showDiffPrev =
@@ -79,7 +82,8 @@ function calculateDiffOptions(file?: vscode.Uri, status?: ActiveEditorStatus) {
         showDiffNext,
         showDiffPrev,
         canDiffNext: !disableDiffNext,
-        canDiffPrev: !disableDiffPrev
+        canDiffPrev: !disableDiffPrev,
+        isPerforceOrDiff
     };
 }
 

--- a/src/ContextVars.ts
+++ b/src/ContextVars.ts
@@ -66,8 +66,7 @@ function calculateDiffOptions(file?: vscode.Uri, status?: ActiveEditorStatus) {
 
     const isNotUnknown =
         status === ActiveEditorStatus.NOT_OPEN || status === ActiveEditorStatus.OPEN;
-    const showDiffPrev =
-        isNotUnknown || isPerforceDoc(file) || isRightDiffWindow(file) || isNotUnknown;
+    const showDiffPrev = isNotUnknown || isPerforceOrDiff;
 
     const rev = getRevision(file);
 

--- a/src/DiffProvider.ts
+++ b/src/DiffProvider.ts
@@ -44,7 +44,7 @@ function diffTitleForFiles(leftFile: Uri, rightFile: Uri) {
             leftFile.fragment +
             " ⟷ " +
             Path.basename(rightFile.fsPath) +
-            (rightFile.fragment ? "#" + rightFile.fragment : " (working)")
+            (rightFile.fragment ? "#" + rightFile.fragment : " (workspace)")
         );
     }
     const leftPath = PerforceUri.getDepotPathFromDepotUri(leftFile);
@@ -210,13 +210,13 @@ function getTitle(resource: Resource, leftTitle: string, diffType: DiffType): st
     let text = "";
     switch (diffType) {
         case DiffType.SHELVE_V_DEPOT:
-            text = leftTitle + " vs " + basename + "@=" + resource.change;
+            text = leftTitle + " ⟷ " + basename + "@=" + resource.change;
             break;
         case DiffType.WORKSPACE_V_SHELVE:
-            text = leftTitle + " vs " + basename + " (workspace)";
+            text = leftTitle + " ⟷ " + basename + " (workspace)";
             break;
         case DiffType.WORKSPACE_V_DEPOT:
-            text = leftTitle + " vs " + basename + " (workspace)";
+            text = leftTitle + " ⟷ " + basename + " (workspace)";
     }
     return text;
 }

--- a/src/DiffProvider.ts
+++ b/src/DiffProvider.ts
@@ -35,7 +35,14 @@ export function diffTitleForDepotPaths(
     rightRevision: string
 ) {
     const [leftTitle, rightTitle] = getPathsWithoutCommonPrefix(leftPath, rightPath);
-    return leftTitle + "#" + leftRevision + " ⟷ " + rightTitle + "#" + rightRevision;
+    return (
+        leftTitle +
+        "#" +
+        leftRevision +
+        " ⟷ " +
+        rightTitle +
+        (rightRevision ? "#" + rightRevision : "")
+    );
 }
 
 function diffTitleForFiles(leftFile: Uri, rightFile: Uri) {
@@ -159,7 +166,7 @@ export async function diffPrevious(fromDoc: Uri) {
         if (isNaN(rev)) {
             await diffPreviousFromWorking(fromDoc);
         } else {
-            await diffPreviousFrom(getPreviousUri(fromDoc));
+            await diffPreviousFrom(fromDoc);
         }
     }
 }

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -38,7 +38,7 @@ export namespace Display {
         _onActiveFileStatusCleared.fire(window.activeTextEditor?.document.uri);
         if (_statusBarItem) {
             _statusBarItem.show();
-            _statusBarItem.text = "P4: $(sync)";
+            _statusBarItem.text = "P4: $(sync~spin)";
             _statusBarItem.tooltip = "Checking file status";
         }
     });

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -30,12 +30,12 @@ export namespace Display {
 
     const _onActiveFileStatusKnown = new EventEmitter<ActiveStatusEvent>();
     export const onActiveFileStatusKnown = _onActiveFileStatusKnown.event;
-    const _onActiveFileStatusCleared = new EventEmitter<void>();
+    const _onActiveFileStatusCleared = new EventEmitter<Uri | undefined>();
     export const onActiveFileStatusCleared = _onActiveFileStatusCleared.event;
     let _initialisedChannel = false;
 
     export const updateEditor = debounce(updateEditorImpl, 1000, () => {
-        _onActiveFileStatusCleared.fire();
+        _onActiveFileStatusCleared.fire(window.activeTextEditor?.document.uri);
         if (_statusBarItem) {
             _statusBarItem.show();
             _statusBarItem.text = "P4: $(sync)";

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -102,6 +102,10 @@ export namespace Display {
                     active = inRoot
                         ? ActiveEditorStatus.NOT_OPEN
                         : ActiveEditorStatus.NOT_IN_WORKSPACE;
+                } else {
+                    _statusBarItem.text = "P4: $(circle-slash)";
+                    _statusBarItem.tooltip = "unknown";
+                    active = ActiveEditorStatus.NOT_IN_WORKSPACE;
                 }
             } catch (err) {
                 // file not under client root

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -31,6 +31,8 @@ export namespace PerforceCommands {
         commands.registerCommand("perforce.submitSingle", submitSingle);
         commands.registerCommand("perforce.diff", diff);
         commands.registerCommand("perforce.diffRevision", diffRevision);
+        commands.registerCommand("perforce.diffPrevious", diffPrevious);
+        commands.registerCommand("perforce.diffNext", diffNext);
         commands.registerCommand("perforce.annotate", annotate);
         commands.registerCommand("perforce.opened", opened);
         commands.registerCommand("perforce.logout", logout);
@@ -244,12 +246,13 @@ export namespace PerforceCommands {
             const depotUri = Utils.makePerforceDocUri(doc.uri, "print", "-q").with({
                 fragment: revStr
             });
+            const rightUri = doc.uri.with({ fragment: "working" });
 
             const fn = Path.basename(doc.uri.fsPath);
             await commands.executeCommand(
                 "vscode.diff",
                 depotUri,
-                doc.uri,
+                rightUri,
                 fn + "#" + revStr + " vs " + fn + " (workspace)"
             );
         }
@@ -309,6 +312,14 @@ export namespace PerforceCommands {
             },
             args
         );
+    }
+
+    function diffPrevious(...args: any[]) {
+        console.log(args);
+    }
+
+    function diffNext(...args: any[]) {
+        console.log(args);
     }
 
     async function diffFiles(leftFile: string, rightFile: string) {

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -373,7 +373,14 @@ export namespace PerforceCommands {
         return diffPreviousFrom(rightUri);
     }
 
-    async function diffPrevious(fromDoc: Uri) {
+    async function diffPrevious(fromDoc?: Uri) {
+        if (!fromDoc) {
+            fromDoc = window.activeTextEditor?.document.uri;
+        }
+        if (!fromDoc) {
+            Display.showError("No file to diff");
+            return false;
+        }
         const usingLeftInfo = diffPreviousUsingLeftInfo(fromDoc);
         if (usingLeftInfo) {
             await usingLeftInfo;
@@ -387,7 +394,14 @@ export namespace PerforceCommands {
         }
     }
 
-    async function diffNext(fromDoc: Uri) {
+    async function diffNext(fromDoc?: Uri) {
+        if (!fromDoc) {
+            fromDoc = window.activeTextEditor?.document.uri;
+        }
+        if (!fromDoc) {
+            Display.showError("No file to diff");
+            return false;
+        }
         const rev = parseInt(fromDoc.fragment);
         if (isNaN(rev)) {
             Display.showImportantError("No more revisions available");

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -362,7 +362,6 @@ export namespace PerforceCommands {
     }
 
     async function diffNext(fromDoc: Uri) {
-        console.log(fromDoc);
         const rev = parseInt(fromDoc.fragment);
         if (isNaN(rev)) {
             Display.showImportantError("No more revisions available");

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -1,6 +1,7 @@
 import { workspace, Uri } from "vscode";
 
 import { Utils } from "./Utils";
+import * as PerforceUri from "./PerforceUri";
 import { Display } from "./Display";
 import { PerforceSCMProvider } from "./ScmProvider";
 
@@ -209,16 +210,6 @@ export namespace PerforceService {
         });
     }
 
-    function getWorkingDirFromPerforceUri(resource: Uri) {
-        if (resource.scheme === "perforce") {
-            // if the open file is in perforce, we hopefully have the workspace path
-            const decoded = Utils.decodeUriQuery(resource.query).workspace;
-            if (decoded && typeof decoded === "string") {
-                return Uri.file(decoded);
-            }
-        }
-    }
-
     function execCommand(
         resource: Uri,
         command: string,
@@ -226,7 +217,7 @@ export namespace PerforceService {
         args?: string[],
         input?: string
     ): void {
-        const actualResource = getWorkingDirFromPerforceUri(resource) ?? resource;
+        const actualResource = PerforceUri.getUsableWorkspace(resource) ?? resource;
         const wksFolder = workspace.getWorkspaceFolder(actualResource);
         const config = wksFolder ? getConfig(wksFolder.uri.fsPath) : null;
         const wksPath = wksFolder?.uri.fsPath;

--- a/src/PerforceUri.ts
+++ b/src/PerforceUri.ts
@@ -1,0 +1,140 @@
+import * as vscode from "vscode";
+
+export type UriArguments = {
+    workspace?: string;
+    depot?: boolean;
+    command?: string;
+    p4Args?: string;
+    leftUri?: string;
+};
+
+type AnyUriArguments = {
+    [key: string]: string | boolean | undefined;
+};
+
+export function getDepotPathFromDepotUri(uri: vscode.Uri): string {
+    return "//" + uri.authority + uri.path;
+}
+
+function encodeParam(param: string, value?: string | boolean) {
+    if (value !== undefined && typeof value === "string") {
+        return encodeURIComponent(param) + "=" + encodeURIComponent(value);
+    } else if (value === undefined || value) {
+        return encodeURIComponent(param);
+    }
+}
+
+/*
+export function fromFsOrDepotPath(
+    workspace: vscode.Uri,
+    fsOrDepotPath: string,
+    revision: string | undefined,
+    isDepotPath: boolean
+) {
+    return isDepotPath ? fromDepotPath(workspace, fsOrDepotPath, revision) : fromUr;
+}
+*/
+
+export function fromDepotPath(
+    workspace: vscode.Uri,
+    depotPath: string,
+    revisionOrAtLabel: string | undefined
+) {
+    const baseUri = vscode.Uri.parse("perforce:" + depotPath).with({
+        fragment: revisionOrAtLabel
+    });
+    return fromUri(baseUri, {
+        depot: true,
+        workspace: workspace.fsPath
+    });
+}
+
+function hasTruthyArg(uri: vscode.Uri, arg: keyof UriArguments): boolean {
+    return !!decodeUriQuery(uri.query)[arg];
+}
+
+export function isDepotUri(uri: vscode.Uri): boolean {
+    return hasTruthyArg(uri, "depot");
+}
+
+export function isUsableForWorkspace(uri: vscode.Uri): boolean {
+    return (!isDepotUri(uri) && !!uri.fsPath) || hasTruthyArg(uri, "workspace");
+}
+
+export function getWorkspaceFromQuery(uri: vscode.Uri) {
+    const ws = decodeUriQuery(uri.query).workspace;
+    return ws ? vscode.Uri.file(ws) : undefined;
+}
+
+export function getUsableWorkspace(uri: vscode.Uri) {
+    return !isDepotUri(uri) && !!uri.fsPath
+        ? vscode.Uri.file(uri.fsPath)
+        : getWorkspaceFromQuery(uri);
+}
+
+export function forCommand(resource: vscode.Uri, command: string, p4Args: string) {
+    return fromUri(vscode.Uri.parse("perforce:"), {
+        command: command,
+        p4Args: p4Args,
+        workspace: resource.fsPath
+    });
+}
+
+export function fromUri(uri: vscode.Uri, otherArgs?: UriArguments) {
+    const defaultArgs = {
+        command: "print",
+        p4Args: "-q"
+    };
+    return uri.with({
+        scheme: "perforce",
+        query: encodeQuery({
+            ...defaultArgs,
+            ...decodeUriQuery(uri.query), // use existing params
+            ...otherArgs
+        })
+    });
+}
+
+export function fromUriWithWorkspace(workspace: vscode.Uri, uri: vscode.Uri) {
+    return fromUri(uri, { workspace: workspace.fsPath });
+}
+
+export function fromUriWithRevision(perforceUri: vscode.Uri, revisionOrAtLabel: string) {
+    return fromUri(perforceUri.with({ fragment: revisionOrAtLabel }));
+}
+
+/**
+ * Add the supplied arguments to a perforce uri - replacing any that are specified in both objects
+ * @param uri the uri to add args to
+ * @param args the arguments to add
+ */
+export function withArgs(uri: vscode.Uri, args: UriArguments) {
+    const curArgs = decodeUriQuery(uri.query);
+    const newQuery = encodeQuery({
+        ...curArgs,
+        ...args
+    });
+    return uri.with({ query: newQuery });
+}
+
+export function encodeQuery(args: UriArguments) {
+    return Object.entries(args)
+        .filter(arg => arg[1] !== false)
+        .map(arg => encodeParam(arg[0], arg[1]))
+        .filter(arg => !!arg)
+        .join("&");
+}
+
+export function decodeUriQuery(query: string): UriArguments {
+    const argArr = query?.split("&") ?? [];
+    const allArgs: AnyUriArguments = {};
+    argArr.forEach(arg => {
+        const parts = arg.split("=");
+        const name = decodeURIComponent(parts[0]);
+        const value = parts[1] ? decodeURIComponent(parts[1]) : true;
+        allArgs[name as keyof AnyUriArguments] = value;
+    });
+
+    // a bit of a hack - could violate the type e.g. if allArgs has a bool for a string type
+    return allArgs as UriArguments;
+}

--- a/src/PerforceUri.ts
+++ b/src/PerforceUri.ts
@@ -95,10 +95,6 @@ export function fromUri(uri: vscode.Uri, otherArgs?: UriArguments) {
     });
 }
 
-export function fromUriWithWorkspace(workspace: vscode.Uri, uri: vscode.Uri) {
-    return fromUri(uri, { workspace: workspace.fsPath });
-}
-
 export function fromUriWithRevision(perforceUri: vscode.Uri, revisionOrAtLabel: string) {
     return fromUri(perforceUri.with({ fragment: revisionOrAtLabel }));
 }

--- a/src/PerforceUri.ts
+++ b/src/PerforceUri.ts
@@ -6,6 +6,8 @@ export type UriArguments = {
     command?: string;
     p4Args?: string;
     leftUri?: string;
+    haveRev?: string;
+    diffStartFile?: string;
 };
 
 type AnyUriArguments = {

--- a/src/PerforceUri.ts
+++ b/src/PerforceUri.ts
@@ -106,13 +106,19 @@ export function fromUriWithRevision(perforceUri: vscode.Uri, revisionOrAtLabel: 
  * @param uri the uri to add args to
  * @param args the arguments to add
  */
-export function withArgs(uri: vscode.Uri, args: UriArguments) {
+export function withArgs(
+    uri: vscode.Uri,
+    args: UriArguments,
+    revisionOrAtLabel?: string
+) {
     const curArgs = decodeUriQuery(uri.query);
     const newQuery = encodeQuery({
         ...curArgs,
         ...args
     });
-    return uri.with({ query: newQuery });
+    return revisionOrAtLabel !== undefined
+        ? uri.with({ query: newQuery, fragment: revisionOrAtLabel })
+        : uri.with({ query: newQuery });
 }
 
 export function encodeQuery(args: UriArguments) {

--- a/src/PerforceUri.ts
+++ b/src/PerforceUri.ts
@@ -119,7 +119,7 @@ export function withArgs(uri: vscode.Uri, args: UriArguments) {
 
 export function encodeQuery(args: UriArguments) {
     return Object.entries(args)
-        .filter(arg => arg[1] !== false)
+        .filter(arg => !!arg[1])
         .map(arg => encodeParam(arg[0], arg[1]))
         .filter(arg => !!arg)
         .join("&");

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,4 +1,4 @@
-import { Event, Uri, workspace } from "vscode";
+import { Event, workspace } from "vscode";
 import { PerforceService } from "./PerforceService";
 
 import * as fs from "fs";
@@ -7,10 +7,6 @@ export function mapEvent<I, O>(event: Event<I>, map: (i: I) => O): Event<O> {
     return (listener, thisArgs = null, disposables?) =>
         event(i => listener.call(thisArgs, map(i)), null, disposables);
 }
-
-export type UriArguments = {
-    [key: string]: string | boolean;
-};
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Utils {
@@ -41,62 +37,5 @@ export namespace Utils {
             .replace(/@/g, "%40");
         const relativeToRoot = PerforceService.convertToRel(fixup);
         return relativeToRoot;
-    }
-
-    export function getDepotPathFromDepotUri(uri: Uri): string {
-        return "//" + uri.authority + uri.path;
-    }
-
-    function encodeParam(param: string, value?: any) {
-        if (value !== undefined && typeof value === "string") {
-            return encodeURIComponent(param) + "=" + encodeURIComponent(value);
-        } else if (value === undefined || value) {
-            return encodeURIComponent(param);
-        }
-    }
-
-    export function makePerforceDocUri(
-        uri: Uri,
-        command: string,
-        p4Args?: string,
-        otherArgs?: { [key: string]: string | boolean }
-    ) {
-        return uri.with({
-            scheme: "perforce",
-            query: makePerforceUriQuery(command, p4Args ?? "", {
-                ...Utils.decodeUriQuery(uri.query), // use existing params
-                ...otherArgs
-            })
-        });
-    }
-
-    export function makePerforceUriQuery(
-        command: string,
-        p4Args: string,
-        otherArgs?: { [key: string]: string | boolean }
-    ) {
-        const allArgs = [encodeParam("p4args", p4Args), encodeParam("command", command)];
-        if (otherArgs) {
-            allArgs.push(
-                ...Object.keys(otherArgs)
-                    .filter(key => otherArgs[key] !== false)
-                    .map(key => encodeParam(key, otherArgs[key]))
-                    .filter(param => !!param)
-            );
-        }
-        return allArgs.join("&");
-    }
-
-    export function decodeUriQuery(query: string) {
-        const argArr = query?.split("&") ?? [];
-        const allArgs: UriArguments = {};
-        argArr.forEach(arg => {
-            const parts = arg.split("=");
-            const name = decodeURIComponent(parts[0]);
-            const value = parts[1] ? decodeURIComponent(parts[1]) : true;
-            allArgs[name] = value;
-        });
-
-        return allArgs;
     }
 }

--- a/src/annotations/MarkdownGenerator.ts
+++ b/src/annotations/MarkdownGenerator.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as p4 from "../api/PerforceApi";
 
-import { Utils } from "../Utils";
+import * as PerforceUri from "../PerforceUri";
 import * as DiffProvider from "../DiffProvider";
 import { isTruthy } from "../api/CommandUtils";
 
@@ -37,13 +37,7 @@ export function makeDiffURI(
 }
 
 function makePerforceURI(underlying: vscode.Uri, change: p4.FileLogItem) {
-    const baseUri = vscode.Uri.parse("perforce:" + change.file).with({
-        fragment: change.revision
-    });
-    return Utils.makePerforceDocUri(baseUri, "print", "-q", {
-        depot: true,
-        workspace: underlying.fsPath
-    });
+    return PerforceUri.fromDepotPath(underlying, change.file, change.revision);
 }
 
 export function makeAnnotateURI(underlying: vscode.Uri, change: p4.FileLogItem) {

--- a/src/api/CommandUtils.ts
+++ b/src/api/CommandUtils.ts
@@ -1,6 +1,7 @@
 import { Utils } from "../Utils";
 import { FileSpec, isFileSpec, PerforceFile, isUri } from "./CommonTypes";
 import * as vscode from "vscode";
+import * as PerforceUri from "../PerforceUri";
 import { PerforceService } from "../PerforceService";
 import { Display } from "../Display";
 
@@ -166,9 +167,9 @@ export function fragmentAsSuffix(
 }
 
 function fileSpecToArg(fileSpec: FileSpec, ignoreRevisionFragments?: boolean) {
-    if (isUri(fileSpec) && Utils.decodeUriQuery(fileSpec.query).depot) {
+    if (isUri(fileSpec) && PerforceUri.isDepotUri(fileSpec)) {
         return (
-            Utils.getDepotPathFromDepotUri(fileSpec) +
+            PerforceUri.getDepotPathFromDepotUri(fileSpec) +
             fragmentAsSuffix(fileSpec.fragment, ignoreRevisionFragments)
         );
     }

--- a/src/api/PerforceApi.ts
+++ b/src/api/PerforceApi.ts
@@ -96,7 +96,9 @@ export type ChangeSpecOptions = {
     existingChangelist?: string;
 };
 
-const changeFlags = flagMapper<ChangeSpecOptions>([], "existingChangelist", true, ["-o"]);
+const changeFlags = flagMapper<ChangeSpecOptions>([], "existingChangelist", ["-o"], {
+    lastArgIsFormattedArray: true
+});
 
 const outputChange = makeSimpleCommand("change", changeFlags);
 
@@ -278,7 +280,9 @@ function parseOpenedErrors(output: string): UnopenedFile[] {
         .filter(isTruthy);
 }
 
-const openedFlags = flagMapper<OpenedFileOptions>([["c", "chnum"]], "files");
+const openedFlags = flagMapper<OpenedFileOptions>([["c", "chnum"]], "files", [], {
+    ignoreRevisionFragments: true
+});
 
 const opened = makeSimpleCommand("opened", openedFlags);
 
@@ -494,7 +498,8 @@ const describeFlags = flagMapper<DescribeOptions>(
         ["s", "omitDiffs"]
     ],
     "chnums",
-    true
+    [],
+    { lastArgIsFormattedArray: true }
 );
 
 const describe = makeSimpleCommand("describe", describeFlags);
@@ -666,12 +671,10 @@ export interface FilelogOptions {
     followBranches?: boolean;
 }
 
-const filelogFlags = flagMapper<FilelogOptions>(
-    [["i", "followBranches"]],
-    "file",
-    false,
-    ["-l", "-t"]
-);
+const filelogFlags = flagMapper<FilelogOptions>([["i", "followBranches"]], "file", [
+    "-l",
+    "-t"
+]);
 
 const filelog = makeSimpleCommand("filelog", filelogFlags);
 
@@ -775,7 +778,6 @@ const annotateFlags = flagMapper<AnnotateOptions>(
         ["i", "followBranches"]
     ],
     "file",
-    false,
     ["-q"]
 );
 

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -13,6 +13,7 @@ import {
 } from "vscode";
 import { WorkspaceConfigAccessor } from "../ConfigService";
 import { Utils } from "../Utils";
+import * as PerforceUri from "../PerforceUri";
 import { Display, ActiveStatusEvent, ActiveEditorStatus } from "../Display";
 import { Resource } from "./Resource";
 
@@ -344,19 +345,14 @@ export class Model implements Disposable {
 
     public async Describe(input: ResourceGroup): Promise<void> {
         if (input.isDefault) {
-            const command = "change";
-            const args = "-o";
-            const uri: Uri = Uri.parse("perforce:").with({
-                query: Utils.makePerforceUriQuery(command, args)
-            });
+            const uri = PerforceUri.forCommand(input.model.workspaceUri, "change", "-o");
             await commands.executeCommand<void>("vscode.open", uri);
         } else {
-            const command = "describe";
-            const args = input.chnum;
-
-            const uri: Uri = Uri.parse("perforce:").with({
-                query: Utils.makePerforceUriQuery(command, args)
-            });
+            const uri = PerforceUri.forCommand(
+                input.model.workspaceUri,
+                "describe",
+                input.chnum
+            );
             await commands.executeCommand<void>("vscode.open", uri);
         }
     }
@@ -1028,7 +1024,11 @@ export class Model implements Disposable {
 
         const resource: Resource = new Resource(
             this,
-            Uri.file(fstatInfo.depotFile),
+            PerforceUri.fromDepotPath(
+                underlyingUri ?? this.workspaceUri,
+                fstatInfo.depotFile,
+                undefined
+            ),
             underlyingUri,
             chnum,
             true,

--- a/src/scm/Resource.ts
+++ b/src/scm/Resource.ts
@@ -9,7 +9,7 @@ import { DecorationProvider } from "./DecorationProvider";
 import { GetStatuses, Status } from "./Status";
 import { IFileType, GetFileType } from "./FileTypes";
 import { Model, FstatInfo } from "./Model";
-import { Utils } from "../Utils";
+import * as PerforceUri from "../PerforceUri";
 
 /**
  * An SCM resource represents a state of an underlying workspace resource
@@ -67,7 +67,7 @@ export class Resource implements SourceControlResourceState {
      * A string representation of the depot path - this is needed because, on windows, the fsPath turns into backslashes
      */
     get depotPath(): string {
-        return Utils.getDepotPathFromDepotUri(this._uri);
+        return PerforceUri.getDepotPathFromDepotUri(this._uri);
     }
     /**
      * The base file from which this file is pending integration - a depot path as a URI
@@ -120,9 +120,11 @@ export class Resource implements SourceControlResourceState {
         headType?: string
     ) {
         this._statuses = GetStatuses(action);
+        this._workingRevision = fstatInfo["workRev"] ?? fstatInfo["haveRev"] ?? "have"; // (files opened for branch probably have a workRev but no haveRev)
+
         if (this._isShelved) {
             // force a depot-like path as the resource URI, to sort them together in the tree
-            this._resourceUri = _uri;
+            this._resourceUri = PerforceUri.fromUriWithRevision(_uri, "@=" + this.change);
         } else {
             if (!_underlyingUri) {
                 throw new Error(
@@ -130,13 +132,17 @@ export class Resource implements SourceControlResourceState {
                 );
             }
             this._resourceUri = _underlyingUri;
-        }
-        if (fstatInfo["resolveFromFile0"]) {
-            this._fromFile = Uri.file(fstatInfo["resolveFromFile0"]);
+            // TODO - do we need the one with the working revision - can't use a perforce: scheme here as it should be a local file
+            //PerforceUri.fromUriWithRevision(_underlyingUri, this._workingRevision);
         }
         this._fromEndRev = fstatInfo["resolveEndFromRev0"];
-
-        this._workingRevision = fstatInfo["workRev"] ?? fstatInfo["haveRev"] ?? "have"; // (files opened for branch probably have a workRev but no haveRev)
+        if (fstatInfo["resolveFromFile0"]) {
+            this._fromFile = PerforceUri.fromDepotPath(
+                this._underlyingUri ?? model.workspaceUri,
+                fstatInfo["resolveFromFile0"],
+                this._fromEndRev
+            );
+        }
         this._headType = GetFileType(headType);
     }
 

--- a/src/test/helpers/helpers.d.ts
+++ b/src/test/helpers/helpers.d.ts
@@ -16,6 +16,7 @@ declare module "chai" {
                     }[]
                 ): void;
                 shelvedResources(
+                    change: { chnum: string },
                     expecteds: {
                         depotPath: string;
                         operation: import("../../scm/Status").Status;

--- a/src/test/helpers/p4Commands.ts
+++ b/src/test/helpers/p4Commands.ts
@@ -1,14 +1,17 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { SinonSpyCall } from "sinon";
 import * as vscode from "vscode";
 import { Resource } from "../../scm/Resource";
 import { Status } from "../../scm/Status";
+import * as PerforceUri from "../../PerforceUri";
 
 function assertP4UriMatches(
     Assertion: Chai.AssertionStatic,
-    got: vscode.Uri,
+    got: vscode.Uri | undefined,
     expected: vscode.Uri,
     message: string
 ) {
+    new Assertion(got, message).to.not.be.undefined;
     new Assertion(got).to.include(
         {
             scheme: expected.scheme,
@@ -18,7 +21,7 @@ function assertP4UriMatches(
         },
         message
     );
-    new Assertion(got.query).to.have.string(expected.query, message);
+    new Assertion(got!.query).to.have.string(expected.query, message);
 }
 
 function resourceToString(resource: Resource) {
@@ -27,11 +30,73 @@ function resourceToString(resource: Resource) {
             uri: resource.uri,
             depotPath: resource.depotPath,
             status: resource.status,
-            isShelved: resource.isShelved
+            isShelved: resource.isShelved,
+            resourceUri: resource.resourceUri?.toString(),
+            underlyingUri: resource.underlyingUri?.toString(),
+            fromFile: resource.fromFile?.toString()
         },
         undefined,
         2
     );
+}
+
+function assertCommonResourceFields(
+    Assertion: Chai.AssertionStatic,
+    resource: Resource,
+    i: number,
+    expected: {
+        depotPath: string;
+        depotRevision: number;
+        operation: Status;
+        localFile: vscode.Uri;
+        resolveFromDepotPath?: string;
+        resolveEndFromRev?: number;
+        suppressFstatClientFile?: boolean;
+    }
+) {
+    new Assertion(resource.depotPath).to.be.equal(
+        expected.depotPath,
+        "Unexpected depot path for resource " + i + " : " + resourceToString(resource)
+    );
+
+    new Assertion(
+        resource.fromEndRev,
+        "Resource " + i + " fromEndRev : " + resourceToString(resource)
+    ).to.equal(expected.resolveEndFromRev?.toString());
+    if (expected.resolveFromDepotPath) {
+        assertP4UriMatches(
+            Assertion,
+            resource.fromFile,
+            PerforceUri.fromDepotPath(
+                expected.localFile,
+                expected.resolveFromDepotPath,
+                expected.resolveEndFromRev?.toString()
+            ),
+            "Resource " + i + " fromFile URI : " + resourceToString(resource)
+        );
+    } else {
+        new Assertion(
+            resource.fromFile,
+            "Resource " + i + " should not have a fromFile " + resourceToString(resource)
+        ).to.be.undefined;
+    }
+    if (expected.suppressFstatClientFile) {
+        new Assertion(
+            resource.underlyingUri,
+            "Resource " + i + " should not have an underlying URI"
+        ).to.be.undefined;
+    } else {
+        assertP4UriMatches(
+            Assertion,
+            resource.underlyingUri,
+            expected.localFile,
+            "Resource " + i + " underlying URI : " + resourceToString(resource)
+        );
+    }
+    new Assertion(
+        resource.status,
+        "Resource " + i + " operation mismatch : " + resourceToString(resource)
+    ).to.equal(expected.operation);
 }
 
 export default function(chai: Chai.ChaiStatic, _utils: Chai.ChaiUtils) {
@@ -65,7 +130,14 @@ export default function(chai: Chai.ChaiStatic, _utils: Chai.ChaiUtils) {
 
     // TODO - this code is excessive - can be simplified - possibly with expect.to.include
     Assertion.addMethod("resources", function(
-        expecteds: { depotPath: string; operation: Status }[]
+        expecteds: {
+            depotPath: string;
+            depotRevision: number;
+            operation: Status;
+            localFile: vscode.Uri;
+            resolveFromDepotPath?: string;
+            resolveEndFromRev?: number;
+        }[]
     ) {
         const obj: Resource[] = this._obj as Resource[];
 
@@ -75,17 +147,16 @@ export default function(chai: Chai.ChaiStatic, _utils: Chai.ChaiUtils) {
         );
         expecteds.forEach((expected, i) => {
             const resource: Resource = obj[i];
-            new Assertion(resource.depotPath).to.be.equal(
-                expected.depotPath,
-                "Unexpected depot path for resource " +
-                    i +
-                    " : " +
-                    resourceToString(resource)
+
+            assertCommonResourceFields(Assertion, resource, i, expected);
+
+            assertP4UriMatches(
+                Assertion,
+                resource.resourceUri,
+                expected.localFile,
+                "Resource " + i + " resource URI : " + resourceToString(resource)
             );
-            new Assertion(
-                resource.status,
-                "Resource " + i + "operation mismatch : " + resourceToString(resource)
-            ).to.equal(expected.operation);
+
             new Assertion(
                 resource.isShelved,
                 "Resource " +
@@ -98,7 +169,17 @@ export default function(chai: Chai.ChaiStatic, _utils: Chai.ChaiUtils) {
     });
 
     Assertion.addMethod("shelvedResources", function(
-        expecteds: { depotPath: string; operation: Status }[]
+        change: {
+            chnum: string;
+        },
+        expecteds: {
+            depotPath: string;
+            depotRevision: number;
+            operation: Status;
+            localFile: vscode.Uri;
+            resolveFromDepotPath?: string;
+            resolveEndFromRev?: number;
+        }[]
     ) {
         const obj: Resource[] = this._obj as Resource[];
 
@@ -108,13 +189,17 @@ export default function(chai: Chai.ChaiStatic, _utils: Chai.ChaiUtils) {
         );
         expecteds.forEach((expected, i) => {
             const resource: Resource = obj[i];
-            new Assertion(resource.depotPath).to.be.equal(
-                expected.depotPath,
-                "Unexpected depot path for resource " +
-                    i +
-                    " : " +
-                    resourceToString(resource)
+            assertP4UriMatches(
+                Assertion,
+                resource.resourceUri,
+                PerforceUri.fromDepotPath(
+                    resource.model.workspaceUri,
+                    expected.depotPath,
+                    "@=" + change.chnum
+                ),
+                "Resource " + i + " resource URI : " + resourceToString(resource)
             );
+            assertCommonResourceFields(Assertion, resource, i, expected);
             new Assertion(
                 resource.status,
                 "Shelved resource " +

--- a/src/test/helpers/testUtils.ts
+++ b/src/test/helpers/testUtils.ts
@@ -68,9 +68,9 @@ export function perforceLocalUriMatcher(file: StubFile) {
     if (!file.localFile) {
         throw new Error("Can't make a local file matcher without a local file");
     }
-    return PerforceUri.fromUri(file.localFile, {
-        workspace: getWorkspaceUri().fsPath
-    }).with({ fragment: file.depotRevision.toString() });
+    return PerforceUri.fromUri(file.localFile).with({
+        fragment: file.depotRevision.toString()
+    });
 }
 
 /**
@@ -78,10 +78,11 @@ export function perforceLocalUriMatcher(file: StubFile) {
  * @param file
  */
 export function perforceDepotUriMatcher(file: StubFile) {
-    return PerforceUri.fromUri(vscode.Uri.parse("perforce:" + file.depotPath), {
-        depot: true,
-        workspace: getWorkspaceUri().fsPath
-    }).with({ fragment: file.depotRevision.toString() });
+    return PerforceUri.fromDepotPath(
+        file.localFile,
+        file.depotPath,
+        file.depotRevision.toString()
+    );
 }
 
 /**
@@ -89,10 +90,14 @@ export function perforceDepotUriMatcher(file: StubFile) {
  * @param file
  */
 export function perforceFromFileUriMatcher(file: StubFile) {
-    return PerforceUri.fromUri(
-        vscode.Uri.parse("perforce:" + file.resolveFromDepotPath),
-        { depot: true, workspace: getWorkspaceUri().fsPath }
-    ).with({ fragment: file.resolveEndFromRev?.toString() });
+    if (!file.resolveFromDepotPath) {
+        throw new Error("Must have a depot path to resolve from!");
+    }
+    return PerforceUri.fromDepotPath(
+        file.localFile,
+        file.resolveFromDepotPath,
+        file.resolveEndFromRev?.toString()
+    );
 }
 
 /**
@@ -113,7 +118,5 @@ export function perforceLocalShelvedUriMatcher(file: StubFile, chnum: string) {
     if (!file.localFile) {
         throw new Error("Can't make a local file matcher without a local file");
     }
-    return PerforceUri.fromUri(file.localFile.with({ fragment: "@=" + chnum }), {
-        workspace: getWorkspaceUri().fsPath
-    });
+    return PerforceUri.fromUri(file.localFile.with({ fragment: "@=" + chnum }));
 }

--- a/src/test/helpers/testUtils.ts
+++ b/src/test/helpers/testUtils.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import * as vscode from "vscode";
-import { Utils } from "../../Utils";
+import * as PerforceUri from "../../PerforceUri";
 import { Status } from "../../scm/Status";
 import { StubFile } from "./StubPerforceModel";
 
@@ -68,7 +68,7 @@ export function perforceLocalUriMatcher(file: StubFile) {
     if (!file.localFile) {
         throw new Error("Can't make a local file matcher without a local file");
     }
-    return Utils.makePerforceDocUri(file.localFile, "print", "-q", {
+    return PerforceUri.fromUri(file.localFile, {
         workspace: getWorkspaceUri().fsPath
     }).with({ fragment: file.depotRevision.toString() });
 }
@@ -78,12 +78,10 @@ export function perforceLocalUriMatcher(file: StubFile) {
  * @param file
  */
 export function perforceDepotUriMatcher(file: StubFile) {
-    return Utils.makePerforceDocUri(
-        vscode.Uri.parse("perforce:" + file.depotPath),
-        "print",
-        "-q",
-        { depot: true, workspace: getWorkspaceUri().fsPath }
-    ).with({ fragment: file.depotRevision.toString() });
+    return PerforceUri.fromUri(vscode.Uri.parse("perforce:" + file.depotPath), {
+        depot: true,
+        workspace: getWorkspaceUri().fsPath
+    }).with({ fragment: file.depotRevision.toString() });
 }
 
 /**
@@ -91,10 +89,8 @@ export function perforceDepotUriMatcher(file: StubFile) {
  * @param file
  */
 export function perforceFromFileUriMatcher(file: StubFile) {
-    return Utils.makePerforceDocUri(
+    return PerforceUri.fromUri(
         vscode.Uri.parse("perforce:" + file.resolveFromDepotPath),
-        "print",
-        "-q",
         { depot: true, workspace: getWorkspaceUri().fsPath }
     ).with({ fragment: file.resolveEndFromRev?.toString() });
 }
@@ -105,12 +101,10 @@ export function perforceFromFileUriMatcher(file: StubFile) {
  * @param chnum
  */
 export function perforceShelvedUriMatcher(file: StubFile, chnum: string) {
-    return Utils.makePerforceDocUri(
+    return PerforceUri.fromUri(
         vscode.Uri.parse("perforce:" + file.depotPath).with({
             fragment: "@=" + chnum
         }),
-        "print",
-        "-q",
         { depot: true, workspace: getWorkspaceUri().fsPath }
     );
 }
@@ -119,10 +113,7 @@ export function perforceLocalShelvedUriMatcher(file: StubFile, chnum: string) {
     if (!file.localFile) {
         throw new Error("Can't make a local file matcher without a local file");
     }
-    return Utils.makePerforceDocUri(
-        file.localFile.with({ fragment: "@=" + chnum }),
-        "print",
-        "-q",
-        { workspace: getWorkspaceUri().fsPath }
-    );
+    return PerforceUri.fromUri(file.localFile.with({ fragment: "@=" + chnum }), {
+        workspace: getWorkspaceUri().fsPath
+    });
 }

--- a/src/test/suite/diffProvider.test.ts
+++ b/src/test/suite/diffProvider.test.ts
@@ -1,0 +1,323 @@
+import { expect } from "chai";
+import * as chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import sinonChai from "sinon-chai";
+
+import * as vscode from "vscode";
+
+import sinon from "sinon";
+import * as PerforceUri from "../../PerforceUri";
+import { Status } from "../../scm/Status";
+import p4Commands from "../helpers/p4Commands";
+import { StubPerforceModel, StubFile } from "../helpers/StubPerforceModel";
+import * as DiffProvider from "../../DiffProvider";
+
+import { getLocalFile, getWorkspaceUri } from "../helpers/testUtils";
+import Sinon from "sinon";
+import { Display } from "../../Display";
+
+chai.use(sinonChai);
+chai.use(p4Commands);
+chai.use(chaiAsPromised);
+
+describe("Diff Provider", () => {
+    if (!vscode.workspace.workspaceFolders?.[0]) {
+        throw new Error("No workspace folders open");
+    }
+    const workspaceUri = getWorkspaceUri();
+
+    const basicFiles: { [key: string]: () => StubFile } = {
+        edit: () => {
+            return {
+                localFile: getLocalFile(workspaceUri, "testFolder", "a.txt"),
+                depotPath: "//depot/testArea/testFolder/a.txt",
+                depotRevision: 4,
+                operation: Status.EDIT
+            };
+        }
+    };
+
+    let showImportantError: Sinon.SinonSpy<any>;
+    let stubModel: StubPerforceModel;
+    let execCommand: Sinon.SinonStub<any>;
+    beforeEach(() => {
+        stubModel = new StubPerforceModel();
+        execCommand = sinon.stub(vscode.commands, "executeCommand");
+        showImportantError = sinon.stub(Display, "showImportantError");
+    });
+    afterEach(() => {
+        sinon.restore();
+    });
+    describe("diffTitleForDepotPaths", () => {
+        it("Returns a title showing the names and revisions for two paths", () => {
+            const path = "//depot/main/file1.txt";
+            const rev1 = "2";
+            const rev2 = "3";
+            expect(DiffProvider.diffTitleForDepotPaths(path, rev1, path, rev2)).to.equal(
+                "file1.txt#2 ⟷ file1.txt#3"
+            );
+        });
+        it("Includes all parts of the filename that are not common between the two", () => {
+            const path1 = "//depot/main/file1.txt";
+            const path2 = "//depot/branches/branch1/file1.txt";
+            const rev1 = "2";
+            const rev2 = "1";
+            expect(
+                DiffProvider.diffTitleForDepotPaths(path1, rev1, path2, rev2)
+            ).to.equal("main/file1.txt#2 ⟷ branches/branch1/file1.txt#1");
+        });
+    });
+    describe("diffFiles", () => {
+        it("Diffs the supplied URIs, adding information about the starting & left file", async () => {
+            const right = basicFiles.edit().localFile;
+            const left = PerforceUri.fromUriWithRevision(right, "2");
+
+            const expectedRight = PerforceUri.withArgs(right, {
+                leftUri: left.toString(),
+                diffStartFile: right.toString()
+            });
+
+            await DiffProvider.diffFiles(left, right);
+
+            expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                left,
+                expectedRight,
+                "a.txt#2 ⟷ a.txt"
+            );
+        });
+        it("Does not replace an existing starting file", async () => {
+            const localFile = basicFiles.edit().localFile;
+            const right = PerforceUri.withArgs(
+                PerforceUri.fromDepotPath(
+                    basicFiles.edit().localFile,
+                    basicFiles.edit().depotPath,
+                    "4"
+                ),
+                { diffStartFile: localFile.toString() }
+            );
+            const left = PerforceUri.fromUriWithRevision(right, "3");
+            const expectedRight = PerforceUri.withArgs(right, {
+                leftUri: left.toString()
+            });
+
+            await DiffProvider.diffFiles(left, right);
+
+            expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                left,
+                expectedRight,
+                "a.txt#3 ⟷ a.txt#4"
+            );
+        });
+        it("Uses a pre-supplied title if supplied", async () => {
+            const right = basicFiles.edit().localFile;
+            const left = PerforceUri.fromUriWithRevision(right, "2");
+
+            const expectedRight = PerforceUri.withArgs(right, {
+                leftUri: left.toString(),
+                diffStartFile: right.toString()
+            });
+
+            await DiffProvider.diffFiles(left, right);
+
+            expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                left,
+                expectedRight,
+                "a.txt#2 ⟷ a.txt"
+            );
+        });
+        it("Does not stack the left file from previous diffs", async () => {
+            const { localFile, depotPath } = basicFiles.edit();
+            const left = PerforceUri.withArgs(
+                PerforceUri.fromDepotPath(localFile, depotPath, "3"),
+                {
+                    leftUri: PerforceUri.fromDepotPath(
+                        localFile,
+                        depotPath,
+                        "2"
+                    ).toString()
+                }
+            );
+            const right = PerforceUri.fromDepotPath(localFile, depotPath, "4");
+            const expectedLeft = PerforceUri.withArgs(left, { leftUri: undefined });
+            const expectedRight = PerforceUri.withArgs(right, {
+                leftUri: expectedLeft.toString()
+            });
+
+            await DiffProvider.diffFiles(left, right);
+
+            expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                expectedLeft,
+                expectedRight,
+                "a.txt#3 ⟷ a.txt#4"
+            );
+        });
+    });
+    describe("diffPrevious", () => {
+        describe("When the URI contains info about the left hand file", () => {
+            it("Diffs the left file against left - 1", async () => {
+                const { localFile, depotPath } = basicFiles.edit();
+                const curLeft = PerforceUri.withArgs(
+                    PerforceUri.fromDepotPath(localFile, depotPath, "2"),
+                    { haveRev: "4" }
+                );
+                const from = PerforceUri.withArgs(localFile, {
+                    leftUri: curLeft.toString(),
+                    haveRev: "4"
+                });
+
+                const expectedLeft = PerforceUri.fromUriWithRevision(curLeft, "1");
+                const expectedRight = PerforceUri.withArgs(curLeft, {
+                    leftUri: expectedLeft.toString()
+                });
+
+                await DiffProvider.diffPrevious(from);
+
+                expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                    expectedLeft,
+                    expectedRight,
+                    "a.txt#1 ⟷ a.txt#2"
+                );
+            });
+            it("Shows an error if the current left revision is <= 1", async () => {
+                const { localFile, depotPath } = basicFiles.edit();
+                const curLeft = PerforceUri.withArgs(
+                    PerforceUri.fromDepotPath(localFile, depotPath, "1"),
+                    { haveRev: "4" }
+                );
+                const from = PerforceUri.withArgs(localFile, {
+                    leftUri: curLeft.toString(),
+                    haveRev: "4"
+                });
+
+                await DiffProvider.diffPrevious(from);
+                expect(showImportantError).to.have.been.calledWithMatch(
+                    "No previous revision"
+                );
+                expect(execCommand).not.to.have.been.called;
+            });
+        });
+        describe("When the URI fragment is not a revision", () => {
+            it("Finds and diffs against the have revision, supplying a haveRev arg", async () => {
+                const { localFile, depotPath } = basicFiles.edit();
+                const have = PerforceUri.fromDepotPath(localFile, depotPath, "4");
+                stubModel.have.resolves(have);
+
+                const expectedLeft = PerforceUri.withArgs(have, { haveRev: "4" });
+                const expectedRight = PerforceUri.withArgs(localFile, {
+                    haveRev: "4",
+                    leftUri: expectedLeft.toString(),
+                    diffStartFile: localFile.toString()
+                });
+
+                await DiffProvider.diffPrevious(localFile);
+
+                expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                    expectedLeft,
+                    expectedRight,
+                    "a.txt#4 ⟷ a.txt (workspace)"
+                );
+            });
+            it("Shows an error if there is no have revision", async () => {
+                const { localFile } = basicFiles.edit();
+                stubModel.have.resolves(undefined);
+
+                await DiffProvider.diffPrevious(localFile);
+                expect(showImportantError).to.have.been.calledWithMatch(
+                    "No previous revision"
+                );
+                expect(execCommand).not.to.have.been.called;
+            });
+        });
+        describe("When the URI fragment contains a revision number", () => {
+            it("Diffs against the previous revision", async () => {
+                const { localFile } = basicFiles.edit();
+
+                const from = PerforceUri.fromUriWithRevision(localFile, "4");
+
+                await DiffProvider.diffPrevious(from);
+
+                const expectedLeft = PerforceUri.fromUriWithRevision(localFile, "3");
+                const expectedRight = PerforceUri.withArgs(
+                    PerforceUri.fromUriWithRevision(localFile, "4"),
+                    {
+                        leftUri: expectedLeft.toString(),
+                        diffStartFile: from.toString()
+                    }
+                );
+
+                expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                    expectedLeft,
+                    expectedRight,
+                    "a.txt#3 ⟷ a.txt#4"
+                );
+            });
+            it("Shows an error if the previous revision is <= 0", async () => {
+                const { localFile } = basicFiles.edit();
+
+                const from = PerforceUri.fromUriWithRevision(localFile, "1");
+
+                await DiffProvider.diffPrevious(from);
+
+                expect(showImportantError).to.have.been.calledWithMatch(
+                    "No previous revision"
+                );
+                expect(execCommand).not.to.have.been.called;
+            });
+        });
+    });
+    describe("diffNext", () => {
+        it("Does not diff files without a revision", async () => {
+            await DiffProvider.diffNext(basicFiles.edit().localFile);
+            expect(showImportantError).to.have.been.calledWithMatch("No more revisions");
+            expect(execCommand).not.to.have.been.called;
+        });
+        it("Diffs against the supplied revision + 1", async () => {
+            const { localFile, depotPath } = basicFiles.edit();
+            const from = PerforceUri.fromDepotPath(localFile, depotPath, "4");
+
+            const expectedLeft = from;
+            const expectedRight = PerforceUri.withArgs(
+                from,
+                { leftUri: expectedLeft.toString() },
+                "5"
+            );
+
+            await DiffProvider.diffNext(from);
+
+            expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                expectedLeft,
+                expectedRight,
+                "a.txt#4 ⟷ a.txt#5"
+            );
+        });
+        describe("When the next revision is greater than the have revision", () => {
+            it("Diffs against the starting file, if one is supplied", async () => {
+                const { localFile, depotPath } = basicFiles.edit();
+                const from = PerforceUri.withArgs(
+                    PerforceUri.fromDepotPath(localFile, depotPath, "4"),
+                    {
+                        haveRev: "4",
+                        diffStartFile: localFile.toString()
+                    }
+                );
+
+                const expectedLeft = from;
+                const expectedRight = PerforceUri.withArgs(
+                    localFile,
+                    {
+                        leftUri: expectedLeft.toString()
+                    },
+                    ""
+                );
+
+                await DiffProvider.diffNext(from);
+
+                expect(execCommand.lastCall).to.be.vscodeDiffCall(
+                    expectedLeft,
+                    expectedRight,
+                    "a.txt#4 ⟷ a.txt (workspace)"
+                );
+            });
+        });
+    });
+});

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -344,15 +344,17 @@ describe("Model & ScmProvider modules (integration)", () => {
 
             expect(instance.resources[1].id).to.equal("pending:3");
             expect(instance.resources[1].label).to.equal("#3: shelved changelist 1");
-            expect(instance.resources[1].resourceStates).to.be.shelvedResources([
-                basicFiles.shelveEdit()
-            ]);
+            expect(instance.resources[1].resourceStates).to.be.shelvedResources(
+                { chnum: "3" },
+                [basicFiles.shelveEdit()]
+            );
 
             expect(instance.resources[2].id).to.equal("pending:4");
             expect(instance.resources[2].label).to.equal("#4: shelved changelist 2");
-            expect(instance.resources[2].resourceStates).to.be.shelvedResources([
-                basicFiles.shelveDelete()
-            ]);
+            expect(instance.resources[2].resourceStates).to.be.shelvedResources(
+                { chnum: "4" },
+                [basicFiles.shelveDelete()]
+            );
         });
         it("Handles open and shelved files", async () => {
             stubModel.changelists = [
@@ -381,7 +383,7 @@ describe("Model & ScmProvider modules (integration)", () => {
             expect(instance.resources[1].label).to.equal("#5: mixed changelist 1");
             expect(
                 instance.resources[1].resourceStates.slice(0, 1)
-            ).to.be.shelvedResources([basicFiles.shelveEdit()]);
+            ).to.be.shelvedResources({ chnum: "5" }, [basicFiles.shelveEdit()]);
             expect(instance.resources[1].resourceStates.slice(1)).to.be.resources([
                 basicFiles.edit(),
                 basicFiles.add()
@@ -391,7 +393,7 @@ describe("Model & ScmProvider modules (integration)", () => {
             expect(instance.resources[2].label).to.equal("#6: mixed changelist 2");
             expect(
                 instance.resources[2].resourceStates.slice(0, 1)
-            ).to.be.shelvedResources([basicFiles.shelveDelete()]);
+            ).to.be.shelvedResources({ chnum: "6" }, [basicFiles.shelveDelete()]);
             expect(instance.resources[2].resourceStates.slice(1)).to.be.resources([
                 basicFiles.delete()
             ]);
@@ -414,9 +416,10 @@ describe("Model & ScmProvider modules (integration)", () => {
             expect(instance.resources[1].id).to.equal("pending:7");
             expect(instance.resources[1].label).to.equal("#7: changelist 1");
 
-            expect(instance.resources[1].resourceStates).to.be.shelvedResources([
-                basicFiles.shelveNoWorkspace()
-            ]);
+            expect(instance.resources[1].resourceStates).to.be.shelvedResources(
+                { chnum: "7" },
+                [basicFiles.shelveNoWorkspace()]
+            );
         });
         it("Handles the same file shelved in two changelists", async () => {
             stubModel.changelists = [
@@ -444,16 +447,18 @@ describe("Model & ScmProvider modules (integration)", () => {
             expect(instance.resources[1].id).to.equal("pending:8");
             expect(instance.resources[1].label).to.equal("#8: changelist 1");
 
-            expect(instance.resources[1].resourceStates).to.be.shelvedResources([
-                basicFiles.shelveEdit()
-            ]);
+            expect(instance.resources[1].resourceStates).to.be.shelvedResources(
+                { chnum: "8" },
+                [basicFiles.shelveEdit()]
+            );
 
             expect(instance.resources[2].id).to.equal("pending:9");
             expect(instance.resources[2].label).to.equal("#9: changelist 2");
 
-            expect(instance.resources[2].resourceStates).to.be.shelvedResources([
-                basicFiles.shelveEdit()
-            ]);
+            expect(instance.resources[2].resourceStates).to.be.shelvedResources(
+                { chnum: "9" },
+                [basicFiles.shelveEdit()]
+            );
         });
         it("Can sort changelists ascending", async () => {
             sinon.stub(workspaceConfig, "changelistOrder").get(() => "ascending");
@@ -522,15 +527,17 @@ describe("Model & ScmProvider modules (integration)", () => {
 
             expect(instance.resources[1].id).to.equal("pending:3");
             expect(instance.resources[1].label).to.equal("#3: shelved changelist 1");
-            expect(instance.resources[1].resourceStates).to.be.shelvedResources([
-                basicFiles.shelveEdit()
-            ]);
+            expect(instance.resources[1].resourceStates).to.be.shelvedResources(
+                { chnum: "3" },
+                [basicFiles.shelveEdit()]
+            );
 
             expect(instance.resources[2].id).to.equal("pending:4");
             expect(instance.resources[2].label).to.equal("#4: shelved changelist 2");
-            expect(instance.resources[2].resourceStates).to.be.shelvedResources([
-                basicFiles.shelveDelete()
-            ]);
+            expect(instance.resources[2].resourceStates).to.be.shelvedResources(
+                { chnum: "4" },
+                [basicFiles.shelveDelete()]
+            );
         });
         it("Has decorations for files", async () => {
             stubModel.changelists = [
@@ -598,7 +605,7 @@ describe("Model & ScmProvider modules (integration)", () => {
             expect(instance.resources[1].label).to.equal("#1: changelist 1");
             expect(
                 instance.resources[1].resourceStates.slice(0, 2)
-            ).to.be.shelvedResources([
+            ).to.be.shelvedResources({ chnum: "1" }, [
                 basicFiles.shelveDelete(),
                 basicFiles.shelveEdit()
             ]);

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -11,6 +11,7 @@ import { PerforceSCMProvider } from "../../ScmProvider";
 import { PerforceContentProvider } from "../../ContentProvider";
 import { Display, ActiveStatusEvent, ActiveEditorStatus } from "../../Display";
 import { Utils } from "../../Utils";
+import * as PerforceUri from "../../PerforceUri";
 import { Resource } from "../../scm/Resource";
 import { Status } from "../../scm/Status";
 import p4Commands from "../helpers/p4Commands";
@@ -51,7 +52,7 @@ function findResourceForShelvedFile(
     const res = group.resourceStates.find(
         resource =>
             (resource as Resource).isShelved &&
-            Utils.getDepotPathFromDepotUri(resource.resourceUri) === file.depotPath
+            PerforceUri.getDepotPathFromDepotUri(resource.resourceUri) === file.depotPath
     );
     if (res === undefined) {
         throw new Error("No shelved resource found");
@@ -1060,10 +1061,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 );
             });
             it("Does not diff non-file resources", async () => {
-                const inUri = Utils.makePerforceDocUri(
-                    basicFiles.edit().localFile,
-                    "print"
-                );
+                const inUri = PerforceUri.fromUri(basicFiles.edit().localFile);
                 const out = await items.instance.provideOriginalResource(inUri);
                 expect(out).to.be.undefined;
             });

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -1056,7 +1056,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     basicFiles.add().localFile.with({
                         scheme: "perforce",
                         fragment: "have",
-                        query: "p4args=-q&command=print"
+                        query: "command=print&p4Args=-q"
                     })
                 );
             });
@@ -1074,7 +1074,9 @@ describe("Model & ScmProvider modules (integration)", () => {
                     vscode.Uri.parse(basicFiles.moveDelete().depotPath).with({
                         scheme: "perforce",
                         fragment: "4",
-                        query: "p4args=-q&command=print&depot"
+                        query:
+                            "command=print&p4Args=-q&depot&workspace=" +
+                            encodeURIComponent(basicFiles.moveAdd().localFile.fsPath)
                     })
                 );
             });
@@ -1537,7 +1539,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         perforceLocalUriMatcher(file),
                         file.localFile,
-                        "a.txt#4 vs a.txt (workspace)"
+                        "a.txt#4 ⟷ a.txt (workspace)"
                     );
                     expect(items.execute).to.be.calledWithMatch(
                         { fsPath: file.localFile.fsPath },
@@ -1565,7 +1567,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.getCall(-1)).to.be.vscodeDiffCall(
                         perforceLocalUriMatcher(file1),
                         file1.localFile,
-                        "a.txt#4 vs a.txt"
+                        "a.txt#4 ⟷ a.txt"
                     );
                     expect(items.execute).to.be.calledWithMatch(
                         { fsPath: file1.localFile.fsPath },
@@ -1604,7 +1606,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         vscode.Uri.parse("perforce:EMPTY"),
                         file.localFile,
-                        "new.txt#0 vs new.txt (workspace)"
+                        "new.txt#0 ⟷ new.txt (workspace)"
                     );
                 });
                 it("Diffs a moved file against the original file", async () => {
@@ -1619,10 +1621,10 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         perforceFromFileUriMatcher(file),
                         file.localFile,
-                        "movedFrom.txt#4 vs moved.txt (workspace)"
+                        "movedFrom.txt#4 ⟷ moved.txt (workspace)"
                     );
                     expect(items.execute).to.be.calledWithMatch(
-                        sinon.match({ fsPath: workspaceUri.fsPath }),
+                        { fsPath: perforceFromFileUriMatcher(file).fsPath },
                         "print",
                         sinon.match.any,
                         ["-q", file.resolveFromDepotPath + "#4"]
@@ -1655,7 +1657,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         vscode.Uri.parse("perforce:EMPTY"),
                         file.localFile,
-                        "branched.txt#0 vs branched.txt (workspace)"
+                        "branched.txt#0 ⟷ branched.txt (workspace)"
                     );
                 });
                 it("Diffs an integration/merge against the target depot file", async () => {
@@ -1670,7 +1672,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         perforceLocalUriMatcher(file),
                         file.localFile,
-                        "integrated.txt#7 vs integrated.txt (workspace)"
+                        "integrated.txt#7 ⟷ integrated.txt (workspace)"
                     );
 
                     expect(items.execute).to.be.calledWithMatch(
@@ -1692,16 +1694,16 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         perforceDepotUriMatcher(file),
                         perforceShelvedUriMatcher(file, "1"),
-                        "a.txt#1 vs a.txt@=1"
+                        "a.txt#1 ⟷ a.txt@=1"
                     );
                     expect(items.execute).to.be.calledWithMatch(
-                        { fsPath: workspaceUri.fsPath },
+                        { fsPath: perforceShelvedUriMatcher(file, "1").fsPath },
                         "print",
                         sinon.match.any,
                         ["-q", file.depotPath + "@=1"]
                     );
                     expect(items.execute).to.be.calledWithMatch(
-                        { fsPath: workspaceUri.fsPath },
+                        { fsPath: perforceDepotUriMatcher(file).fsPath },
                         "print",
                         sinon.match.any,
                         ["-q", file.depotPath + "#1"]
@@ -1719,10 +1721,10 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         perforceShelvedUriMatcher(file, "1"),
                         file.localFile,
-                        "a.txt@=1 vs a.txt (workspace)"
+                        "a.txt@=1 ⟷ a.txt (workspace)"
                     );
                     expect(items.execute).to.be.calledWithMatch(
-                        { fsPath: workspaceUri.fsPath },
+                        { fsPath: perforceShelvedUriMatcher(file, "1").fsPath },
                         "print",
                         sinon.match.any,
                         ["-q", file.depotPath + "@=1"]
@@ -1740,7 +1742,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         perforceLocalShelvedUriMatcher(file, "1"),
                         file.localFile,
-                        "a.txt@=1 vs a.txt (workspace)"
+                        "a.txt@=1 ⟷ a.txt (workspace)"
                     );
                     expect(items.execute).to.be.calledWithMatch(
                         { fsPath: file.localFile.fsPath },

--- a/src/test/suite/perforceCommands.test.ts
+++ b/src/test/suite/perforceCommands.test.ts
@@ -9,7 +9,7 @@ import * as sinon from "sinon";
 import { stubExecute, StubPerforceModel } from "../helpers/StubPerforceModel";
 import p4Commands from "../helpers/p4Commands";
 import { PerforceCommands } from "../../PerforceCommands";
-import { Utils } from "../../Utils";
+import * as PerforceUri from "../../PerforceUri";
 import { PerforceContentProvider } from "../../ContentProvider";
 import { Display } from "../../Display";
 import { getLocalFile } from "../helpers/testUtils";
@@ -58,7 +58,7 @@ describe("Perforce Command Module (integration)", () => {
             await vscode.window.showTextDocument(localFile);
             await PerforceCommands.diff();
             expect(execCommand.lastCall).to.be.vscodeDiffCall(
-                Utils.makePerforceDocUri(localFile, "print", "-q").with({
+                PerforceUri.fromUri(localFile).with({
                     fragment: "have"
                 }),
                 localFile,
@@ -70,7 +70,7 @@ describe("Perforce Command Module (integration)", () => {
             await vscode.window.showTextDocument(localFile);
             await PerforceCommands.diff(5);
             expect(execCommand.lastCall).to.be.vscodeDiffCall(
-                Utils.makePerforceDocUri(localFile, "print", "-q").with({
+                PerforceUri.fromUri(localFile).with({
                     fragment: "5"
                 }),
                 localFile,
@@ -148,7 +148,7 @@ describe("Perforce Command Module (integration)", () => {
 
             const localFile = getLocalFile(workspaceUri, "testFolder", "a.txt");
             await vscode.window.showTextDocument(
-                Utils.makePerforceDocUri(localFile, "print", "-q").with({
+                PerforceUri.fromUri(localFile).with({
                     fragment: "5"
                 })
             );

--- a/src/test/suite/perforceCommands.test.ts
+++ b/src/test/suite/perforceCommands.test.ts
@@ -14,6 +14,7 @@ import { PerforceContentProvider } from "../../ContentProvider";
 import { Display } from "../../Display";
 import { getLocalFile } from "../helpers/testUtils";
 import { PerforceSCMProvider } from "../../ScmProvider";
+import { Status } from "../../scm/Status";
 
 chai.use(sinonChai);
 chai.use(p4Commands);
@@ -55,14 +56,26 @@ describe("Perforce Command Module (integration)", () => {
     describe("Diff", () => {
         it("Opens the have revision for the currently open file by default", async () => {
             const localFile = getLocalFile(workspaceUri, "testFolder", "a.txt");
+            stubModel.changelists = [
+                {
+                    chnum: "default",
+                    description: "n/a",
+                    files: [
+                        {
+                            depotPath: "//depot/testFolder/a.txt",
+                            depotRevision: 2,
+                            localFile: localFile,
+                            operation: Status.EDIT
+                        }
+                    ]
+                }
+            ];
             await vscode.window.showTextDocument(localFile);
             await PerforceCommands.diff();
             expect(execCommand.lastCall).to.be.vscodeDiffCall(
-                PerforceUri.fromUri(localFile).with({
-                    fragment: "have"
-                }),
+                PerforceUri.fromDepotPath(localFile, "//depot/testFolder/a.txt", "2"),
                 localFile,
-                "a.txt#have vs a.txt (workspace)"
+                "a.txt#2 ⟷ a.txt (workspace)"
             );
         });
         it("Opens the supplied revision for the currently open file", async () => {
@@ -74,7 +87,7 @@ describe("Perforce Command Module (integration)", () => {
                     fragment: "5"
                 }),
                 localFile,
-                "new.txt#5 vs new.txt (workspace)"
+                "new.txt#5 ⟷ new.txt (workspace)"
             );
         });
     });

--- a/src/test/suite/perforceUri.test.ts
+++ b/src/test/suite/perforceUri.test.ts
@@ -105,6 +105,22 @@ describe("Perforce Uris", () => {
                 "command=print&p4Args=hello&depot&" + workspaceArg
             );
         });
+        it("Accepts an optional revision", () => {
+            const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
+            const augmented = PerforceUri.withArgs(uri, { p4Args: "hello" }, "3");
+            expect(augmented.query).to.equal(
+                "command=print&p4Args=hello&depot&" + workspaceArg
+            );
+            expect(augmented.fragment).to.equal("3");
+        });
+        it("Does not override the fragment if no revision supplied", () => {
+            const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
+            const augmented = PerforceUri.withArgs(uri, { p4Args: "hello" });
+            expect(augmented.query).to.equal(
+                "command=print&p4Args=hello&depot&" + workspaceArg
+            );
+            expect(augmented.fragment).to.equal("2");
+        });
     });
     describe("isDepotUri", () => {
         it("Returns true for depot URIs with the depot flag", () => {

--- a/src/test/suite/perforceUri.test.ts
+++ b/src/test/suite/perforceUri.test.ts
@@ -1,13 +1,15 @@
 import { expect } from "chai";
 
 import * as vscode from "vscode";
+import * as path from "path";
 
 import * as PerforceUri from "../../PerforceUri";
 
 describe("Perforce Uris", () => {
     const depotPath = "//depot/my/path/file.txt";
     const localUri = vscode.Uri.file("/home/file.txt");
-    const workspaceArg = "workspace=%5Chome%5Cfile.txt";
+    const workspaceArg =
+        "workspace=" + encodeURIComponent(path.sep + "home" + path.sep + "file.txt");
 
     describe("Encode query", () => {
         it("Produces an encoded query string", () => {

--- a/src/test/suite/perforceUri.test.ts
+++ b/src/test/suite/perforceUri.test.ts
@@ -1,0 +1,169 @@
+import { expect } from "chai";
+
+import * as vscode from "vscode";
+
+import * as PerforceUri from "../../PerforceUri";
+
+describe("Perforce Uris", () => {
+    const depotPath = "//depot/my/path/file.txt";
+    const localUri = vscode.Uri.file("/home/file.txt");
+    const workspaceArg = "workspace=%5Chome%5Cfile.txt";
+
+    describe("Encode query", () => {
+        it("Produces an encoded query string", () => {
+            const query = PerforceUri.encodeQuery({
+                command: "p&r=int",
+                p4Args: "-q",
+                depot: true,
+                leftUri: undefined
+            });
+            expect(query).to.equal("command=p%26r%3Dint&p4Args=-q&depot");
+        });
+    });
+    describe("Decode query", () => {
+        it("Decodes an encoded query string to an object", () => {
+            const query = "command=p%26r%3Dint&p4Args=-q&depot";
+
+            const decoded = PerforceUri.decodeUriQuery(query);
+            expect(decoded).to.deep.equal({
+                p4Args: "-q",
+                command: "p&r=int",
+                depot: true
+            });
+        });
+    });
+    describe("fromUri", () => {
+        it("Makes a URI with a default command", () => {
+            const uri = PerforceUri.fromUri(localUri);
+            expect(uri.scheme).to.equal("perforce");
+            expect(uri.fsPath).to.equal(localUri.fsPath);
+            expect(uri.query).to.equal("command=print&p4Args=-q");
+        });
+        it("Accepts additional arguments that can override the defaults", () => {
+            const uri = PerforceUri.fromUri(localUri, {
+                command: "opened",
+                p4Args: undefined
+            });
+            expect(uri.scheme).to.equal("perforce");
+            expect(uri.fsPath).to.equal(localUri.fsPath);
+            expect(uri.query).to.equal("command=opened");
+        });
+    });
+    describe("forCommand", () => {
+        it("Produces a URI for an arbitrary command", () => {
+            const uri = PerforceUri.forCommand(localUri, "set", "-q");
+            expect(uri.scheme).to.equal("perforce");
+            expect(uri.fsPath).to.equal("");
+            expect(uri.query).to.equal("command=set&p4Args=-q&" + workspaceArg);
+        });
+    });
+    describe("fromDepotPath", () => {
+        it("Produces a URI for a depot path, including the depot parameter", () => {
+            const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
+            expect(uri.scheme).to.equal("perforce");
+            expect(uri.authority).to.equal("depot");
+            expect(uri.path).to.equal("/my/path/file.txt");
+            expect(uri.query).to.equal("command=print&p4Args=-q&depot&" + workspaceArg);
+            expect(uri.fragment).to.equal("2");
+        });
+        it("Has an optional revision", () => {
+            const uri = PerforceUri.fromDepotPath(localUri, depotPath, undefined);
+            expect(uri.scheme).to.equal("perforce");
+            expect(uri.authority).to.equal("depot");
+            expect(uri.path).to.equal("/my/path/file.txt");
+            expect(uri.query).to.equal("command=print&p4Args=-q&depot&" + workspaceArg);
+            expect(uri.fragment).to.equal("");
+        });
+    });
+    describe("fromUriWithRevision", () => {
+        it("Produces a perforce URI with an added revision / label fragment", () => {
+            const uri = PerforceUri.fromUriWithRevision(localUri, "@=99");
+            expect(uri.scheme).to.equal("perforce");
+            expect(uri.fsPath).to.equal(localUri.fsPath);
+            expect(uri.query).to.equal("command=print&p4Args=-q");
+            expect(uri.fragment).to.equal("@=99");
+        });
+    });
+    describe("withArgs", () => {
+        it("Augments existing query arguments", () => {
+            const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
+            const left = PerforceUri.fromUriWithRevision(localUri, "1");
+            const augmented = PerforceUri.withArgs(uri, { leftUri: left.toString() });
+            expect(augmented.query).to.equal(
+                "command=print&p4Args=-q&depot&" +
+                    workspaceArg +
+                    "&leftUri=" +
+                    encodeURIComponent(left.toString())
+            );
+        });
+        it("Overrides existing query arguments", () => {
+            const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
+            const augmented = PerforceUri.withArgs(uri, { p4Args: "hello" });
+            expect(augmented.query).to.equal(
+                "command=print&p4Args=hello&depot&" + workspaceArg
+            );
+        });
+    });
+    describe("isDepotUri", () => {
+        it("Returns true for depot URIs with the depot flag", () => {
+            const uri = PerforceUri.fromDepotPath(localUri, depotPath, undefined);
+            expect(PerforceUri.isDepotUri(uri)).to.be.true;
+        });
+        it("Returns false for normal URIs", () => {
+            expect(PerforceUri.isDepotUri(localUri)).to.be.false;
+        });
+        it("Returns false for perforce URIs without the depot flag", () => {
+            const uri = PerforceUri.fromUri(localUri);
+            expect(PerforceUri.isDepotUri(uri)).to.be.false;
+        });
+    });
+    describe("isUsableForWorkspace", () => {
+        it("Returns true for local files", () => {
+            expect(PerforceUri.isUsableForWorkspace(localUri)).to.be.true;
+        });
+        it("Returns false for depot URIs without a workspace", () => {
+            const uri = PerforceUri.fromUri(vscode.Uri.parse("perforce://depot/hello"), {
+                depot: true
+            });
+            expect(PerforceUri.isUsableForWorkspace(uri)).to.be.false;
+        });
+        it("Returns true for depot URIs with a workspace argument", () => {
+            const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
+            expect(PerforceUri.isUsableForWorkspace(uri)).to.be.true;
+        });
+    });
+    describe("getWorkspaceFromQuery", () => {
+        it("Gets the workspace param from a depot URI", () => {
+            const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
+            expect(PerforceUri.getWorkspaceFromQuery(uri)).to.deep.equal(
+                vscode.Uri.file(localUri.fsPath)
+            );
+        });
+        it("Is undefined if there is no workspace", () => {
+            const uri = PerforceUri.fromUri(vscode.Uri.parse("perforce://depot/hello"), {
+                depot: true
+            });
+            expect(PerforceUri.getWorkspaceFromQuery(uri)).to.be.undefined;
+        });
+    });
+    describe("getUsableWorkspace", () => {
+        it("Returns a URI of the fs path for non-depot URIs", () => {
+            const uri = PerforceUri.fromUri(localUri);
+            expect(PerforceUri.getUsableWorkspace(uri)).to.deep.equal(
+                vscode.Uri.file(localUri.fsPath)
+            );
+        });
+        it("Returns the workspace param from a depot URI", () => {
+            const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
+            expect(PerforceUri.getUsableWorkspace(uri)).to.deep.equal(
+                vscode.Uri.file(localUri.fsPath)
+            );
+        });
+    });
+    describe("getDepotPathFromDepotUri", () => {
+        it("Can determine a valid path from a Uri", () => {
+            const depotUri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
+            expect(PerforceUri.getDepotPathFromDepotUri(depotUri)).to.be.equal(depotPath);
+        });
+    });
+});

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -16,21 +16,18 @@ describe("Utils module", () => {
         });
         it("Can encode and decode a URI Query", () => {
             const query = PerforceUri.encodeQuery({
-                command: "print",
+                command: "p&r=int",
                 p4Args: "-q",
-                depot: true
-                //leftDepotPath: "s&t=uff"
+                depot: true,
+                leftUri: undefined
             });
-            expect(query).to.equal(
-                "p4args=-q&command=print&depot&leftDepotPath=s%26t%3Duff"
-            );
+            expect(query).to.equal("command=p%26r%3Dint&p4Args=-q&depot");
 
             const decoded = PerforceUri.decodeUriQuery(query);
             expect(decoded).to.deep.equal({
-                p4args: "-q",
-                command: "print",
-                depot: true,
-                stringArg: "s&t=uff"
+                p4Args: "-q",
+                command: "p&r=int",
+                depot: true
             });
         });
         it("Can make a full perforce doc URI", () => {
@@ -39,7 +36,7 @@ describe("Utils module", () => {
             });
             expect(uri.scheme).to.equal("perforce");
             expect(uri.authority).to.equal("depot");
-            expect(uri.query).to.equal("p4args=-q&command=print&depot");
+            expect(uri.query).to.equal("command=print&p4Args=-q&depot");
         });
     });
     describe("Path expansion", () => {

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -1,44 +1,8 @@
 import { expect } from "chai";
 
-import * as vscode from "vscode";
-
 import { Utils } from "../../Utils";
-// TODO test in a different file!
-import * as PerforceUri from "../../PerforceUri";
 
 describe("Utils module", () => {
-    describe("Perforce Uris", () => {
-        const depotPath = "//depot/my/path/file.txt";
-        const depotUri = vscode.Uri.file(depotPath);
-
-        it("Can determine a valid path from a Uri", () => {
-            expect(PerforceUri.getDepotPathFromDepotUri(depotUri)).to.be.equal(depotPath);
-        });
-        it("Can encode and decode a URI Query", () => {
-            const query = PerforceUri.encodeQuery({
-                command: "p&r=int",
-                p4Args: "-q",
-                depot: true,
-                leftUri: undefined
-            });
-            expect(query).to.equal("command=p%26r%3Dint&p4Args=-q&depot");
-
-            const decoded = PerforceUri.decodeUriQuery(query);
-            expect(decoded).to.deep.equal({
-                p4Args: "-q",
-                command: "p&r=int",
-                depot: true
-            });
-        });
-        it("Can make a full perforce doc URI", () => {
-            const uri = PerforceUri.fromUri(depotUri, {
-                depot: true
-            });
-            expect(uri.scheme).to.equal("perforce");
-            expect(uri.authority).to.equal("depot");
-            expect(uri.query).to.equal("command=print&p4Args=-q&depot");
-        });
-    });
     describe("Path expansion", () => {
         it("Escapes special characters", () => {
             const path = "AFile%*#@.txt";

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -3,6 +3,8 @@ import { expect } from "chai";
 import * as vscode from "vscode";
 
 import { Utils } from "../../Utils";
+// TODO test in a different file!
+import * as PerforceUri from "../../PerforceUri";
 
 describe("Utils module", () => {
     describe("Perforce Uris", () => {
@@ -10,17 +12,20 @@ describe("Utils module", () => {
         const depotUri = vscode.Uri.file(depotPath);
 
         it("Can determine a valid path from a Uri", () => {
-            expect(Utils.getDepotPathFromDepotUri(depotUri)).to.be.equal(depotPath);
+            expect(PerforceUri.getDepotPathFromDepotUri(depotUri)).to.be.equal(depotPath);
         });
         it("Can encode and decode a URI Query", () => {
-            const query = Utils.makePerforceUriQuery("print", "-q", {
-                depot: true,
-                nothing: false,
-                stringArg: "s&t=uff"
+            const query = PerforceUri.encodeQuery({
+                command: "print",
+                p4Args: "-q",
+                depot: true
+                //leftDepotPath: "s&t=uff"
             });
-            expect(query).to.equal("p4args=-q&command=print&depot&stringArg=s%26t%3Duff");
+            expect(query).to.equal(
+                "p4args=-q&command=print&depot&leftDepotPath=s%26t%3Duff"
+            );
 
-            const decoded = Utils.decodeUriQuery(query);
+            const decoded = PerforceUri.decodeUriQuery(query);
             expect(decoded).to.deep.equal({
                 p4args: "-q",
                 command: "print",
@@ -29,7 +34,7 @@ describe("Utils module", () => {
             });
         });
         it("Can make a full perforce doc URI", () => {
-            const uri = Utils.makePerforceDocUri(depotUri, "print", "-q", {
+            const uri = PerforceUri.fromUri(depotUri, {
                 depot: true
             });
             expect(uri.scheme).to.equal("perforce");


### PR DESCRIPTION
Adds next and previous buttons to the editor title context.

To support this, Perforce URI handling was moved to a separate module, and more information is encoded in the URI when performing a diff:
* The URI of the left document is encoded in the query of the right doc
  * This is because the context buttons always operate on the right hand doc with no information about the left hand doc
 * The URI of the starting document for the diff is encoded so that 'diff next' works once we reach the have revision
 * The have revision is encoded so that we know when we have reached the have revision when diffing next

Resources have slightly more sensible URIs that are more useful 'by default' which slightly simplifies the diff handling

The buttons can be enabled on all diffable files (uses the context of OPEN / NOT_OPEN to decide when a file is diffable), just on perforce: files (such as diffs, annotations) or never. The context menu still has these options if they are not shown as icons
