### PR TITLE
Focus on slevesque / mjcrouch extensions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -436,7 +436,8 @@ async function checkForSlevesque(ctx: vscode.ExtensionContext) {
             ctx.globalState.update("ignoreSlevesque", true);
         } else if (chosen === showExts) {
             vscode.commands.executeCommand(
-                "workbench.extensions.action.showInstalledExtensions"
+                "workbench.extensions.action.showExtensionsWithIds",
+                ["slevesque.perforce", "mjcrouch.perforce"]
             );
         }
     }


### PR DESCRIPTION
- When the check finds there is both,
- and the user clicks "Show installed",
- Focuses specifically on the extensions in the extension view