### PR TITLE
Maintain position when annotating a file

### DIFF
--- a/src/ContextVars.ts
+++ b/src/ContextVars.ts
@@ -52,7 +52,7 @@ function getRevision(file?: vscode.Uri) {
     if (!file) {
         return -1;
     }
-    const fileRev = parseInt(file.fragment);
+    const fileRev = parseInt(PerforceUri.getRevOrAtLabel(file));
     if (isNaN(fileRev)) {
         return -1;
     }

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -28,6 +28,8 @@ export interface ActiveStatusEvent {
 export namespace Display {
     export const channel = window.createOutputChannel("Perforce Log");
 
+    let _lastStatusEvent: ActiveStatusEvent | undefined;
+
     const _onActiveFileStatusKnown = new EventEmitter<ActiveStatusEvent>();
     export const onActiveFileStatusKnown = _onActiveFileStatusKnown.event;
     const _onActiveFileStatusCleared = new EventEmitter<Uri | undefined>();
@@ -39,6 +41,7 @@ export namespace Display {
         if (!_statusBarActivated) {
             return;
         }
+        _lastStatusEvent = undefined;
         _onActiveFileStatusCleared.fire(window.activeTextEditor?.document.uri);
         if (_statusBarItem) {
             _statusBarItem.show();
@@ -64,6 +67,10 @@ export namespace Display {
         subscriptions.push(window.onDidChangeActiveTextEditor(updateEditor));
 
         updateEditor();
+    }
+
+    export function getLastActiveFileStatus() {
+        return _lastStatusEvent;
     }
 
     export function activateStatusBar() {
@@ -126,7 +133,8 @@ export namespace Display {
                 active = ActiveEditorStatus.NOT_IN_WORKSPACE;
             }
 
-            _onActiveFileStatusKnown.fire({ file: doc.uri, status: active, details });
+            _lastStatusEvent = { file: doc.uri, status: active, details };
+            _onActiveFileStatusKnown.fire(_lastStatusEvent);
         } else {
             _statusBarItem.hide();
         }

--- a/src/PerforceUri.ts
+++ b/src/PerforceUri.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode";
-import { Display } from "./Display";
 
 export type UriArguments = {
     workspace?: string;
@@ -16,27 +15,6 @@ export type UriArguments = {
 type AnyUriArguments = {
     [key: string]: string | boolean | undefined;
 };
-
-export function isSameAsOpenFile(uri: vscode.Uri) {
-    const open = vscode.window.activeTextEditor?.document.uri;
-    if (!open) {
-        return false;
-    }
-
-    if (isSameFileOrDepotPath(uri, open)) {
-        return true;
-    }
-
-    if (isDepotUri(uri)) {
-        const path = Display.getLastActiveFileStatus()?.details?.depotPath;
-        if (!path) {
-            return false;
-        }
-        return path === getDepotPathFromDepotUri(uri);
-    }
-
-    return false;
-}
 
 export function isSameFileOrDepotPath(a: vscode.Uri, b: vscode.Uri) {
     if (isDepotUri(a) && isDepotUri(b)) {

--- a/src/annotations/AnnotationProvider.ts
+++ b/src/annotations/AnnotationProvider.ts
@@ -82,11 +82,16 @@ export class AnnotationProvider {
             .filter(isTruthy);
     }
 
+    private async getOpenFileRangesIfSameFile() {
+        try {
+            const isSame = await Display.isSameAsOpenFile(this._doc);
+            return isSame ? vscode.window.activeTextEditor?.visibleRanges : undefined;
+        } catch {}
+    }
+
     private async loadEditor() {
         AnnotationProvider._onWillLoadEditor.fire(this._p4Uri);
-        const ranges = PerforceUri.isSameAsOpenFile(this._doc)
-            ? vscode.window.activeTextEditor?.visibleRanges
-            : undefined;
+        const ranges = await this.getOpenFileRangesIfSameFile();
         this._editor = await vscode.window.showTextDocument(this._p4Uri);
 
         if (ranges) {

--- a/src/annotations/AnnotationProvider.ts
+++ b/src/annotations/AnnotationProvider.ts
@@ -84,7 +84,15 @@ export class AnnotationProvider {
 
     private async loadEditor() {
         AnnotationProvider._onWillLoadEditor.fire(this._p4Uri);
+        const ranges = PerforceUri.isSameAsOpenFile(this._doc)
+            ? vscode.window.activeTextEditor?.visibleRanges
+            : undefined;
         this._editor = await vscode.window.showTextDocument(this._p4Uri);
+
+        if (ranges) {
+            this._editor.revealRange(ranges[0]);
+        }
+
         this.applyBaseDecorations();
         // don't apply highlights until a line is selected
     }
@@ -182,7 +190,7 @@ export class AnnotationProvider {
         const decorations = getDecorations(underlying, annotations, log);
 
         // try to use the depot URI to open the document, so that we can perform revision actions on it
-        if (!uri.fragment && !PerforceUri.isDepotUri(uri) && log[0]) {
+        if (!PerforceUri.getRevOrAtLabel(uri) && !PerforceUri.isDepotUri(uri) && log[0]) {
             uri = PerforceUri.fromDepotPath(uri, log[0].file, log[0].revision);
         }
 

--- a/src/api/CommandUtils.ts
+++ b/src/api/CommandUtils.ts
@@ -187,7 +187,10 @@ function fileSpecToArg(fileSpec: FileSpec, ignoreRevisionFragments?: boolean) {
     if (isUri(fileSpec) && PerforceUri.isDepotUri(fileSpec)) {
         return (
             PerforceUri.getDepotPathFromDepotUri(fileSpec) +
-            fragmentAsSuffix(fileSpec.fragment, ignoreRevisionFragments)
+            fragmentAsSuffix(
+                PerforceUri.getRevOrAtLabel(fileSpec),
+                ignoreRevisionFragments
+            )
         );
     }
     return (

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -1125,7 +1125,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     basicFiles.add().localFile.with({
                         scheme: "perforce",
                         fragment: "have",
-                        query: "command=print&p4Args=-q",
+                        query: "command=print&p4Args=-q&rev=have",
                     })
                 );
             });
@@ -1146,7 +1146,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                         query:
                             "command=print&p4Args=-q&depot&workspace=" +
                             encodeURIComponent(basicFiles.moveAdd().localFile.fsPath) +
-                            "&depotName=depot",
+                            "&depotName=depot&rev=4",
                     })
                 );
             });

--- a/src/test/suite/perforceUri.test.ts
+++ b/src/test/suite/perforceUri.test.ts
@@ -66,7 +66,7 @@ describe("Perforce Uris", () => {
             expect(uri.authority).to.equal("depot");
             expect(uri.path).to.equal("/my/path/file.txt");
             expect(uri.query).to.equal(
-                "command=print&p4Args=-q&depot&" + workspaceArg + "&depotName=depot"
+                "command=print&p4Args=-q&depot&" + workspaceArg + "&depotName=depot&rev=2"
             );
             expect(uri.fragment).to.equal("2");
         });
@@ -86,7 +86,7 @@ describe("Perforce Uris", () => {
             const uri = PerforceUri.fromUriWithRevision(localUri, "@=99");
             expect(uri.scheme).to.equal("perforce");
             expect(uri.fsPath).to.equal(localUri.fsPath);
-            expect(uri.query).to.equal("command=print&p4Args=-q");
+            expect(uri.query).to.equal("command=print&p4Args=-q&rev=%40%3D99");
             expect(uri.fragment).to.equal("@=99");
         });
     });
@@ -98,7 +98,7 @@ describe("Perforce Uris", () => {
             expect(augmented.query).to.equal(
                 "command=print&p4Args=-q&depot&" +
                     workspaceArg +
-                    "&depotName=depot" +
+                    "&depotName=depot&rev=2" +
                     "&leftUri=" +
                     encodeURIComponent(left.toString())
             );
@@ -107,14 +107,18 @@ describe("Perforce Uris", () => {
             const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
             const augmented = PerforceUri.withArgs(uri, { p4Args: "hello" });
             expect(augmented.query).to.equal(
-                "command=print&p4Args=hello&depot&" + workspaceArg + "&depotName=depot"
+                "command=print&p4Args=hello&depot&" +
+                    workspaceArg +
+                    "&depotName=depot&rev=2"
             );
         });
         it("Accepts an optional revision", () => {
             const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
             const augmented = PerforceUri.withArgs(uri, { p4Args: "hello" }, "3");
             expect(augmented.query).to.equal(
-                "command=print&p4Args=hello&depot&" + workspaceArg + "&depotName=depot"
+                "command=print&p4Args=hello&depot&" +
+                    workspaceArg +
+                    "&depotName=depot&rev=3"
             );
             expect(augmented.fragment).to.equal("3");
         });
@@ -122,7 +126,9 @@ describe("Perforce Uris", () => {
             const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
             const augmented = PerforceUri.withArgs(uri, { p4Args: "hello" });
             expect(augmented.query).to.equal(
-                "command=print&p4Args=hello&depot&" + workspaceArg + "&depotName=depot"
+                "command=print&p4Args=hello&depot&" +
+                    workspaceArg +
+                    "&depotName=depot&rev=2"
             );
             expect(augmented.fragment).to.equal("2");
         });


### PR DESCRIPTION
* Checks if the file being annotated is the same as the active editor and if so sets the visible range in the new editor to match the existing one

* Encode the revision in to the query in URIs - not reading it currently, but vs code was (correctly) treating URIs with the same path but different fragments as the same file and not opening a new version
  * This meant that if you had a depot file open and chose to annotate a different revision it would apply the annotations to the open revision instead of opening a new document
  * Preferably any uses that rely on the `fsPath` or `fragment` of the URI should be replaced with calls to `PerforceUri` functions so we have centralised control of URI encoding and decoding - I would ultimately like to encode the revision with the '#' into the `fsPath` itself so that it shows up in the editor title when opening a depot file, but this is quite complicated
