### PR TITLE
Add sync commands to various locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ You can specify how you want the extension to activate by setting the parameter 
 |`perforce.resolve.p4editor`        |`string`   |Overrides P4EDITOR when running resolve commands
 |`perforce.swarmHost`               |`string`   |Specifies the hostname of the Swarm server for annotation links. (`https://localhost`)
 |`perforce.editorButtons.diffPrevAndNext`      |`enum`  |Controls when to show buttons on the editor title menu for diffing next / previous
+|`perforce.explorer.showSyncCommands`|`boolean` |Whether to show commands in the explorer context menu for syncing files and folders
 |&nbsp;
 |`perforce.bottleneck.maxConcurrent` |`number`  |Limit the maximum number of perforce commands running at any given time.
 

--- a/package.json
+++ b/package.json
@@ -306,6 +306,11 @@
                     "default": 200,
                     "description": "The maximum number of results to return in the changelist search",
                     "minimum": 1
+                },
+                "perforce.explorer.showSyncCommands": {
+                    "type": "boolean",
+                    "default": "true",
+                    "description": "Whether to show sync commands on the explorer context menu"
                 }
             }
         },
@@ -375,6 +380,16 @@
                 "category": "Perforce"
             },
             {
+                "command": "perforce.syncOpenFile",
+                "title": "Sync file - Sync the open file to the latest revision",
+                "category": "Perforce"
+            },
+            {
+                "command": "perforce.syncOpenFileRevision",
+                "title": "Sync file revision - Sync the open file to a specific revision",
+                "category": "Perforce"
+            },
+            {
                 "command": "perforce.diff",
                 "title": "Diff - Display diff of client file with depot file",
                 "category": "Perforce"
@@ -423,6 +438,16 @@
                     "light": "resources/icons/light/p4.svg",
                     "dark": "resources/icons/dark/p4.svg"
                 }
+            },
+            {
+                "command": "perforce.explorer.syncPath",
+                "title": "Perforce: Sync file",
+                "category": "Perforce"
+            },
+            {
+                "command": "perforce.explorer.syncDir",
+                "title": "Perforce: Sync directory",
+                "category": "Perforce"
             },
             {
                 "command": "perforce.Sync",
@@ -815,6 +840,14 @@
                 {
                     "command": "perforce.changeSearch.disableAutoRefresh",
                     "when": "0"
+                },
+                {
+                    "command": "perforce.explorer.syncPath",
+                    "when": "0"
+                },
+                {
+                    "command": "perforce.explorer.syncDir",
+                    "when": "0"
                 }
             ],
             "scm/title": [
@@ -1083,6 +1116,18 @@
                     "command": "perforce.diffNext",
                     "group": "perforce@2",
                     "when": "isInDiffEditor && perforce.activation.hasScmProvider"
+                }
+            ],
+            "explorer/context": [
+                {
+                    "command": "perforce.explorer.syncPath",
+                    "group": "perforce@1",
+                    "when": "!explorerResourceIsFolder && perforce.activation.hasScmProvider && config.perforce.explorer.showSyncCommands"
+                },
+                {
+                    "command": "perforce.explorer.syncDir",
+                    "group": "perforce@1",
+                    "when": "explorerResourceIsFolder && perforce.activation.hasScmProvider && config.perforce.explorer.showSyncCommands"
                 }
             ],
             "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -446,7 +446,7 @@
             },
             {
                 "command": "perforce.explorer.syncDir",
-                "title": "Perforce: Sync directory",
+                "title": "Perforce: Sync folder",
                 "category": "Perforce"
             },
             {

--- a/src/ContentProvider.ts
+++ b/src/ContentProvider.ts
@@ -63,3 +63,11 @@ export class PerforceContentProvider {
         return runPerforceCommand(resource, command, allP4Args, { hideStdErr: true });
     }
 }
+
+let _perforceContentProvider: PerforceContentProvider;
+export function perforceContentProvider() {
+    if (!_perforceContentProvider) {
+        _perforceContentProvider = new PerforceContentProvider();
+    }
+    return _perforceContentProvider;
+}

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -177,7 +177,7 @@ export namespace Display {
     }
 
     export function showMessage(message: string) {
-        window.setStatusBarMessage("Perforce: " + message, 3000);
+        window.setStatusBarMessage("Perforce: " + message.replace(/\r?\n/g, " "), 3000);
         channel.append(message + "\n");
     }
 
@@ -186,7 +186,7 @@ export namespace Display {
     }
 
     export function showError(error: string) {
-        window.setStatusBarMessage("Perforce: " + error, 3000);
+        window.setStatusBarMessage("Perforce: " + error.replace(/\r?\n/g, " "), 3000);
         channel.appendLine(`ERROR: ${JSON.stringify(error)}`);
     }
 

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -22,6 +22,7 @@ import * as AnnotationProvider from "./annotations/AnnotationProvider";
 import * as DiffProvider from "./DiffProvider";
 import * as QuickPicks from "./quickPick/QuickPicks";
 import { showQuickPick } from "./quickPick/QuickPickProvider";
+import { splitBy } from "./TsUtils";
 
 // TODO resolve
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -32,6 +33,10 @@ export namespace PerforceCommands {
         commands.registerCommand("perforce.delete", deleteOpenFile);
         commands.registerCommand("perforce.revert", revertOpenFile);
         commands.registerCommand("perforce.submitSingle", submitSingle);
+        commands.registerCommand("perforce.syncOpenFile", syncOpenFile);
+        commands.registerCommand("perforce.syncOpenFileRevision", syncOpenFileRevision);
+        commands.registerCommand("perforce.explorer.syncPath", syncExplorerPath);
+        commands.registerCommand("perforce.explorer.syncDir", syncExplorerDir);
         commands.registerCommand("perforce.diff", diff);
         commands.registerCommand("perforce.diffRevision", diffRevision);
         commands.registerCommand("perforce.diffPrevious", diffPrevious);
@@ -231,6 +236,97 @@ export namespace PerforceCommands {
         Display.showMessage("Changelist " + output.chnum + " submitted");
     }
 
+    async function pickRevision(uri: Uri, placeHolder: string) {
+        const revisions = await p4.getFileHistory(uri, {
+            file: uri,
+            followBranches: false,
+            omitNonContributoryIntegrations: true,
+        });
+
+        const items = revisions
+            .filter((rev, _i, arr) => rev.file === arr[0].file) // ignore pre-renamed files
+            .map((rev) => {
+                return {
+                    label: `#${rev.revision} change: ${rev.chnum}`,
+                    description: rev.description,
+                    item: rev,
+                };
+            });
+
+        const chosen = await window.showQuickPick(items, { placeHolder });
+
+        return chosen?.item;
+    }
+
+    export async function syncOpenFile() {
+        const file = window.activeTextEditor?.document.uri;
+        if (!file || file.scheme !== "file") {
+            Display.showError("No open file to sync");
+            return;
+        }
+
+        await p4.sync(file, { files: [file] });
+        PerforceSCMProvider.RefreshAll();
+        Display.showMessage("File Synced");
+    }
+
+    export async function syncOpenFileRevision() {
+        const file = window.activeTextEditor?.document.uri;
+        if (!file || file.scheme !== "file") {
+            Display.showError("No open file to sync");
+            return;
+        }
+
+        const revision = await pickRevision(file, "Choose a revision to sync");
+
+        if (revision) {
+            const chosen = PerforceUri.fromDepotPath(
+                file,
+                revision.file,
+                revision.revision
+            );
+            await p4.sync(file, { files: [chosen] });
+            PerforceSCMProvider.RefreshAll();
+            Display.showMessage("File Synced");
+        }
+    }
+
+    function withExplorerProgress(func: () => Promise<any>) {
+        return window.withProgress(
+            { location: { viewId: "workbench.view.explorer" } },
+            func
+        );
+    }
+
+    export async function syncExplorerDir(dir: Uri | string, dirs: Uri[]) {
+        const resource = typeof dir === "string" ? Uri.parse(dir) : dir;
+        const allDirs = [resource, ...dirs.filter((d) => d.fsPath !== resource.fsPath)];
+        const promises = allDirs.map((d) => {
+            const path = Path.join(d.fsPath, "...");
+            return p4.sync(d, { files: [path] });
+        });
+        try {
+            await withExplorerProgress(() => Promise.all(promises));
+        } catch {}
+        PerforceSCMProvider.RefreshAll();
+        Display.showMessage("Directory Synced");
+    }
+
+    // accepts a string for any custom tasks etc
+    export async function syncExplorerPath(file: Uri | string, files: Uri[]) {
+        const resource = typeof file === "string" ? Uri.parse(file) : file;
+        const allFiles = [resource, ...files.filter((f) => f.fsPath !== resource.fsPath)];
+        const filesByDir = splitBy(allFiles, (f) => Path.dirname(f.fsPath));
+        const promises = filesByDir.map((dirFiles) =>
+            p4.sync(dirFiles[0], { files: dirFiles })
+        );
+        try {
+            await withExplorerProgress(() => Promise.all(promises));
+        } catch {}
+        PerforceSCMProvider.RefreshAll();
+        Display.showMessage("File Synced");
+    }
+
     export async function diff(revision?: number) {
         const editor = window.activeTextEditor;
         if (!checkFileSelected()) {
@@ -261,7 +357,7 @@ export namespace PerforceCommands {
         }
     }
 
-    export function diffRevision() {
+    export async function diffRevision() {
         const editor = window.activeTextEditor;
         if (!checkFileSelected()) {
             return false;
@@ -277,44 +373,10 @@ export namespace PerforceCommands {
 
         const doc = editor.document;
 
-        const args = ["-s", Utils.expansePath(doc.uri.fsPath)];
-        PerforceService.execute(
-            doc.uri,
-            "filelog",
-            (err, stdout, stderr) => {
-                if (err) {
-                    Display.showError(err.message);
-                } else if (stderr) {
-                    Display.showError(stderr.toString());
-                } else {
-                    const revisions = stdout.split("\n");
-                    const revisionsData: QuickPickItem[] = [];
-                    revisions.shift(); // remove the first line - filename
-                    revisions.forEach((revisionInfo) => {
-                        if (!revisionInfo.includes("... #")) {
-                            return;
-                        }
-
-                        const splits = revisionInfo.split(" ");
-                        const rev = splits[1].substring(1); // splice 1st character '#'
-                        const change = splits[3];
-                        const label = `#${rev} change: ${change}`;
-                        const description = revisionInfo.substring(
-                            revisionInfo.indexOf(splits[9]) + splits[9].length + 1
-                        );
-
-                        revisionsData.push({ label, description });
-                    });
-
-                    window.showQuickPick(revisionsData).then((revision) => {
-                        if (revision) {
-                            diff(parseInt(revision.label.substring(1)));
-                        }
-                    });
-                }
-            },
-            args
-        );
+        const revision = await pickRevision(doc.uri, "Choose a revision to diff against");
+        if (revision) {
+            diff(parseInt(revision.revision));
+        }
     }
 
     async function diffPrevious(fromDoc?: Uri) {
@@ -535,6 +597,14 @@ export namespace PerforceCommands {
             description: "Submit the open file, ONLY if it is in the default changelist",
         });
         items.push({
+            label: "sync file",
+            description: "Sync the file to the latest revision",
+        });
+        items.push({
+            label: "sync revision",
+            description: "Choose a revision to sync",
+        });
+        items.push({
             label: "diff",
             description: "Display diff of client file with depot file",
         });
@@ -575,6 +645,12 @@ export namespace PerforceCommands {
                         break;
                     case "submit single file":
                         submitSingle();
+                        break;
+                    case "sync file":
+                        syncOpenFile();
+                        break;
+                    case "sync revision":
+                        syncOpenFileRevision();
                         break;
                     case "diff":
                         diff();

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -265,9 +265,11 @@ export namespace PerforceCommands {
             return;
         }
 
-        await p4.sync(file, { files: [file] });
+        try {
+            await p4.sync(file, { files: [file] });
+            Display.showMessage("File Synced");
+        } catch {}
         PerforceSCMProvider.RefreshAll();
-        Display.showMessage("File Synced");
     }
 
     export async function syncOpenFileRevision() {
@@ -285,9 +287,11 @@ export namespace PerforceCommands {
                 revision.file,
                 revision.revision
             );
-            await p4.sync(file, { files: [chosen] });
+            try {
+                await p4.sync(file, { files: [chosen] });
+                Display.showMessage("File Synced");
+            } catch {}
             PerforceSCMProvider.RefreshAll();
-            Display.showMessage("File Synced");
         }
     }
 
@@ -307,9 +311,9 @@ export namespace PerforceCommands {
         });
         try {
             await withExplorerProgress(() => Promise.all(promises));
+            Display.showMessage("Directory Synced");
         } catch {}
         PerforceSCMProvider.RefreshAll();
-        Display.showMessage("Directory Synced");
     }
 
     // accepts a string for any custom tasks etc
@@ -322,9 +326,9 @@ export namespace PerforceCommands {
         );
         try {
             await withExplorerProgress(() => Promise.all(promises));
+            Display.showMessage("File Synced");
         } catch {}
         PerforceSCMProvider.RefreshAll();
-        Display.showMessage("File Synced");
     }
 
     export async function diff(revision?: number) {

--- a/src/TsUtils.ts
+++ b/src/TsUtils.ts
@@ -60,3 +60,15 @@ export function addUniqueKeysToSet<T, K extends keyof T>(
 ) {
     return items.filter((i) => (current.has(i[key]) ? false : current.add(i[key])));
 }
+
+export function splitBy<T, R>(items: T[], keyFunc: (item: T) => R): T[][] {
+    const arrs = new Map<R, T[]>();
+    items.forEach((item) => {
+        const key = keyFunc(item);
+        if (!arrs.get(key)) {
+            arrs.set(key, []);
+        }
+        arrs.get(key)?.push(item);
+    });
+    return [...arrs.values()];
+}

--- a/src/api/commands/filelog.ts
+++ b/src/api/commands/filelog.ts
@@ -11,12 +11,17 @@ import { isTruthy, parseDate } from "../../TsUtils";
 export interface FilelogOptions {
     file: PerforceFile;
     followBranches?: boolean;
+    omitNonContributoryIntegrations?: boolean;
 }
 
-const filelogFlags = flagMapper<FilelogOptions>([["i", "followBranches"]], "file", [
-    "-l",
-    "-t",
-]);
+const filelogFlags = flagMapper<FilelogOptions>(
+    [
+        ["i", "followBranches"],
+        ["s", "omitNonContributoryIntegrations"],
+    ],
+    "file",
+    ["-l", "-t"]
+);
 
 const filelog = makeSimpleCommand("filelog", filelogFlags);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import { PerforceCommands } from "./PerforceCommands";
-import { PerforceContentProvider } from "./ContentProvider";
+import { PerforceContentProvider, perforceContentProvider } from "./ContentProvider";
 import FileSystemActions from "./FileSystemActions";
 import { PerforceSCMProvider } from "./ScmProvider";
 import { PerforceService } from "./PerforceService";
@@ -500,7 +500,7 @@ function doOneTimeRegistration() {
         Display.initialize(_disposable);
         ContextVars.initialize(_disposable);
 
-        _perforceContentProvider = new PerforceContentProvider();
+        _perforceContentProvider = perforceContentProvider();
         _disposable.push(_perforceContentProvider);
 
         _disposable.push(


### PR DESCRIPTION
* status bar menu - sync file, sync revision
* file quick pick - sync revision
* explorer context menu - sync file, sync directory
  * Supports multi select
    * For files, splits into directories and syncs all files in a dir together
    * For dirs, one sync per directory
* Adds option to control whether to show explorer context
* remove line breaks in status bar messages
  * makes them readable if multi-line

Attempts to notify content provider when have revision changes so that the gutter diffs are updated. Can't reasonably do this for all cases though, e.g. directory syncs and syncs from the quick pick

fixes #123 