### PR TITLE
Add quick pick for individual shelved files

### DIFF
--- a/src/DiffProvider.ts
+++ b/src/DiffProvider.ts
@@ -14,11 +14,25 @@ export enum DiffType {
     WORKSPACE_V_SHELVE,
 }
 
+function numberOfLeadingSlashes(str: string, after = 0) {
+    return str
+        .slice(after)
+        .split("")
+        .findIndex((a) => a !== "/" && a !== "\\");
+}
+
 function findLengthOfCommonPrefix(sa: string, sb: string) {
     const aDir = Path.dirname(sa);
     const bDir = Path.dirname(sb);
     if (aDir === bDir) {
-        return aDir.length + 1;
+        const remainingCommonSlashes = Math.max(
+            0,
+            Math.min(
+                numberOfLeadingSlashes(sa, aDir.length),
+                numberOfLeadingSlashes(sb, bDir.length)
+            )
+        );
+        return aDir.length + remainingCommonSlashes;
     }
     const i = sa.split("").findIndex((a, i) => a !== sb[i]);
     return i;

--- a/src/api/PerforceApi.ts
+++ b/src/api/PerforceApi.ts
@@ -7,3 +7,4 @@ export * from "./commands/basicOps";
 export * from "./commands/filelog";
 export * from "./commands/changes";
 export * from "./commands/integrated";
+export * from "./CommonTypes";

--- a/src/quickPick/ChangeQuickPick.ts
+++ b/src/quickPick/ChangeQuickPick.ts
@@ -12,6 +12,7 @@ import { configAccessor } from "../ConfigService";
 import { focusChangelist } from "../search/ChangelistTreeView";
 import { PerforceSCMProvider } from "../ScmProvider";
 import { pluralise, isTruthy } from "../TsUtils";
+import { showQuickPickForShelvedFile } from "./ShelvedFileQuickPick";
 
 const nbsp = "\xa0";
 
@@ -297,6 +298,7 @@ function makeFilePicks(
                     file.depotPath +
                     "#" +
                     file.revision,
+                description: file.operation,
                 performAction: () => {
                     const thisUri = PerforceUri.fromDepotPath(
                         PerforceUri.getUsableWorkspace(uri) ?? uri,
@@ -369,13 +371,13 @@ function makeShelvedFilePicks(
                     file.depotPath +
                     "#" +
                     file.revision,
+                description: file.operation,
                 performAction: () => {
-                    const thisUri = PerforceUri.fromDepotPath(
+                    showQuickPickForShelvedFile(
                         PerforceUri.getUsableWorkspace(uri) ?? uri,
-                        file.depotPath,
-                        file.revision
+                        file,
+                        change
                     );
-                    showQuickPickForFile(thisUri);
                 },
             };
         })

--- a/src/quickPick/FileQuickPick.ts
+++ b/src/quickPick/FileQuickPick.ts
@@ -161,8 +161,8 @@ async function getChangeDetails(
 ): Promise<ChangeDetails> {
     const haveFile = cached?.haveFile ?? (await p4.have(uri, { file: uri }));
 
-    const uriRev = uri.fragment;
-    const useRev = !uri.fragment || isNaN(parseInt(uriRev)) ? haveFile?.revision : uriRev;
+    const uriRev = PerforceUri.getRevOrAtLabel(uri);
+    const useRev = !uriRev || isNaN(parseInt(uriRev)) ? haveFile?.revision : uriRev;
     if (!useRev) {
         Display.showError("Unable to get file details without a revision");
         throw new Error("No revision available for " + uri.toString());

--- a/src/quickPick/QuickPicks.ts
+++ b/src/quickPick/QuickPicks.ts
@@ -1,5 +1,6 @@
 import * as QuickPickProvider from "./QuickPickProvider";
 import * as FileQuickPick from "./FileQuickPick";
+import * as ShelvedFileQuickPick from "./ShelvedFileQuickPick";
 import * as ChangeQuickPick from "./ChangeQuickPick";
 import * as IntegrationQuickPick from "./IntegrationQuickPick";
 import * as ChangeSearchQuickPick from "./ChangeSearchQuickPick";
@@ -34,5 +35,9 @@ export function registerQuickPicks() {
     QuickPickProvider.registerQuickPickProvider(
         "integ",
         IntegrationQuickPick.integrationQuickPickProvider
+    );
+    QuickPickProvider.registerQuickPickProvider(
+        "shelvedFile",
+        ShelvedFileQuickPick.shelvedFileQuickPickProvider
     );
 }

--- a/src/quickPick/ShelvedFileQuickPick.ts
+++ b/src/quickPick/ShelvedFileQuickPick.ts
@@ -1,0 +1,122 @@
+import * as vscode from "vscode";
+
+import * as PerforceUri from "../PerforceUri";
+import * as p4 from "../api/PerforceApi";
+
+import * as qp from "./QuickPickProvider";
+import * as DiffProvider from "../DiffProvider";
+import { Display } from "../Display";
+import { DescribedChangelist, shelve } from "../api/PerforceApi";
+import { showQuickPickForFile } from "./FileQuickPick";
+import { toReadableDateTime } from "../DateFormatter";
+import { configAccessor } from "../ConfigService";
+import { focusChangelist } from "../search/ChangelistTreeView";
+import { PerforceSCMProvider } from "../ScmProvider";
+import { pluralise, isTruthy } from "../TsUtils";
+import { GetStatus, operationCreatesFile } from "../scm/Status";
+import * as ChangeQuickPick from "./ChangeQuickPick";
+
+const nbsp = "\xa0";
+
+export const shelvedFileQuickPickProvider: qp.ActionableQuickPickProvider = {
+    provideActions: async (
+        resource: vscode.Uri,
+        operation: p4.DepotFileOperation,
+        change: p4.ChangeInfo
+    ) => {
+        const depotUri = PerforceUri.fromDepotPath(
+            resource,
+            operation.depotPath,
+            operation.revision
+        );
+        const have = await p4.have(resource, { file: depotUri });
+        const actions = makeDiffPicks(resource, depotUri, operation, have, change);
+        actions.push({
+            label: "$(list-flat) Go to changelist details",
+            description:
+                "Change " + change.chnum + nbsp + " $(book) " + nbsp + change.description,
+            performAction: () =>
+                ChangeQuickPick.showQuickPickForChangelist(depotUri, change.chnum),
+        });
+        return {
+            items: actions,
+            placeHolder: makeShelvedFileSummary(operation.depotPath, change),
+        };
+    },
+};
+
+export async function showQuickPickForShelvedFile(
+    resource: vscode.Uri,
+    operation: p4.DepotFileOperation,
+    change: p4.ChangeInfo
+) {
+    await qp.showQuickPick("shelvedFile", resource, operation, change);
+}
+
+function makeShelvedFileSummary(depotPath: string, changeInfo: p4.ChangeInfo) {
+    return (
+        "Shelved File " +
+        depotPath +
+        "@=" +
+        changeInfo.chnum +
+        " - " +
+        changeInfo.description.join(" ")
+    );
+}
+
+function makeDiffPicks(
+    resource: vscode.Uri,
+    uri: vscode.Uri,
+    operation: p4.DepotFileOperation,
+    have: p4.HaveFile | undefined,
+    change: p4.ChangeInfo
+): qp.ActionableQuickPickItem[] {
+    const shelvedUri = PerforceUri.fromUriWithRevision(uri, "@=" + change.chnum);
+    const status = GetStatus(operation.operation);
+    return [
+        {
+            label: "$(file) Show shelved file",
+            description: "Open the shelved file in the editor",
+            performAction: () => {
+                vscode.window.showTextDocument(shelvedUri);
+            },
+        },
+        have
+            ? {
+                  label: "$(file) Open workspace file",
+                  description: "Open the local file in the editor",
+                  performAction: () => {
+                      vscode.window.showTextDocument(have.localUri);
+                  },
+              }
+            : undefined,
+        !operationCreatesFile(status)
+            ? {
+                  label: "$(diff) Diff against source revision",
+                  description: DiffProvider.diffTitleForDepotPaths(
+                      operation.depotPath,
+                      operation.revision,
+                      operation.depotPath,
+                      "@=" + change.chnum
+                  ),
+                  performAction: () => DiffProvider.diffFiles(uri, shelvedUri),
+              }
+            : undefined,
+        {
+            label: "$(diff) Diff against workspace file",
+            description: have ? "" : "No matching workspace file found",
+            performAction: have
+                ? () => {
+                      DiffProvider.diffFiles(shelvedUri, have.localUri);
+                  }
+                : undefined,
+        },
+        /*{
+            label: "$(diff) Diff against...",
+            description: "Choose another revision to diff against",
+            performAction: () => {
+                showDiffChooserForFile(uri);
+            },
+        },*/
+    ].filter(isTruthy);
+}

--- a/src/scm/Status.ts
+++ b/src/scm/Status.ts
@@ -13,6 +13,43 @@ export enum Status {
     UNKNOWN,
 }
 
+export function operationCreatesFile(status: Status) {
+    return [Status.ADD, Status.BRANCH, Status.MOVE_ADD].includes(status);
+}
+
+export function operationDeletesFile(status: Status) {
+    return [Status.DELETE, Status.MOVE_DELETE].includes(status);
+}
+
+export function GetStatus(statusText: string): Status {
+    switch (statusText.trim().toLowerCase()) {
+        case "add":
+            return Status.ADD;
+        case "archive":
+            return Status.ARCHIVE;
+        case "branch":
+            return Status.BRANCH;
+        case "delete":
+            return Status.DELETE;
+        case "edit":
+            return Status.EDIT;
+        case "integrate":
+            return Status.INTEGRATE;
+        case "import":
+            return Status.IMPORT;
+        case "lock":
+            return Status.LOCK;
+        case "move/add":
+            return Status.MOVE_ADD;
+        case "move/delete":
+            return Status.MOVE_DELETE;
+        case "purge":
+            return Status.PURGE;
+        default:
+            return Status.UNKNOWN;
+    }
+}
+
 export function GetStatuses(statusText: string): Status[] {
     const result: Status[] = [];
     if (!statusText) {
@@ -21,44 +58,7 @@ export function GetStatuses(statusText: string): Status[] {
 
     const statusStrings: string[] = statusText.split(",");
     for (let i = 0; i < statusStrings.length; i++) {
-        switch (statusStrings[i].trim().toLowerCase()) {
-            case "add":
-                result.push(Status.ADD);
-                break;
-            case "archive":
-                result.push(Status.ARCHIVE);
-                break;
-            case "branch":
-                result.push(Status.BRANCH);
-                break;
-            case "delete":
-                result.push(Status.DELETE);
-                break;
-            case "edit":
-                result.push(Status.EDIT);
-                break;
-            case "integrate":
-                result.push(Status.INTEGRATE);
-                break;
-            case "import":
-                result.push(Status.IMPORT);
-                break;
-            case "lock":
-                result.push(Status.LOCK);
-                break;
-            case "move/add":
-                result.push(Status.MOVE_ADD);
-                break;
-            case "move/delete":
-                result.push(Status.MOVE_DELETE);
-                break;
-            case "purge":
-                result.push(Status.PURGE);
-                break;
-            default:
-                result.push(Status.UNKNOWN);
-                break;
-        }
+        result.push(GetStatus(statusStrings[i]));
     }
 
     return result;

--- a/src/test/suite/diffProvider.test.ts
+++ b/src/test/suite/diffProvider.test.ts
@@ -58,6 +58,14 @@ describe("Diff Provider", () => {
                 "file1.txt#2 ⟷ file1.txt#3"
             );
         });
+        it("Uses the full filename when the dirnames are the same", () => {
+            const path = "//depot/main/file1.txt";
+            const rev1 = "2";
+            const rev2 = "3";
+            expect(
+                DiffProvider.diffTitleForDepotPaths(path + "a", rev1, path + "b", rev2)
+            ).to.equal("file1.txta#2 ⟷ file1.txtb#3");
+        });
         it("Includes all parts of the filename that are not common between the two", () => {
             const path1 = "//depot/main/file1.txt";
             const path2 = "//depot/branches/branch1/file1.txt";


### PR DESCRIPTION
* Allows shelved file to be viewed, diffed against source revision, diffed against workspace revision
* Also adds shelved files to the changelist search results

Fixed some minor issues with diff titles (e.g. path/file1.txt vs path/file2.txt previously resulted in "1.txt vs 2.txt", shelved revision was showing as file#@=123)