### PR TITLE
Automatically refresh the scm provider on login

### DIFF
--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -520,6 +520,7 @@ export namespace PerforceCommands {
                     Display.showMessage("Login successful");
                     Display.updateEditor();
                     loggedIn = true;
+                    PerforceSCMProvider.RefreshAll();
                 } catch {}
             }
         } else {


### PR DESCRIPTION
Automatically refresh on successful logon only - generally, the user would want an up to date scm provider, so there's no need to make them do it manually!