### PR TITLE
Show & resolve unresolved files

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ This fork fixes many issues from the original extension and adds a variety of ot
 * Automatically creates an SCM provider to manage changelists when you open a file from a different perforce client
 * Adds support for attaching jobs to changelists
 * Improved support for shelved files & changelists
+* Basic support for resolving and re-resolving changelists
 * Supports multiple P4CONFIG files in the same workspace
 * Works more reliably with personal servers
 * Ability to move selected file from the default changelist to a new changelist
@@ -367,6 +368,7 @@ You can specify how you want the extension to activate by setting the parameter 
 |`perforce.hideEmptyChangelists`    |`boolean`  |Hide changelists with no file in the SCM Explorer.
 |`perforce.hideSubmitIcon`          |`boolean`  |Don't show the submit icon next to the changelist description.
 |`perforce.promptBeforeSubmit`      |`boolean`  |Whether to prompt for confirmation before submitting a saved changelist.
+|`perforce.resolve.p4editor`        |`string`   |Overrides P4EDITOR when running resolve commands
 |`perforce.editorButtons.diffPrevAndNext`      |`enum`  |Controls when to show buttons on the editor title menu for diffing next / previous
 |&nbsp;
 |`perforce.bottleneck.maxConcurrent` |`number`  |Limit the maximum number of perforce commands running at any given time.

--- a/package.json
+++ b/package.json
@@ -188,6 +188,11 @@
                     "default": "none",
                     "description": "Configure a path to p4 or an alternate command if needed"
                 },
+                "perforce.resolve.p4editor": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Overrides P4EDITOR when running resolve commands. Use an empty value to not override. Use `code --wait` to resolve files in vscode. When editing a merge file in vscode, save the file and close it to continue the resolve"
+                },
                 "perforce.countBadge": {
                     "type": "string",
                     "description": "Controls the badge counter for Perforce",

--- a/package.json
+++ b/package.json
@@ -530,6 +530,16 @@
                 "icon": "$(edit)"
             },
             {
+                "command": "perforce.resolveChangelist",
+                "title": "Resolve changelist...",
+                "category": "Perforce"
+            },
+            {
+                "command": "perforce.reresolveChangelist",
+                "title": "Re-resolve changelist...",
+                "category": "Perforce"
+            },
+            {
                 "command": "perforce.reopenFile",
                 "title": "Move to changelist...",
                 "category": "Perforce",
@@ -674,6 +684,14 @@
                 },
                 {
                     "command": "perforce.describe",
+                    "when": "0"
+                },
+                {
+                    "command": "perforce.resolveChangelist",
+                    "when": "0"
+                },
+                {
+                    "command": "perforce.reresolveChangelist",
                     "when": "0"
                 },
                 {
@@ -862,6 +880,16 @@
                     "group": "1_modification@4"
                 },
                 {
+                    "command": "perforce.resolveChangelist",
+                    "when": "scmProvider == perforce && scmResourceGroup =~ /unres/",
+                    "group": "1_resolve@1"
+                },
+                {
+                    "command": "perforce.reresolveChangelist",
+                    "when": "scmProvider == perforce && scmResourceGroup =~ /reres/",
+                    "group": "1_resolve@2"
+                },
+                {
                     "command": "perforce.shelveChangelist",
                     "when": "scmProvider == perforce && scmResourceGroup != default",
                     "group": "2_shelving@1"
@@ -889,7 +917,7 @@
                 {
                     "command": "perforce.unfixJob",
                     "when": "scmProvider == perforce && scmResourceGroup != default",
-                    "group": "3_job@1"
+                    "group": "3_job@2"
                 },
                 {
                     "command": "perforce.describe",

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
                 "perforce.resolve.p4editor": {
                     "type": "string",
                     "default": "",
-                    "description": "Overrides P4EDITOR when running resolve commands. Use an empty value to not override. Use `code --wait` to resolve files in vscode. When editing a merge file in vscode, save the file and close it to continue the resolve"
+                    "description": "Overrides P4EDITOR when running resolve commands, allowing you to use a different editor to edit the merge file. Use an empty value to not override.\n\nUse `code --wait` to resolve files in vscode. When editing a merge file in vscode, save the file and close it to continue the resolve.\n\nIMPORTANT: `code --wait` DOES NOT APPEAR TO WORK AS A P4EDITOR ON WINDOWS"
                 },
                 "perforce.countBadge": {
                     "type": "string",

--- a/resources/icons/dark/status-unresolved-add.svg
+++ b/resources/icons/dark/status-unresolved-add.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#3c8746" stroke="#FF5533" stroke-width="13" x="5" y="6" width="90" height="89" rx="40" ry="40"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    A
+  </text>
+</svg>

--- a/resources/icons/dark/status-unresolved-archive.svg
+++ b/resources/icons/dark/status-unresolved-archive.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#7F4E7E" stroke="#FF5533" stroke-width="13" x="5" y="6" width="90" height="89" rx="40" ry="40"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    A
+  </text>
+</svg>

--- a/resources/icons/dark/status-unresolved-branch.svg
+++ b/resources/icons/dark/status-unresolved-branch.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#3c8746" stroke="#FF5533" stroke-width="13" x="5" y="6" width="90" height="89" rx="40" ry="40"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    B
+  </text>
+</svg>

--- a/resources/icons/dark/status-unresolved-delete.svg
+++ b/resources/icons/dark/status-unresolved-delete.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#9E121D" stroke="#FF5533" stroke-width="13" x="5" y="6" width="90" height="89" rx="40" ry="40"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    D
+  </text>
+</svg>

--- a/resources/icons/dark/status-unresolved-edit.svg
+++ b/resources/icons/dark/status-unresolved-edit.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#1B80B2" stroke="#FF5533" stroke-width="13" x="5" y="6" width="90" height="89" rx="40" ry="40"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    E
+  </text>
+</svg>

--- a/resources/icons/dark/status-unresolved-integrate.svg
+++ b/resources/icons/dark/status-unresolved-integrate.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#7F4E7E" stroke="#FF5533" stroke-width="13" x="5" y="6" width="90" height="89" rx="40" ry="40"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    I
+  </text>
+</svg>

--- a/resources/icons/dark/status-unresolved-lock.svg
+++ b/resources/icons/dark/status-unresolved-lock.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#692C77" stroke="#FF5533" stroke-width="13" x="5" y="6" width="90" height="89" rx="40" ry="40"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    L
+  </text>
+</svg>

--- a/resources/icons/dark/status-unresolved-move.svg
+++ b/resources/icons/dark/status-unresolved-move.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#4668C5" stroke="#FF5533" stroke-width="13" x="5" y="6" width="90" height="89" rx="40" ry="40"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    M
+  </text>
+</svg>

--- a/resources/icons/light/status-unresolved-add.svg
+++ b/resources/icons/light/status-unresolved-add.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#3c8746" stroke="#FF5533" stroke-width="13" x="5" y="6" width="90" height="89" rx="40" ry="40"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    A
+  </text>
+</svg>

--- a/resources/icons/light/status-unresolved-archive.svg
+++ b/resources/icons/light/status-unresolved-archive.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#7F4E7E" stroke="#FF5533" stroke-width="13" x="5" y="6" width="90" height="89" rx="40" ry="40"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    A
+  </text>
+</svg>

--- a/resources/icons/light/status-unresolved-branch.svg
+++ b/resources/icons/light/status-unresolved-branch.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#3c8746" stroke="#FF5533" stroke-width="13" x="5" y="6" width="90" height="89" rx="40" ry="40"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    B
+  </text>
+</svg>

--- a/resources/icons/light/status-unresolved-delete.svg
+++ b/resources/icons/light/status-unresolved-delete.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#9E121D" stroke="#FF5533" stroke-width="13" x="5" y="6" width="90" height="89" rx="40" ry="40"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    D
+  </text>
+</svg>

--- a/resources/icons/light/status-unresolved-edit.svg
+++ b/resources/icons/light/status-unresolved-edit.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#1B80B2" stroke="#FF5533" stroke-width="13" x="5" y="6" width="90" height="89" rx="40" ry="40"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    E
+  </text>
+</svg>

--- a/resources/icons/light/status-unresolved-integrate.svg
+++ b/resources/icons/light/status-unresolved-integrate.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#7F4E7E" stroke="#FF5533" stroke-width="13" x="5" y="6" width="90" height="89" rx="40" ry="40"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    I
+  </text>
+</svg>

--- a/resources/icons/light/status-unresolved-lock.svg
+++ b/resources/icons/light/status-unresolved-lock.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#692C77" stroke="#FF5533" stroke-width="13" x="5" y="6" width="90" height="89" rx="40" ry="40"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    L
+  </text>
+</svg>

--- a/resources/icons/light/status-unresolved-move.svg
+++ b/resources/icons/light/status-unresolved-move.svg
@@ -1,0 +1,6 @@
+<svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect fill="#4668C5" stroke="#FF5533" stroke-width="13" x="5" y="6" width="90" height="89" rx="40" ry="40"/>
+  <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
+    M
+  </text>
+</svg>

--- a/src/ConfigService.ts
+++ b/src/ConfigService.ts
@@ -81,6 +81,10 @@ export class ConfigAccessor {
         return this.getConfigItem("deleteOnFileDelete") ?? false;
     }
 
+    public get resolveP4EDITOR(): string | undefined {
+        return this.getConfigItem("resolve.p4editor");
+    }
+
     public get swarmHost(): string | undefined {
         return this.getConfigItem("swarmHost");
     }

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -16,6 +16,7 @@ import * as CP from "child_process";
 import spawn from "cross-spawn";
 import { CommandLimiter } from "./CommandLimiter";
 import * as Path from "path";
+import { configAccessor } from "./ConfigService";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace PerforceService {
@@ -236,7 +237,12 @@ export namespace PerforceService {
         spawnArgs: CP.SpawnOptions,
         responseCallback: (err: Error | null, stdout: string, stderr: string) => void
     ) {
-        const exec = new ShellExecution(cmd, allArgs, { cwd: spawnArgs.cwd });
+        const editor = configAccessor.resolveP4EDITOR;
+        const env = editor ? { P4EDITOR: editor } : undefined;
+        const exec = new ShellExecution(cmd, allArgs, {
+            cwd: spawnArgs.cwd,
+            env,
+        });
         try {
             const myTask = new Task(
                 { type: "perforce" },

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -1,4 +1,12 @@
-import { workspace, Uri, FileType } from "vscode";
+import {
+    workspace,
+    Uri,
+    FileType,
+    Task,
+    tasks,
+    ShellExecution,
+    Disposable,
+} from "vscode";
 
 import * as PerforceUri from "./PerforceUri";
 import { Display } from "./Display";
@@ -84,7 +92,8 @@ export namespace PerforceService {
         command: string,
         responseCallback: (err: Error | null, stdout: string, stderr: string) => void,
         args?: string[],
-        input?: string
+        input?: string,
+        useTerminal?: boolean
     ): void {
         if (debugModeActive && !debugModeSetup) {
             limiter.debugMode = true;
@@ -100,7 +109,8 @@ export namespace PerforceService {
                     responseCallback(...rest);
                 },
                 args,
-                input
+                input,
+                useTerminal
             );
         }, `<JOB_ID:${++id}:${command}>`);
     }
@@ -142,7 +152,8 @@ export namespace PerforceService {
         command: string,
         responseCallback: (err: Error | null, stdout: string, stderr: string) => void,
         args?: string[],
-        input?: string
+        input?: string,
+        useTerminal?: boolean
     ) {
         const actualResource = PerforceUri.getUsableWorkspace(resource) ?? resource;
         const cmd = getPerforceCmdPath();
@@ -160,7 +171,14 @@ export namespace PerforceService {
 
         const env = { ...process.env, PWD: cwd };
         const spawnArgs: CP.SpawnOptions = { cwd, env };
-        spawnPerforceCommand(cmd, allArgs, spawnArgs, responseCallback, input);
+        spawnPerforceCommand(
+            cmd,
+            allArgs,
+            spawnArgs,
+            responseCallback,
+            input,
+            useTerminal
+        );
     }
 
     function spawnPerforceCommand(
@@ -168,9 +186,24 @@ export namespace PerforceService {
         allArgs: string[],
         spawnArgs: CP.SpawnOptions,
         responseCallback: (err: Error | null, stdout: string, stderr: string) => void,
-        input?: string
+        input?: string,
+        useTerminal?: boolean
     ) {
         logExecutedCommand(cmd, allArgs, input, spawnArgs);
+        if (useTerminal) {
+            spawnInTerminal(cmd, allArgs, spawnArgs, responseCallback);
+        } else {
+            spawnNormally(cmd, allArgs, spawnArgs, responseCallback, input);
+        }
+    }
+
+    function spawnNormally(
+        cmd: string,
+        allArgs: string[],
+        spawnArgs: CP.SpawnOptions,
+        responseCallback: (err: Error | null, stdout: string, stderr: string) => void,
+        input?: string
+    ) {
         const child = spawn(cmd, allArgs, spawnArgs);
 
         let called = false;
@@ -195,6 +228,38 @@ export namespace PerforceService {
         });
     }
 
+    let taskId = 0;
+
+    async function spawnInTerminal(
+        cmd: string,
+        allArgs: string[],
+        spawnArgs: CP.SpawnOptions,
+        responseCallback: (err: Error | null, stdout: string, stderr: string) => void
+    ) {
+        const exec = new ShellExecution(cmd, allArgs, { cwd: spawnArgs.cwd });
+        try {
+            const myTask = new Task(
+                { type: "perforce" },
+                "Perforce #" + ++taskId,
+                "perforce",
+                exec
+            );
+            await tasks.executeTask(myTask);
+            const disposable: Disposable = tasks.onDidEndTask((task) => {
+                if (task.execution.task.name === myTask.name) {
+                    responseCallback(null, "", "");
+                    disposable.dispose();
+                }
+            });
+        } catch (err) {
+            responseCallback(err, "", "");
+        }
+    }
+
+    function escapeCommand(args: string[]) {
+        return args.map((arg) => `'${arg.replace(/'/g, `'\\''`)}'`);
+    }
+
     function logExecutedCommand(
         cmd: string,
         args: string[],
@@ -204,7 +269,7 @@ export namespace PerforceService {
         // not necessarily using these escaped values, because cross-spawn does its own escaping,
         // but no sensible way of logging the unescaped array for a user. The output command line
         // should at least be copy-pastable and work
-        const escapedArgs = args.map((arg) => `'${arg.replace(/'/g, `'\\''`)}'`);
+        const escapedArgs = escapeCommand(args);
         const loggedCommand = [cmd].concat(escapedArgs);
         const censoredInput = args[0].includes("login") ? "***" : input;
         const loggedInput = input ? " < " + censoredInput : "";

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -356,6 +356,14 @@ export class PerforceSCMProvider {
             PerforceSCMProvider.UnfixJob.bind(this)
         );
         commands.registerCommand(
+            "perforce.resolveChangelist",
+            PerforceSCMProvider.ResolveChangelist.bind(this)
+        );
+        commands.registerCommand(
+            "perforce.reresolveChangelist",
+            PerforceSCMProvider.ReResolveChangelist.bind(this)
+        );
+        commands.registerCommand(
             "perforce.loginScm",
             PerforceSCMProvider.Login.bind(this)
         );
@@ -546,6 +554,20 @@ export class PerforceSCMProvider {
             const group = arg;
             const model: Model = group.model;
             await model.Revert(group, true);
+        }
+    }
+
+    public static async ResolveChangelist(input: ResourceGroup) {
+        const model = input.model;
+        if (model) {
+            await model.ResolveChangelist(input);
+        }
+    }
+
+    public static async ReResolveChangelist(input: ResourceGroup) {
+        const model = input.model;
+        if (model) {
+            await model.ReResolveChangelist(input);
         }
     }
 

--- a/src/api/CommandUtils.ts
+++ b/src/api/CommandUtils.ts
@@ -215,6 +215,7 @@ type CommandParams = {
     input?: string;
     hideStdErr?: boolean;
     stdErrIsOk?: boolean;
+    useTerminal?: boolean;
 };
 
 export function runPerforceCommandIgnoringStdErr(
@@ -244,14 +245,15 @@ export async function runPerforceCommand(
     args: string[],
     params: CommandParams
 ): Promise<string> {
-    const { input, hideStdErr, stdErrIsOk } = params;
+    const { input, hideStdErr, stdErrIsOk, useTerminal } = params;
 
     try {
         const [stdout, stderr] = await runPerforceCommandRaw(
             resource,
             command,
             args,
-            input
+            input,
+            useTerminal
         );
         if (stderr) {
             if (hideStdErr) {
@@ -281,7 +283,8 @@ function runPerforceCommandRaw(
     resource: vscode.Uri,
     command: string,
     args: string[],
-    input?: string
+    input?: string,
+    useTerminal?: boolean
 ): Promise<[string, string]> {
     return new Promise((resolve, reject) =>
         PerforceService.execute(
@@ -295,7 +298,8 @@ function runPerforceCommandRaw(
                 }
             },
             args,
-            input
+            input,
+            useTerminal
         )
     );
 }

--- a/src/api/commands/basicOps.ts
+++ b/src/api/commands/basicOps.ts
@@ -298,3 +298,25 @@ export async function isLoggedIn(resource: vscode.Uri): Promise<boolean> {
 }
 
 export const logout = makeSimpleCommand<NoOpts>("logout", () => []);
+
+export type ResolveOptions = {
+    chnum?: string;
+    reresolve?: boolean;
+    files?: PerforceFile[];
+};
+
+const resolveFlags = flagMapper<ResolveOptions>(
+    [
+        ["c", "chnum"],
+        ["f", "reresolve"],
+    ],
+    "files",
+    [],
+    {
+        ignoreRevisionFragments: true,
+    }
+);
+
+export const resolve = makeSimpleCommand("resolve", resolveFlags, () => {
+    return { useTerminal: true };
+});

--- a/src/quickPick/ChangeQuickPick.ts
+++ b/src/quickPick/ChangeQuickPick.ts
@@ -71,11 +71,19 @@ async function unshelveAndRefresh(resource: vscode.Uri, options: p4.UnshelveOpti
         const output = await p4.unshelve(resource, options);
         Display.showMessage("Changelist unshelved");
         if (output.warnings.length > 0) {
-            Display.showImportantError(
-                "The changelist was unshelved, but " +
+            const resolveButton = "Resolve changelist";
+            const chosen = await vscode.window.showWarningMessage(
+                "Changelist #" +
+                    options.shelvedChnum +
+                    " was unshelved, but " +
                     pluralise(output.warnings.length, "file needs", 0, "files need") +
-                    " resolving"
+                    " resolving",
+                resolveButton
             );
+            if (chosen === resolveButton) {
+                await p4.resolve(resource, { chnum: options.shelvedChnum });
+                PerforceSCMProvider.RefreshAll();
+            }
         }
     } catch (err) {
         Display.showImportantError(err);

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -544,6 +544,20 @@ export class Model implements Disposable {
         Display.channel.append(output);
     }
 
+    public async ResolveChangelist(input: ResourceGroup) {
+        this.assertIsNotDefault(input);
+
+        await p4.resolve(this._workspaceUri, { chnum: input.chnum });
+        this.Refresh();
+    }
+
+    public async ReResolveChangelist(input: ResourceGroup) {
+        this.assertIsNotDefault(input);
+
+        await p4.resolve(this._workspaceUri, { chnum: input.chnum, reresolve: true });
+        this.Refresh();
+    }
+
     public async ShelveChangelist(input: ResourceGroup, revert?: boolean): Promise<void> {
         if (input.isDefault) {
             throw new Error("Cannot shelve the default changelist");
@@ -929,6 +943,15 @@ export class Model implements Disposable {
         return resource;
     }
 
+    private static makeGroupId(resources: Resource[], change: ChangeInfo) {
+        const items = [
+            "pending",
+            resources.some((r) => r.isUnresolved) ? "unres" : undefined,
+            resources.some((r) => r.isReresolvable) ? "reres" : undefined,
+        ].filter(isTruthy);
+        return items.join("_") + ":" + change.chnum;
+    }
+
     private createResourceGroups(changelists: ChangeInfo[], resources: Resource[]) {
         if (!this._sourceControl) {
             throw new Error("Source control not initialised");
@@ -970,8 +993,9 @@ export class Model implements Disposable {
                         return;
                     }
                 }
+                const groupId = Model.makeGroupId(resourceStates, c);
                 const group = sc.createResourceGroup(
-                    "pending:" + c.chnum,
+                    groupId,
                     "#" + c.chnum + ": " + c.description.join(" ")
                 ) as ResourceGroup;
                 group.model = this;

--- a/src/scm/Resource.ts
+++ b/src/scm/Resource.ts
@@ -27,6 +27,7 @@ export class Resource implements SourceControlResourceState {
     private _resourceUri: Uri;
     private _fromFile?: Uri;
     private _fromEndRev?: string;
+    private _isUnresolved?: boolean;
 
     /**
      * The working revision of the file if open (it should be)
@@ -55,7 +56,11 @@ export class Resource implements SourceControlResourceState {
         return this._resourceUri;
     }
     get decorations(): SourceControlResourceDecorations {
-        return DecorationProvider.getDecorations(this._statuses, this._isShelved);
+        return DecorationProvider.getDecorations(
+            this._statuses,
+            this._isShelved,
+            this._isUnresolved
+        );
     }
     /**
      * The underlying URI is always the workspace path, where it is known, or undefined otherwise
@@ -125,6 +130,7 @@ export class Resource implements SourceControlResourceState {
         if (this._isShelved) {
             // force a depot-like path as the resource URI, to sort them together in the tree
             this._resourceUri = PerforceUri.fromUriWithRevision(_uri, "@=" + this.change);
+            this._isUnresolved = false;
         } else {
             if (!_underlyingUri) {
                 throw new Error(
@@ -132,6 +138,7 @@ export class Resource implements SourceControlResourceState {
                 );
             }
             this._resourceUri = _underlyingUri;
+            this._isUnresolved = !!fstatInfo["unresolved"];
             // TODO - do we need the one with the working revision - can't use a perforce: scheme here as it should be a local file
             //PerforceUri.fromUriWithRevision(_underlyingUri, this._workingRevision);
         }

--- a/src/scm/Resource.ts
+++ b/src/scm/Resource.ts
@@ -28,6 +28,7 @@ export class Resource implements SourceControlResourceState {
     private _fromFile?: Uri;
     private _fromEndRev?: string;
     private _isUnresolved: boolean;
+    private _isReresolvable: boolean;
 
     /**
      * The working revision of the file if open (it should be)
@@ -114,6 +115,14 @@ export class Resource implements SourceControlResourceState {
         return this._workingRevision;
     }
 
+    get isUnresolved() {
+        return this._isUnresolved;
+    }
+
+    get isReresolvable() {
+        return this._isReresolvable;
+    }
+
     constructor(
         public model: Model,
         private _uri: Uri,
@@ -131,6 +140,7 @@ export class Resource implements SourceControlResourceState {
             // force a depot-like path as the resource URI, to sort them together in the tree
             this._resourceUri = PerforceUri.fromUriWithRevision(_uri, "@=" + this.change);
             this._isUnresolved = false;
+            this._isReresolvable = false;
         } else {
             if (!_underlyingUri) {
                 throw new Error(
@@ -139,6 +149,7 @@ export class Resource implements SourceControlResourceState {
             }
             this._resourceUri = _underlyingUri;
             this._isUnresolved = !!fstatInfo["unresolved"];
+            this._isReresolvable = !!fstatInfo["reresolvable"];
             // TODO - do we need the one with the working revision - can't use a perforce: scheme here as it should be a local file
             //PerforceUri.fromUriWithRevision(_underlyingUri, this._workingRevision);
         }

--- a/src/scm/Resource.ts
+++ b/src/scm/Resource.ts
@@ -27,7 +27,7 @@ export class Resource implements SourceControlResourceState {
     private _resourceUri: Uri;
     private _fromFile?: Uri;
     private _fromEndRev?: string;
-    private _isUnresolved?: boolean;
+    private _isUnresolved: boolean;
 
     /**
      * The working revision of the file if open (it should be)

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -39,7 +39,7 @@ interface TestItems {
     showMessage: sinon.SinonSpy<[string], void>;
     showModalMessage: sinon.SinonSpy<[string], void>;
     showError: sinon.SinonSpy<[string], void>;
-    showImportantError: sinon.SinonSpy<[string], void>;
+    showImportantError: sinon.SinonSpy<[string, ...string[]], void>;
     refresh: sinon.SinonSpy;
 }
 
@@ -1241,6 +1241,9 @@ describe("Model & ScmProvider modules (integration)", () => {
             });
 
             it("Displays a warning if files need resolving", async () => {
+                const warn = sinon
+                    .stub(vscode.window, "showWarningMessage")
+                    .resolves(undefined);
                 items.stubModel.unshelve.resolves({
                     files: [
                         { depotPath: basicFiles.edit().depotPath, operation: "edit" },
@@ -1257,9 +1260,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(items.showMessage).to.have.been.calledOnceWith(
                     "Changelist unshelved"
                 );
-                expect(items.showImportantError).to.have.been.calledOnceWith(
-                    sinon.match("needs resolving")
-                );
+                expect(warn).to.have.been.calledOnceWith(sinon.match("needs resolving"));
                 expect(items.refresh).to.have.been.calledOnce;
             });
 
@@ -1519,6 +1520,9 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(items.refresh).to.have.been.called;
             });
             it("Does not delete the shelved file if a resolve is needed", async () => {
+                const warn = sinon
+                    .stub(vscode.window, "showWarningMessage")
+                    .resolves(undefined);
                 const resource = findResourceForShelvedFile(
                     items.instance.resources[1],
                     basicFiles.shelveEdit()
@@ -1539,9 +1543,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 await PerforceSCMProvider.ShelveOrUnshelve(resource);
 
                 expect(items.stubModel.shelve).not.to.have.been.called;
-                expect(items.showImportantError).to.have.been.calledWithMatch(
-                    "needs resolving"
-                );
+                expect(warn).to.have.been.calledWithMatch("needs resolving");
                 expect(items.refresh).to.have.been.called;
             });
             it("Does not delete the shelved file if the unshelve fails", async () => {

--- a/src/test/suite/perforceApi.test.ts
+++ b/src/test/suite/perforceApi.test.ts
@@ -21,7 +21,8 @@ function basicExecuteStub(
     command: string,
     responseCallback: (err: Error | null, stdout: string, stderr: string) => void,
     args?: string[],
-    _input?: string
+    _input?: string,
+    _useTerminal?: boolean
 ) {
     let out = command;
     if (args && args.length > 0) {


### PR DESCRIPTION
Adds red outline to icon when a file is unresolved

Adds commands to resolve a changelist or re-resolve a changelist if it contains unresolved / reresolvable files

Adds buttons on warning prompts, when a file needs resolving, to run the resolve for that changelist / file

This just shows the command line using a task, rather than providing any more parsing etc -  I can't really find a good way of handling the resolve programatically, other than parsing the input, sending output, parsing input, sending output etc. - unless it's just auto-merging, which is not always useful. This seems like the simplest way to report the progress and allow the user to make choices for now

Need https://github.com/microsoft/vscode/pull/90952 to be merged before doing resolve for individual files from the scm view (to avoid cluttering the context menu for all files)

fixes #114