### PR TITLE
Use correct resource URI for file results

### DIFF
--- a/src/search/ChangelistTreeView.ts
+++ b/src/search/ChangelistTreeView.ts
@@ -208,7 +208,7 @@ class SearchResultFile extends SelfExpandingTreeItem<any> {
             arguments: [
                 "file",
                 PerforceUri.fromDepotPath(
-                    this._resource,
+                    PerforceUri.getUsableWorkspace(this._resource) ?? this._resource,
                     this._file.depotPath,
                     this._file.revision
                 ).toString(),


### PR DESCRIPTION
Fixes problem clicking on a file when looking at a changelist focused from the quick pick