### PR TITLE
Use correct case when reading the depot path from a depot URI

### DIFF
--- a/src/PerforceUri.ts
+++ b/src/PerforceUri.ts
@@ -8,6 +8,7 @@ export type UriArguments = {
     leftUri?: string;
     haveRev?: string;
     diffStartFile?: string;
+    depotName?: string;
 };
 
 type AnyUriArguments = {
@@ -15,7 +16,8 @@ type AnyUriArguments = {
 };
 
 export function getDepotPathFromDepotUri(uri: vscode.Uri): string {
-    return "//" + uri.authority + uri.path;
+    const args = decodeUriQuery(uri.query);
+    return "//" + (args.depotName ?? uri.authority) + uri.path;
 }
 
 function encodeParam(param: string, value?: string | boolean) {
@@ -45,9 +47,11 @@ export function fromDepotPath(
     const baseUri = vscode.Uri.parse("perforce:" + depotPath).with({
         fragment: revisionOrAtLabel,
     });
+    const depotName = depotPath.split("/")[2];
     return fromUri(baseUri, {
         depot: true,
         workspace: workspace.fsPath,
+        depotName,
     });
 }
 

--- a/src/test/helpers/p4Commands.ts
+++ b/src/test/helpers/p4Commands.ts
@@ -179,6 +179,7 @@ export default function (chai: Chai.ChaiStatic, _utils: Chai.ChaiUtils) {
             localFile: vscode.Uri;
             resolveFromDepotPath?: string;
             resolveEndFromRev?: number;
+            suppressFstatClientFile?: boolean;
         }[]
     ) {
         const obj: Resource[] = this._obj as Resource[];
@@ -193,7 +194,9 @@ export default function (chai: Chai.ChaiStatic, _utils: Chai.ChaiUtils) {
                 Assertion,
                 resource.resourceUri,
                 PerforceUri.fromDepotPath(
-                    resource.model.workspaceUri,
+                    expected.suppressFstatClientFile
+                        ? resource.model.workspaceUri
+                        : expected.localFile,
                     expected.depotPath,
                     "@=" + change.chnum
                 ),

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -1151,7 +1151,8 @@ describe("Model & ScmProvider modules (integration)", () => {
                         fragment: "4",
                         query:
                             "command=print&p4Args=-q&depot&workspace=" +
-                            encodeURIComponent(basicFiles.moveAdd().localFile.fsPath),
+                            encodeURIComponent(basicFiles.moveAdd().localFile.fsPath) +
+                            "&depotName=depot",
                     })
                 );
             });

--- a/src/test/suite/perforceUri.test.ts
+++ b/src/test/suite/perforceUri.test.ts
@@ -65,7 +65,9 @@ describe("Perforce Uris", () => {
             expect(uri.scheme).to.equal("perforce");
             expect(uri.authority).to.equal("depot");
             expect(uri.path).to.equal("/my/path/file.txt");
-            expect(uri.query).to.equal("command=print&p4Args=-q&depot&" + workspaceArg);
+            expect(uri.query).to.equal(
+                "command=print&p4Args=-q&depot&" + workspaceArg + "&depotName=depot"
+            );
             expect(uri.fragment).to.equal("2");
         });
         it("Has an optional revision", () => {
@@ -73,7 +75,9 @@ describe("Perforce Uris", () => {
             expect(uri.scheme).to.equal("perforce");
             expect(uri.authority).to.equal("depot");
             expect(uri.path).to.equal("/my/path/file.txt");
-            expect(uri.query).to.equal("command=print&p4Args=-q&depot&" + workspaceArg);
+            expect(uri.query).to.equal(
+                "command=print&p4Args=-q&depot&" + workspaceArg + "&depotName=depot"
+            );
             expect(uri.fragment).to.equal("");
         });
     });
@@ -94,6 +98,7 @@ describe("Perforce Uris", () => {
             expect(augmented.query).to.equal(
                 "command=print&p4Args=-q&depot&" +
                     workspaceArg +
+                    "&depotName=depot" +
                     "&leftUri=" +
                     encodeURIComponent(left.toString())
             );
@@ -102,14 +107,14 @@ describe("Perforce Uris", () => {
             const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
             const augmented = PerforceUri.withArgs(uri, { p4Args: "hello" });
             expect(augmented.query).to.equal(
-                "command=print&p4Args=hello&depot&" + workspaceArg
+                "command=print&p4Args=hello&depot&" + workspaceArg + "&depotName=depot"
             );
         });
         it("Accepts an optional revision", () => {
             const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
             const augmented = PerforceUri.withArgs(uri, { p4Args: "hello" }, "3");
             expect(augmented.query).to.equal(
-                "command=print&p4Args=hello&depot&" + workspaceArg
+                "command=print&p4Args=hello&depot&" + workspaceArg + "&depotName=depot"
             );
             expect(augmented.fragment).to.equal("3");
         });
@@ -117,7 +122,7 @@ describe("Perforce Uris", () => {
             const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
             const augmented = PerforceUri.withArgs(uri, { p4Args: "hello" });
             expect(augmented.query).to.equal(
-                "command=print&p4Args=hello&depot&" + workspaceArg
+                "command=print&p4Args=hello&depot&" + workspaceArg + "&depotName=depot"
             );
             expect(augmented.fragment).to.equal("2");
         });
@@ -182,6 +187,11 @@ describe("Perforce Uris", () => {
         it("Can determine a valid path from a Uri", () => {
             const depotUri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
             expect(PerforceUri.getDepotPathFromDepotUri(depotUri)).to.be.equal(depotPath);
+        });
+        it("Uses correct case for the depot name", () => {
+            const path = "//DepOt/myFile";
+            const depotUri = PerforceUri.fromDepotPath(localUri, path, "2");
+            expect(PerforceUri.getDepotPathFromDepotUri(depotUri)).to.be.equal(path);
         });
     });
 });


### PR DESCRIPTION
encodes the depot name as a URI component.

Fixes an issue where the depot path contains upper case characters - VS code URI parses them to lower case

fixes #97