### PR TITLE
Fix annotations for revisions with multiple source files

### DIFF
--- a/src/ConfigService.ts
+++ b/src/ConfigService.ts
@@ -142,6 +142,10 @@ export class ConfigAccessor {
             this.setConfigItemGlobally("fileShelveMode", "prompt");
         }
     }
+
+    public get annotateFollowBranches(): boolean {
+        return this.getConfigItem("annotate.followBranches") ?? false;
+    }
 }
 
 export const configAccessor = new ConfigAccessor();

--- a/src/TsUtils.ts
+++ b/src/TsUtils.ts
@@ -4,7 +4,7 @@
  * @param obj a single element
  * @returns the truthiness of the value, and narrows the type to T
  */
-export function isTruthy<T>(obj: T | undefined | null): obj is T {
+export function isTruthy<T>(obj: T | undefined | null | void): obj is T {
     return !!obj;
 }
 
@@ -51,4 +51,12 @@ export function isPositiveOrZero(str: string) {
 export function dedupe<T, K extends keyof T>(items: T[], key: K) {
     const done = new Set<T[K]>();
     return items.filter((i) => (done.has(i[key]) ? false : done.add(i[key])));
+}
+
+export function addUniqueKeysToSet<T, K extends keyof T>(
+    current: Set<T[K]>,
+    items: T[],
+    key: K
+) {
+    return items.filter((i) => (current.has(i[key]) ? false : current.add(i[key])));
 }


### PR DESCRIPTION
* When a filelog has a change with multiple sources, run more filelog commands to expand them out
* Improve complexity of annotation by caching stuff by change number - previously O(n*m) for combination of filelog length and file length
* Don't stop the whole annotation when one change is missing (in case of other unknown cases)

Also, correctly show all source revisions in the file history quick pick when there are multiple

fixes #120 