### PR TITLE
Add "move / rename" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -460,6 +460,11 @@
                 "category": "Perforce"
             },
             {
+                "command": "perforce.move",
+                "title": "Move - Move or Rename the open file",
+                "category": "Perforce"
+            },
+            {
                 "command": "perforce.Sync",
                 "title": "Sync",
                 "category": "Perforce",
@@ -857,6 +862,10 @@
                 },
                 {
                     "command": "perforce.explorer.syncDir",
+                    "when": "0"
+                },
+                {
+                    "command": "perforce.explorer.move",
                     "when": "0"
                 }
             ],

--- a/package.json
+++ b/package.json
@@ -311,6 +311,11 @@
                     "type": "boolean",
                     "default": "true",
                     "description": "Whether to show sync commands on the explorer context menu"
+                },
+                "perforce.explorer.showFileOpCommands": {
+                    "type": "boolean",
+                    "default": "true",
+                    "description": "Whether to show file operation commands on the explorer context menu (move / rename etc)"
                 }
             }
         },
@@ -447,6 +452,11 @@
             {
                 "command": "perforce.explorer.syncDir",
                 "title": "Perforce: Sync folder",
+                "category": "Perforce"
+            },
+            {
+                "command": "perforce.explorer.move",
+                "title": "Perforce: Move / Rename",
                 "category": "Perforce"
             },
             {
@@ -1128,6 +1138,11 @@
                     "command": "perforce.explorer.syncDir",
                     "group": "perforce@1",
                     "when": "explorerResourceIsFolder && perforce.activation.hasScmProvider && config.perforce.explorer.showSyncCommands"
+                },
+                {
+                    "command": "perforce.explorer.move",
+                    "group": "perforce@5",
+                    "when": "perforce.activation.hasScmProvider && config.perforce.explorer.showFileOpCommands"
                 }
             ],
             "view/item/context": [

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -356,7 +356,7 @@ export namespace PerforceCommands {
             await p4.edit.ignoringAndHidingStdErr(file, { files: [fromWild] });
             await p4.move(file, { fromToFile: [fromWild, toWild] });
         } catch (err) {
-            Display.showImportantError(err);
+            Display.showImportantError(err.toString());
         }
     }
 
@@ -365,7 +365,7 @@ export namespace PerforceCommands {
             await p4.edit.ignoringAndHidingStdErr(file, { files: [file] });
             await p4.move(file, { fromToFile: [file, newFsPath] });
         } catch (err) {
-            Display.showImportantError(err);
+            Display.showImportantError(err.toString());
         }
     }
 
@@ -398,9 +398,9 @@ export namespace PerforceCommands {
                 moveOne(file, Path.join(newPath, Path.basename(file.fsPath)))
             );
             try {
-                await Promise.all(promises);
+                await withExplorerProgress(() => Promise.all(promises));
             } catch (err) {
-                Display.showImportantError(err);
+                Display.showImportantError(err.toString());
             }
             PerforceSCMProvider.RefreshAll();
         }
@@ -420,9 +420,9 @@ export namespace PerforceCommands {
         });
         if (newPath) {
             try {
-                await moveOne(file, newPath);
+                await withExplorerProgress(() => moveOne(file, newPath));
             } catch (err) {
-                Display.showImportantError(err);
+                Display.showImportantError(err.toString());
             }
             PerforceSCMProvider.RefreshAll();
         }

--- a/src/api/commands/basicOps.ts
+++ b/src/api/commands/basicOps.ts
@@ -320,3 +320,19 @@ const resolveFlags = flagMapper<ResolveOptions>(
 export const resolve = makeSimpleCommand("resolve", resolveFlags, () => {
     return { useTerminal: true };
 });
+
+export type EditOptions = {
+    chnum?: string;
+    files: PerforceFile[];
+};
+const editFlags = flagMapper<EditOptions>([["c", "chnum"]], "files");
+
+export const edit = makeSimpleCommand("edit", editFlags);
+
+export type MoveOptions = {
+    chnum?: string;
+    fromToFile: [PerforceFile, PerforceFile];
+};
+const moveFlags = flagMapper<MoveOptions>([["c", "chnum"]], "fromToFile");
+
+export const move = makeSimpleCommand("move", moveFlags);

--- a/src/test/helpers/StubPerforceModel.ts
+++ b/src/test/helpers/StubPerforceModel.ts
@@ -94,6 +94,9 @@ export class StubPerforceModel {
     public unshelve: sinon.SinonStub<any>;
     public inputChangeSpec: sinon.SinonStub<any>;
     public del: sinon.SinonStub<any>;
+    public move: sinon.SinonStub<any>;
+    public edit: sinon.SinonStub<any>;
+    public editIgnoringStdErr: sinon.SinonStub<any>;
 
     constructor() {
         this.changelists = [];
@@ -140,6 +143,11 @@ export class StubPerforceModel {
             .stub(p4, "inputChangeSpec")
             .resolves({ chnum: "99", rawOutput: "Change 99 created" });
         this.del = sinon.stub(p4, "del").resolves("Files deleted");
+        this.move = sinon.stub(p4, "move").resolves("File moved");
+        this.editIgnoringStdErr = sinon
+            .stub(p4.edit, "ignoringAndHidingStdErr")
+            .resolves("File edited");
+        this.edit = sinon.stub(p4, "edit").resolves("File edited");
     }
 
     resolveOpenFiles(


### PR DESCRIPTION
`Adds move / rename to the explorer context menu and status bar menu

* If multiple files or directories are selected, they must all be in the same dir, and the command moves the selected files to a different directory
* If a single file or directory is selected, the command renames it
* In either case, for a directory being moved it uses wildcards to move all children
* In all cases it opens the file (or wildcarded files) for edit, ignoring errors, and then opens them for move (without the -r) - this seems like it should cover cases where the file is already open or not open yet
* When moving a single file, if the file being moved is the active editor, then it opens the new file in the editor

Not sure about the setting name / description.
If we add more commands my thinking is the breakdown is:
file op commands: move / rename / delete
'normal' commands that don't involve file operations (not sure what to call them): add / edit / revert (/ copy?)
sync commands: sync file / dir