### PR TITLE
Don't add query params to file: URIs when diffing

### DIFF
--- a/package.json
+++ b/package.json
@@ -394,14 +394,21 @@
                 "title": "Diff against the previous revision",
                 "icon": "$(arrow-left)",
                 "category": "Perforce",
-                "enablement": "perforce.currentFile.canDiffPrev"
+                "enablement": "perforce.currentFile.resourceRevision != 1"
+            },
+            {
+                "command": "perforce.diffPreviousFromDiff",
+                "title": "Diff against the previous revision",
+                "icon": "$(arrow-left)",
+                "category": "Perforce",
+                "enablement": "isInDiffEditor && perforce.currentFile.resourceRevision != 1 && perforce.currentFile.resourceRevision != 2 || isInDiffLeftEditor && perforce.currentFile.resourceRevision != 1"
             },
             {
                 "command": "perforce.diffNext",
                 "title": "Diff against the next revision",
                 "icon": "$(arrow-right)",
                 "category": "Perforce",
-                "enablement": "perforce.currentFile.canDiffNext"
+                "enablement": "resourceScheme == perforce"
             },
             {
                 "command": "perforce.annotate",
@@ -746,6 +753,10 @@
                     "when": "0"
                 },
                 {
+                    "command": "perforce.diffPreviousFromDiff",
+                    "when": "0"
+                },
+                {
                     "command": "perforce.loginScm",
                     "when": "0"
                 },
@@ -1021,27 +1032,57 @@
                 {
                     "command": "perforce.diffPrevious",
                     "group": "navigation@-11",
-                    "when": "perforce.currentFile.showDiffPrev && config.perforce.editorButtons.diffPrevAndNext =~ /All/ || perforce.currentFile.showDiffPrev && config.perforce.editorButtons.diffPrevAndNext =~ /Only/ && perforce.currentFile.isPerforceOrDiff"
+                    "when": "!isInDiffEditor && perforce.currentFile.status =~ /OPEN/ && config.perforce.editorButtons.diffPrevAndNext =~ /All/"
+                },
+                {
+                    "command": "perforce.diffPrevious",
+                    "group": "navigation@-11",
+                    "when": "!isInDiffEditor && perforce.currentFile.status != OPEN && perforce.currentFile.status != NOT_OPEN && config.perforce.editorButtons.diffPrevAndNext =~ /All/ && resourceScheme == perforce"
+                },
+                {
+                    "command": "perforce.diffPrevious",
+                    "group": "navigation@-11",
+                    "when": "!isInDiffEditor && perforce.currentFile.status =~ /OPEN/ && config.perforce.editorButtons.diffPrevAndNext =~ /Only/ && resourceScheme == perforce"
+                },
+                {
+                    "command": "perforce.diffPreviousFromDiff",
+                    "group": "navigation@-11",
+                    "when": "isInDiffEditor && perforce.activation.hasScmProvider && config.perforce.editorButtons.diffPrevAndNext =~ /(All|Only)/"
                 },
                 {
                     "command": "perforce.depotActions",
                     "group": "navigation@-10",
-                    "when": "perforce.currentFile.isPerforceOrDiff"
+                    "when": "isInDiffEditor && perforce.activation.hasScmProvider || resourceScheme == perforce"
                 },
                 {
                     "command": "perforce.diffNext",
                     "group": "navigation@-9",
-                    "when": "perforce.currentFile.showDiffNext && config.perforce.editorButtons.diffPrevAndNext =~ /All/ || perforce.currentFile.showDiffPrev && config.perforce.editorButtons.diffPrevAndNext =~ /Only/ && perforce.currentFile.isPerforceOrDiff"
+                    "when": "!isInDiffEditor && config.perforce.editorButtons.diffPrevAndNext =~ /(All|Only)/ && resourceScheme == perforce && perforce.currentFile.hasRevision"
+                },
+                {
+                    "command": "perforce.diffNext",
+                    "group": "navigation@-9",
+                    "when": "isInDiffEditor && perforce.activation.hasScmProvider && config.perforce.editorButtons.diffPrevAndNext =~ /(All|Only)/"
                 },
                 {
                     "command": "perforce.diffPrevious",
                     "group": "perforce@1",
-                    "when": "perforce.currentFile.showDiffPrev"
+                    "when": "!isInDiffEditor && perforce.currentFile.status =~ /OPEN/"
+                },
+                {
+                    "command": "perforce.diffPrevious",
+                    "group": "perforce@1",
+                    "when": "!isInDiffEditor && perforce.currentFile.status != OPEN && perforce.currentFile.status != NOT_OPEN && resourceScheme == perforce"
+                },
+                {
+                    "command": "perforce.diffPreviousFromDiff",
+                    "group": "perforce@1",
+                    "when": "isInDiffEditor && perforce.activation.hasScmProvider"
                 },
                 {
                     "command": "perforce.diffNext",
                     "group": "perforce@2",
-                    "when": "perforce.currentFile.showDiffNext"
+                    "when": "isInDiffEditor && perforce.activation.hasScmProvider"
                 }
             ],
             "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -401,7 +401,7 @@
                 "title": "Diff against the previous revision",
                 "icon": "$(arrow-left)",
                 "category": "Perforce",
-                "enablement": "isInDiffEditor && perforce.currentFile.resourceRevision != 1 && perforce.currentFile.resourceRevision != 2 || isInDiffLeftEditor && perforce.currentFile.resourceRevision != 1"
+                "enablement": "isInDiffEditor && perforce.currentFile.resourceRevision != 1 && !perforce.currentFile.isRightDiffOnRev2"
             },
             {
                 "command": "perforce.diffNext",

--- a/src/ContextVars.ts
+++ b/src/ContextVars.ts
@@ -13,6 +13,7 @@ const makeDefault = () => {
         message: "",
         hasRevision: false,
         resourceRevision: "",
+        isRightDiffOnRev2: false,
     };
 };
 
@@ -51,11 +52,13 @@ function calculateDiffOptions(file?: vscode.Uri) {
     const rev = getRevision(file);
     const hasRevision = rev > 0;
     const resourceRevision = rev.toString();
+    const isRightDiffOnRev2 = rev === 2 && !!file?.query.includes("leftUri=");
 
     // show next diff button only for diffs (including diffs without a revision - for consistent button placement)
     return {
         hasRevision,
         resourceRevision,
+        isRightDiffOnRev2,
     };
 }
 

--- a/src/ContextVars.ts
+++ b/src/ContextVars.ts
@@ -1,4 +1,4 @@
-import { Display, ActiveStatusEvent, ActiveEditorStatus } from "./Display";
+import { Display, ActiveStatusEvent } from "./Display";
 import * as vscode from "vscode";
 import * as PerforceUri from "./PerforceUri";
 
@@ -11,12 +11,8 @@ const makeDefault = () => {
         operation: "",
         filetype: "",
         message: "",
-        showDiffPrev: false,
-        showDiffNext: false,
-        canDiffPrev: false,
-        canDiffNext: false,
-        isPerforceOrDiff: false,
         hasRevision: false,
+        resourceRevision: "",
     };
 };
 
@@ -40,14 +36,6 @@ function getFileContext(arg: keyof ContextVars) {
     return fileContext[arg] ?? "";
 }
 
-function isPerforceDoc(file?: vscode.Uri) {
-    return !!file && file.scheme === "perforce";
-}
-
-function isRightDiffWindow(file?: vscode.Uri) {
-    return !!file && !!PerforceUri.decodeUriQuery(file.query).leftUri;
-}
-
 function getRevision(file?: vscode.Uri) {
     if (!file) {
         return -1;
@@ -59,38 +47,20 @@ function getRevision(file?: vscode.Uri) {
     return fileRev;
 }
 
-function calculateDiffOptions(file?: vscode.Uri, status?: ActiveEditorStatus) {
-    const isRightWindow = isRightDiffWindow(file);
-    // show diff buttons for all perforce files, all diff windows and anything that is NOT 'not in workspace'
-
-    const isPerforceOrDiff = isRightWindow || isPerforceDoc(file);
-
-    const isNotUnknown =
-        status === ActiveEditorStatus.NOT_OPEN || status === ActiveEditorStatus.OPEN;
-    const showDiffPrev = isNotUnknown || isPerforceOrDiff;
-
+function calculateDiffOptions(file?: vscode.Uri) {
     const rev = getRevision(file);
     const hasRevision = rev > 0;
+    const resourceRevision = rev.toString();
 
     // show next diff button only for diffs (including diffs without a revision - for consistent button placement)
-    const showDiffNext = showDiffPrev && (rev >= 0 || isRightWindow);
-
-    const disableDiffPrev =
-        (isPerforceDoc && rev === 1) || (isRightWindow && rev <= 2 && rev > 0);
-    const disableDiffNext = isRightDiffWindow && rev <= 0;
-
     return {
-        showDiffNext,
-        showDiffPrev,
-        canDiffNext: !disableDiffNext,
-        canDiffPrev: !disableDiffPrev,
-        isPerforceOrDiff,
         hasRevision,
+        resourceRevision,
     };
 }
 
 function setContextVars(event: ActiveStatusEvent) {
-    const diffOptions = calculateDiffOptions(event.file, event.status);
+    const diffOptions = calculateDiffOptions(event.file);
 
     fileContext = {
         status: event.status.toString(),

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -35,6 +35,7 @@ export namespace PerforceCommands {
         commands.registerCommand("perforce.diff", diff);
         commands.registerCommand("perforce.diffRevision", diffRevision);
         commands.registerCommand("perforce.diffPrevious", diffPrevious);
+        commands.registerCommand("perforce.diffPreviousFromDiff", diffPreviousFromDiff);
         commands.registerCommand("perforce.diffNext", diffNext);
         commands.registerCommand("perforce.depotActions", showDepotActions);
         commands.registerCommand("perforce.showQuickPick", showQuickPick);
@@ -325,6 +326,15 @@ export namespace PerforceCommands {
             return false;
         }
         await DiffProvider.diffPrevious(fromDoc);
+    }
+
+    async function diffPreviousFromDiff() {
+        const fromDoc = window.activeTextEditor?.document.uri;
+        if (!fromDoc) {
+            Display.showError("No file to diff");
+            return false;
+        }
+        await DiffProvider.diffPrevious(fromDoc, true);
     }
 
     async function diffNext(fromDoc?: Uri) {


### PR DESCRIPTION
* This caused problems in various places such as remote-SSH and cpp extension
* Instead, use `isInDiffEditor` context vars to work out what to do
 * when already diffing previous from the right hand diff editor, skip a revision, to diff have vs have -1
* Behaviour is slightly more limited when diffing previous from a working file diff
  * (will diff against have -1 vs have instead of left -1 vs left unless the left window is clicked first)
* Moved some logic out of ts into package json

Fixes #118 
Probably fixes #119 