### PR TITLE
Catch file check errors. Auto-delete from containing directory

### DIFF
--- a/src/FileSystemActions.ts
+++ b/src/FileSystemActions.ts
@@ -19,6 +19,7 @@ import { Display } from "./Display";
 import { PerforceCommands } from "./PerforceCommands";
 import { PerforceSCMProvider } from "./ScmProvider";
 import { ConfigAccessor } from "./ConfigService";
+import * as Path from "path";
 
 export interface FileSystemEventProvider {
     onWillSaveTextDocument: typeof workspace.onWillSaveTextDocument;
@@ -175,8 +176,11 @@ export default class FileSystemActions {
 
         const fullUri = isDirectory ? uri.with({ path: uri.path + "/..." }) : uri;
 
+        // run from the containing location (can't run from the directory as it probably doesn't exist any more)
+        const runFrom = Uri.file(Path.dirname(uri.fsPath));
+
         // DO NOT AWAIT the revert, because we are holding up the deletion
-        PerforceCommands.p4revertAndDelete(fullUri);
+        PerforceCommands.p4revertAndDelete(fullUri, runFrom);
     }
 
     private static shouldExclude(uri: Uri): boolean {

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -152,10 +152,10 @@ export namespace PerforceCommands {
         await p4delete(fileUri);
     }
 
-    export async function p4delete(fileUri: Uri) {
+    export async function p4delete(fileUri: Uri, resource?: Uri) {
         const deleteOpts: p4.DeleteOptions = { paths: [fileUri] };
         try {
-            await p4.del(fileUri, deleteOpts);
+            await p4.del(resource ?? fileUri, deleteOpts);
             Display.showMessage(fileUri.fsPath + " deleted.");
             Display.updateEditor();
             PerforceSCMProvider.RefreshAll();
@@ -179,10 +179,10 @@ export namespace PerforceCommands {
         await p4revert(fileUri);
     }
 
-    export async function p4revert(fileUri: Uri) {
+    export async function p4revert(fileUri: Uri, resource?: Uri) {
         const revertOpts: p4.RevertOptions = { paths: [fileUri] };
         try {
-            await p4.revert(fileUri, revertOpts);
+            await p4.revert(resource ?? fileUri, revertOpts);
             Display.showMessage(fileUri.fsPath + " reverted.");
             Display.updateEditor();
             PerforceSCMProvider.RefreshAll();
@@ -192,9 +192,9 @@ export namespace PerforceCommands {
         }
     }
 
-    export async function p4revertAndDelete(uri: Uri) {
-        await PerforceCommands.p4revert(uri);
-        await PerforceCommands.p4delete(uri);
+    export async function p4revertAndDelete(uri: Uri, resource?: Uri) {
+        await PerforceCommands.p4revert(uri, resource);
+        await PerforceCommands.p4delete(uri, resource);
     }
 
     export async function submitSingle() {

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -130,6 +130,13 @@ export namespace PerforceService {
         });
     }
 
+    async function isDirectory(uri: Uri): Promise<boolean> {
+        try {
+            return (await workspace.fs.stat(uri)).type === FileType.Directory;
+        } catch {}
+        return false;
+    }
+
     async function execCommand(
         resource: Uri,
         command: string,
@@ -147,12 +154,9 @@ export namespace PerforceService {
             allArgs.push(...args);
         }
 
-        const isDirectory =
-            (await workspace.fs.stat(actualResource)).type === FileType.Directory;
+        const isDir = await isDirectory(actualResource);
 
-        const cwd = isDirectory
-            ? actualResource.fsPath
-            : Path.dirname(actualResource.fsPath);
+        const cwd = isDir ? actualResource.fsPath : Path.dirname(actualResource.fsPath);
 
         const env = { ...process.env, PWD: cwd };
         const spawnArgs: CP.SpawnOptions = { cwd, env };


### PR DESCRIPTION
The delete directory command was trying to run from the directory that had already been deleted, which failed

Pass in the parent directory instead