### PR TITLE
Add "add / edit / revert" to explorer context menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,10 @@ You can specify how you want the extension to activate by setting the parameter 
 |`perforce.resolve.p4editor`        |`string`   |Overrides P4EDITOR when running resolve commands
 |`perforce.swarmHost`               |`string`   |Specifies the hostname of the Swarm server for annotation links. (`https://localhost`)
 |`perforce.editorButtons.diffPrevAndNext`      |`enum`  |Controls when to show buttons on the editor title menu for diffing next / previous
+|&nbsp;
 |`perforce.explorer.showSyncCommands`|`boolean` |Whether to show commands in the explorer context menu for syncing files and folders
+|`perforce.explorer.showBasicOpCommands`|`boolean` |Whether to show commands in the explorer context menu for adding, editing and reverting files
+|`perforce.explorer.showFileOpCommands`|`boolean` |Whether to show commands in the explorer context menu for moving files with p4 move
 |&nbsp;
 |`perforce.bottleneck.maxConcurrent` |`number`  |Limit the maximum number of perforce commands running at any given time.
 

--- a/package.json
+++ b/package.json
@@ -312,6 +312,11 @@
                     "default": "true",
                     "description": "Whether to show sync commands on the explorer context menu"
                 },
+                "perforce.explorer.showBasicOpCommands": {
+                    "type": "boolean",
+                    "default": "true",
+                    "description": "Whether to show basic operation commands on the explorer context menu (add / edit / revert)"
+                },
                 "perforce.explorer.showFileOpCommands": {
                     "type": "boolean",
                     "default": "true",
@@ -446,12 +451,27 @@
             },
             {
                 "command": "perforce.explorer.syncPath",
-                "title": "Perforce: Sync file",
+                "title": "Perforce: Sync",
                 "category": "Perforce"
             },
             {
-                "command": "perforce.explorer.syncDir",
-                "title": "Perforce: Sync folder",
+                "command": "perforce.explorer.add",
+                "title": "Perforce: Add",
+                "category": "Perforce"
+            },
+            {
+                "command": "perforce.explorer.edit",
+                "title": "Perforce: Edit",
+                "category": "Perforce"
+            },
+            {
+                "command": "perforce.explorer.revert",
+                "title": "Perforce: Revert",
+                "category": "Perforce"
+            },
+            {
+                "command": "perforce.explorer.revertUnchanged",
+                "title": "Perforce: Revert if unchanged",
                 "category": "Perforce"
             },
             {
@@ -861,7 +881,19 @@
                     "when": "0"
                 },
                 {
-                    "command": "perforce.explorer.syncDir",
+                    "command": "perforce.explorer.add",
+                    "when": "0"
+                },
+                {
+                    "command": "perforce.explorer.edit",
+                    "when": "0"
+                },
+                {
+                    "command": "perforce.explorer.revert",
+                    "when": "0"
+                },
+                {
+                    "command": "perforce.explorer.revertUnchanged",
                     "when": "0"
                 },
                 {
@@ -1140,17 +1172,32 @@
             "explorer/context": [
                 {
                     "command": "perforce.explorer.syncPath",
-                    "group": "perforce@1",
-                    "when": "!explorerResourceIsFolder && perforce.activation.hasScmProvider && config.perforce.explorer.showSyncCommands"
+                    "group": "perforce1-sync@1",
+                    "when": "perforce.activation.hasScmProvider && config.perforce.explorer.showSyncCommands"
                 },
                 {
-                    "command": "perforce.explorer.syncDir",
-                    "group": "perforce@1",
-                    "when": "explorerResourceIsFolder && perforce.activation.hasScmProvider && config.perforce.explorer.showSyncCommands"
+                    "command": "perforce.explorer.add",
+                    "group": "perforce2-op@1",
+                    "when": "!explorerResourceIsFolder && perforce.activation.hasScmProvider && config.perforce.explorer.showBasicOpCommands"
+                },
+                {
+                    "command": "perforce.explorer.edit",
+                    "group": "perforce2-op@2",
+                    "when": "!explorerResourceIsFolder && perforce.activation.hasScmProvider && config.perforce.explorer.showBasicOpCommands"
+                },
+                {
+                    "command": "perforce.explorer.revert",
+                    "group": "perforce2-op@3",
+                    "when": "!explorerResourceIsFolder && perforce.activation.hasScmProvider && config.perforce.explorer.showBasicOpCommands"
+                },
+                {
+                    "command": "perforce.explorer.revertUnchanged",
+                    "group": "perforce2-op@4",
+                    "when": "!explorerResourceIsFolder && perforce.activation.hasScmProvider && config.perforce.explorer.showBasicOpCommands"
                 },
                 {
                     "command": "perforce.explorer.move",
-                    "group": "perforce@5",
+                    "group": "perforce3-fileop@1",
                     "when": "perforce.activation.hasScmProvider && config.perforce.explorer.showFileOpCommands"
                 }
             ],

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -185,6 +185,11 @@ export namespace Display {
         window.showInformationMessage(message, { modal: true });
     }
 
+    export async function requestConfirmation(message: string, yes: string) {
+        const chosen = await window.showWarningMessage(message, { modal: true }, yes);
+        return chosen === yes;
+    }
+
     export function showError(error: string) {
         window.setStatusBarMessage("Perforce: " + error.replace(/\r?\n/g, " "), 3000);
         channel.appendLine(`ERROR: ${JSON.stringify(error)}`);

--- a/src/api/commands/basicOps.ts
+++ b/src/api/commands/basicOps.ts
@@ -321,6 +321,14 @@ export const resolve = makeSimpleCommand("resolve", resolveFlags, () => {
     return { useTerminal: true };
 });
 
+export type AddOptions = {
+    chnum?: string;
+    files: PerforceFile[];
+};
+const addFlags = flagMapper<AddOptions>([["c", "chnum"]], "files");
+
+export const add = makeSimpleCommand("add", addFlags);
+
 export type EditOptions = {
     chnum?: string;
     files: PerforceFile[];

--- a/src/test/suite/perforceCommands.test.ts
+++ b/src/test/suite/perforceCommands.test.ts
@@ -93,6 +93,7 @@ describe("Perforce Command Module (integration)", () => {
     });
     describe("Revert", () => {
         it("Reverts the file open in the editor", async () => {
+            const warn = sinon.stub(Display, "requestConfirmation").resolves(true);
             const localFile = getLocalFile(workspaceUri, "testFolder", "a.txt");
             await vscode.window.showTextDocument(localFile, {
                 preview: false,
@@ -107,6 +108,7 @@ describe("Perforce Command Module (integration)", () => {
             expect(stubModel.revert.getCall(-1).args[1]).to.deep.equal({
                 paths: [localFile],
             });
+            expect(warn).to.have.been.calledWithMatch("sure");
 
             expect(refresh).to.have.been.called;
         });


### PR DESCRIPTION
* Also change to just one sync command instead of sync file / folder
* Add confirmation dialog to revert in status menu
* Also adds link to file history in status bar menu

~I think this still needs some tidying up wrt to selecting a mix of files and folders - the add / edit / revert currently only show when right clicking on a file, but if you select a folder and a file and then right click a file it will fail on the folders because they aren't wildcarded~

~This is probably ok - a bit safer than just allowing a whole directory to be reverted by accident, but think the bit where it consolidates passed in params could be updated to check if a directory is selected, stop the commands from running at-all and show a prompt~

~One option - allow directory command if a single dir is selected but don't allow directory commands if multiple files / dirs are selected~

Made all commands operate on dirs, but count and display the number of directories selected before reverting