### PR TITLE
Remove check for same server address

### DIFF
--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -393,8 +393,7 @@ export class PerforceSCMProvider {
         return (
             a.clientName === b.clientName &&
             a.clientRoot.fsPath === b.clientRoot.fsPath &&
-            a.userName === b.userName &&
-            a.serverAddress === b.serverAddress
+            a.userName === b.userName
         );
     }
 


### PR DESCRIPTION
* different hostnames can resolve to the same server
* VS code can't actually handle two SCM providers with the same directory anyway, so we just ended up with an invisible provider adding to the count and running double commands
* (arguably, we could just use client root as the only differentiator... one to consider)