### PR TITLE
Unshelve other changelists

### DIFF
--- a/src/TsUtils.ts
+++ b/src/TsUtils.ts
@@ -31,9 +31,16 @@ export function parseDate(dateString: string) {
     }
 }
 
-export function pluralise(num: number, word: string, limit?: number) {
+export function pluralise(
+    num: number,
+    word: string,
+    limit?: number,
+    fullPlural?: string
+) {
     const isLimit = num === limit;
-    return num + (isLimit ? "+ " : " ") + (num === 1 && !isLimit ? word : word + "s");
+    const pluralWord = fullPlural || word + "s";
+    const pluralised = num === 1 && !isLimit ? word : pluralWord;
+    return num + (isLimit ? "+ " : " ") + pluralised;
 }
 
 export function isPositiveOrZero(str: string) {

--- a/src/quickPick/ChangeQuickPick.ts
+++ b/src/quickPick/ChangeQuickPick.ts
@@ -11,6 +11,7 @@ import { toReadableDateTime } from "../DateFormatter";
 import { configAccessor } from "../ConfigService";
 import { focusChangelist } from "../search/ChangelistTreeView";
 import { PerforceSCMProvider } from "../ScmProvider";
+import { pluralise } from "../TsUtils";
 
 const nbsp = "\xa0";
 
@@ -72,8 +73,8 @@ async function unshelveAndRefresh(resource: vscode.Uri, options: p4.UnshelveOpti
         if (output.warnings.length > 0) {
             Display.showImportantError(
                 "The changelist was unshelved, but " +
-                    output.warnings.length +
-                    " file(s) need resolving"
+                    pluralise(output.warnings.length, "file needs", 0, "files need") +
+                    " resolving"
             );
         }
     } catch (err) {

--- a/src/quickPick/ChangeQuickPick.ts
+++ b/src/quickPick/ChangeQuickPick.ts
@@ -10,6 +10,7 @@ import { showQuickPickForFile } from "./FileQuickPick";
 import { toReadableDateTime } from "../DateFormatter";
 import { configAccessor } from "../ConfigService";
 import { focusChangelist } from "../search/ChangelistTreeView";
+import { PerforceSCMProvider } from "../ScmProvider";
 
 const nbsp = "\xa0";
 
@@ -43,6 +44,7 @@ export const changeQuickPickProvider: qp.ActionableQuickPickProvider = {
         const actions = makeFocusPick(resource, change).concat(
             makeSwarmPick(change),
             makeClipboardPicks(resource, change),
+            makeUnshelvePicks(resource, shelvedChange),
             makeJobPicks(resource, change),
             makeFilePicks(resource, change),
             makeShelvedFilePicks(resource, shelvedChange)
@@ -62,6 +64,114 @@ export const changeQuickPickProvider: qp.ActionableQuickPickProvider = {
         };
     },
 };
+
+async function unshelveAndRefresh(resource: vscode.Uri, options: p4.UnshelveOptions) {
+    try {
+        const output = await p4.unshelve(resource, options);
+        Display.showMessage("Changelist unshelved");
+        if (output.warnings.length > 0) {
+            Display.showImportantError(
+                "The changelist was unshelved, but " +
+                    output.warnings.length +
+                    " file(s) need resolving"
+            );
+        }
+    } catch (err) {}
+    PerforceSCMProvider.RefreshAll();
+}
+
+export const unshelveChangeQuickPickProvider: qp.ActionableQuickPickProvider = {
+    provideActions: async (
+        resourceOrStr: vscode.Uri | string,
+        chnum: string,
+        clobber: boolean = true,
+        branchMapping?: string
+    ): Promise<qp.ActionableQuickPick> => {
+        const resource = qp.asUri(resourceOrStr);
+        const defaultChangelistAction: qp.ActionableQuickPickItem = {
+            label: "Default changelist",
+            description:
+                "Unshelve into the default changelist, or the current changelist if already unshelved",
+            performAction: () =>
+                unshelveAndRefresh(resource, {
+                    shelvedChnum: chnum,
+                    branchMapping,
+                    force: clobber,
+                }),
+        };
+        const newChangelistAction: qp.ActionableQuickPickItem = {
+            label: "New changelist",
+            description: "Unshelve into a new changelist",
+            performAction: async () => {
+                const spec = await p4.getChangeSpec(resource, {});
+                spec.description = "Unshelved from change #" + chnum;
+                spec.files = [];
+                const newChange = await p4.inputChangeSpec(resource, { spec });
+                await unshelveAndRefresh(resource, {
+                    shelvedChnum: chnum,
+                    toChnum: newChange.chnum,
+                    branchMapping,
+                    force: clobber,
+                });
+            },
+        };
+        const changelistActions = await getUnshelveChangelistPicks(
+            resource,
+            chnum,
+            clobber,
+            branchMapping
+        );
+        return {
+            items: [defaultChangelistAction, newChangelistAction, ...changelistActions],
+            excludeFromHistory: true,
+            placeHolder:
+                "Unshelve changelist " +
+                chnum +
+                (branchMapping ? " through branch " + branchMapping : "") +
+                (clobber ? " (WILL CLOBBER WRITABLE FILES)" : ""),
+        };
+    },
+};
+
+async function getUnshelveChangelistPicks(
+    resource: vscode.Uri,
+    chnum: string,
+    clobber: boolean,
+    branchMapping?: string
+) {
+    const info = await p4.getInfo(resource, {});
+    const user = info.get("User name");
+
+    if (!user) {
+        return [];
+    }
+
+    const changelists = await p4.getChangelists(resource, {
+        user,
+        status: p4.ChangelistStatus.PENDING,
+    });
+    return changelists.map<qp.ActionableQuickPickItem>((c) => {
+        return {
+            label: c.chnum,
+            description: c.description.join(" "),
+            performAction: () =>
+                unshelveAndRefresh(resource, {
+                    shelvedChnum: chnum,
+                    toChnum: c.chnum,
+                    branchMapping,
+                    force: clobber,
+                }),
+        };
+    });
+}
+
+export async function showUnshelveQuickPick(
+    resource: vscode.Uri,
+    chnum: string,
+    branchMapping?: string
+) {
+    return qp.showQuickPick("unshelveChange", resource, chnum, true, branchMapping);
+}
 
 export async function showQuickPickForChangelist(resource: vscode.Uri, chnum: string) {
     await qp.showQuickPick("change", resource, chnum);
@@ -185,6 +295,42 @@ function makeFilePicks(
             };
         })
     );
+}
+
+function makeUnshelvePicks(
+    uri: vscode.Uri,
+    change?: DescribedChangelist
+): qp.ActionableQuickPickItem[] {
+    if (!change || change.shelvedFiles.length < 1) {
+        return [];
+    }
+    return [
+        {
+            label: "$(cloud-download) Unshelve changelist...",
+            description: "Unshelve into a selected changelist",
+            performAction: () => {
+                showUnshelveQuickPick(uri, change.chnum);
+            },
+        },
+        {
+            label: "$(cloud-download) Unshelve via branch mapping...",
+            description: "Unshelve, mapping through a branch spec",
+            performAction: async (reopen) => {
+                const branch = await vscode.window.showInputBox({
+                    prompt:
+                        "Enter branch name to unshelve changelist " +
+                        change.chnum +
+                        " through",
+                    ignoreFocusOut: true,
+                });
+                if (branch === undefined) {
+                    reopen();
+                } else {
+                    showUnshelveQuickPick(uri, change.chnum, branch);
+                }
+            },
+        },
+    ];
 }
 
 function makeShelvedFilePicks(

--- a/src/quickPick/ChangeQuickPick.ts
+++ b/src/quickPick/ChangeQuickPick.ts
@@ -76,7 +76,9 @@ async function unshelveAndRefresh(resource: vscode.Uri, options: p4.UnshelveOpti
                     " file(s) need resolving"
             );
         }
-    } catch (err) {}
+    } catch (err) {
+        Display.showImportantError(err);
+    }
     PerforceSCMProvider.RefreshAll();
 }
 

--- a/src/quickPick/QuickPicks.ts
+++ b/src/quickPick/QuickPicks.ts
@@ -24,6 +24,10 @@ export function registerQuickPicks() {
         ChangeQuickPick.changeQuickPickProvider
     );
     QuickPickProvider.registerQuickPickProvider(
+        "unshelveChange",
+        ChangeQuickPick.unshelveChangeQuickPickProvider
+    );
+    QuickPickProvider.registerQuickPickProvider(
         "changeResults",
         ChangeSearchQuickPick.changeSearchQuickPickProvider
     );

--- a/src/test/helpers/StubPerforceModel.ts
+++ b/src/test/helpers/StubPerforceModel.ts
@@ -132,7 +132,10 @@ export class StubPerforceModel {
             chnum: "250",
         });
         this.sync = sinon.stub(p4, "sync").resolves("synced");
-        this.unshelve = sinon.stub(p4, "unshelve").resolves("unshelved");
+        this.unshelve = sinon.stub(p4, "unshelve").resolves({
+            files: [{ depotPath: "//depot/dummy", operation: "edit" }],
+            warnings: [],
+        });
         this.inputChangeSpec = sinon
             .stub(p4, "inputChangeSpec")
             .resolves({ chnum: "99", rawOutput: "Change 99 created" });

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -27,7 +27,6 @@ import {
 import { ChangeSpec } from "../../api/CommonTypes";
 import { SubmitChangelistOptions } from "../../api/PerforceApi";
 import { ClientRoot } from "../../extension";
-import { basename } from "path";
 
 chai.use(sinonChai);
 chai.use(p4Commands);

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -27,6 +27,7 @@ import {
 import { ChangeSpec } from "../../api/CommonTypes";
 import { SubmitChangelistOptions } from "../../api/PerforceApi";
 import { ClientRoot } from "../../extension";
+import { basename } from "path";
 
 chai.use(sinonChai);
 chai.use(p4Commands);
@@ -1240,6 +1241,29 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(items.refresh).to.have.been.calledOnce;
             });
 
+            it("Displays a warning if files need resolving", async () => {
+                items.stubModel.unshelve.resolves({
+                    files: [
+                        { depotPath: basicFiles.edit().depotPath, operation: "edit" },
+                        ,
+                    ],
+                    warnings: [
+                        {
+                            depotPath: basicFiles.edit().depotPath,
+                            resolvePath: basicFiles.edit().depotPath + "@=1",
+                        },
+                    ],
+                });
+                await PerforceSCMProvider.UnshelveChangelist(items.instance.resources[1]);
+                expect(items.showMessage).to.have.been.calledOnceWith(
+                    "Changelist unshelved"
+                );
+                expect(items.showImportantError).to.have.been.calledOnceWith(
+                    sinon.match("needs resolving")
+                );
+                expect(items.refresh).to.have.been.calledOnce;
+            });
+
             it("Cannot unshelve default changelist", async () => {
                 await expect(
                     PerforceSCMProvider.UnshelveChangelist(items.instance.resources[0])
@@ -1493,6 +1517,32 @@ describe("Model & ScmProvider modules (integration)", () => {
                     delete: true,
                     paths: [basicFiles.shelveEdit().depotPath],
                 });
+                expect(items.refresh).to.have.been.called;
+            });
+            it("Does not delete the shelved file if a resolve is needed", async () => {
+                const resource = findResourceForShelvedFile(
+                    items.instance.resources[1],
+                    basicFiles.shelveEdit()
+                );
+                items.stubModel.unshelve.resolves({
+                    files: [
+                        { depotPath: basicFiles.edit().depotPath, operation: "edit" },
+                        ,
+                    ],
+                    warnings: [
+                        {
+                            depotPath: basicFiles.edit().depotPath,
+                            resolvePath: basicFiles.edit().depotPath + "@=1",
+                        },
+                    ],
+                });
+
+                await PerforceSCMProvider.ShelveOrUnshelve(resource);
+
+                expect(items.stubModel.shelve).not.to.have.been.called;
+                expect(items.showImportantError).to.have.been.calledWithMatch(
+                    "needs resolving"
+                );
                 expect(items.refresh).to.have.been.called;
             });
             it("Does not delete the shelved file if the unshelve fails", async () => {


### PR DESCRIPTION
Adds option to the changelist quick pick to unshelve a changelist if it contains shelved files

* Into a changelist
* Into a changelist, via a branch mapping - not hugely useful *yet* as you still need to resolve after this kind of unshelve
* Parses the unshelve output
  * Shows a warning if files require resolve

Think the code needs some tidy up - could possibly have a better format for the parsed output. Should also apply the same check for unresolved files in the scm unshelve view, which I'll probably include in this PR

Fixes #103 