### PR TITLE
Quick pick improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -721,6 +721,17 @@
                 "title": "Disable auto search",
                 "category": "Perforce",
                 "icon": "$(sync)"
+            },
+            {
+                "command": "perforce.showOpenFileHistory",
+                "title": "History - show open file history",
+                "category": "Perforce"
+            },
+            {
+                "command": "perforce.showLastQuickPick",
+                "title": "Re-open last quick pick menu",
+                "category": "Perforce",
+                "icon": "$(list-flat)"
             }
         ],
         "menus": {
@@ -949,6 +960,11 @@
                 {
                     "command": "perforce.showOutput",
                     "group": "3_info",
+                    "when": "scmProvider == perforce"
+                },
+                {
+                    "command": "perforce.showLastQuickPick",
+                    "group": "4_more",
                     "when": "scmProvider == perforce"
                 }
             ],
@@ -1354,6 +1370,11 @@
                 "when": "editorTextFocus"
             },
             {
+                "key": "alt+p alt+d",
+                "command": "perforce.diffRevision",
+                "when": "editorTextFocus"
+            },
+            {
                 "key": "alt+p n",
                 "command": "perforce.annotate",
                 "when": "editorTextFocus"
@@ -1365,6 +1386,55 @@
             {
                 "key": "alt+p s",
                 "command": "perforce.submitDefault"
+            },
+            {
+                "key": "alt+p h",
+                "command": "perforce.showOpenFileHistory",
+                "when": "editorTextFocus"
+            },
+            {
+                "key": "alt+p m",
+                "command": "perforce.move",
+                "when": "editorTextFocus"
+            },
+            {
+                "key": "alt+p p",
+                "command": "perforce.showLastQuickPick",
+                "when": "editorTextFocus"
+            },
+            {
+                "key": "alt+p down",
+                "command": "perforce.syncOpenFile",
+                "when": "editorTextFocus"
+            },
+            {
+                "key": "alt+p alt+down",
+                "command": "perforce.syncOpenFileRevision",
+                "when": "editorTextFocus"
+            },
+            {
+                "key": "alt+p shift+down",
+                "command": "perforce.Sync"
+            },
+            {
+                "key": "alt+p left",
+                "command": "perforce.diffPrevious",
+                "when": "!isInDiffEditor && perforce.currentFile.resourceRevision != 1"
+            },
+            {
+                "key": "alt+p left",
+                "command": "perforce.diffPreviousFromDiff",
+                "when": "isInDiffEditor && perforce.currentFile.resourceRevision != 1 && !perforce.currentFile.isRightDiffOnRev2"
+            },
+            {
+                "key": "alt+p right",
+                "command": "perforce.diffNext",
+                "when": "resourceScheme == perforce"
+            },
+            {
+                "key": "alt+p up",
+                "command": "perforce.submitSingle",
+                "when": "editorTextFocus"
             }
         ]
     },

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -22,7 +22,7 @@ import { PerforceSCMProvider } from "./ScmProvider";
 import * as AnnotationProvider from "./annotations/AnnotationProvider";
 import * as DiffProvider from "./DiffProvider";
 import * as QuickPicks from "./quickPick/QuickPicks";
-import { showQuickPick } from "./quickPick/QuickPickProvider";
+import { showQuickPick, openLastQuickPick } from "./quickPick/QuickPickProvider";
 import { splitBy, pluralise, isTruthy } from "./TsUtils";
 import { perforceContentProvider } from "./ContentProvider";
 import { showRevChooserForFile } from "./quickPick/FileQuickPick";
@@ -39,6 +39,7 @@ export namespace PerforceCommands {
         commands.registerCommand("perforce.syncOpenFile", syncOpenFile);
         commands.registerCommand("perforce.syncOpenFileRevision", syncOpenFileRevision);
         commands.registerCommand("perforce.explorer.syncPath", syncExplorerPath);
+        commands.registerCommand("perforce.showOpenFileHistory", showFileHistory);
         commands.registerCommand("perforce.explorer.move", moveExplorerFiles);
         commands.registerCommand("perforce.explorer.add", addExplorerFiles);
         commands.registerCommand("perforce.explorer.edit", editExplorerFiles);
@@ -56,6 +57,7 @@ export namespace PerforceCommands {
         commands.registerCommand("perforce.diffNext", diffNext);
         commands.registerCommand("perforce.depotActions", showDepotActions);
         commands.registerCommand("perforce.showQuickPick", showQuickPick);
+        commands.registerCommand("perforce.showLastQuickPick", openLastQuickPick);
         commands.registerCommand("perforce.annotate", annotate);
         commands.registerCommand("perforce.opened", opened);
         commands.registerCommand("perforce.logout", logout);

--- a/src/quickPick/ChangeQuickPick.ts
+++ b/src/quickPick/ChangeQuickPick.ts
@@ -55,7 +55,8 @@ export const changeQuickPickProvider: qp.ActionableQuickPickProvider = {
         return {
             items: actions,
             placeHolder:
-                "Change " +
+                (change.isPending ? "Pending" : "Submitted") +
+                " change " +
                 chnum +
                 " by " +
                 change.user +
@@ -142,6 +143,7 @@ export const unshelveChangeQuickPickProvider: qp.ActionableQuickPickProvider = {
                 "Unshelve changelist " +
                 chnum +
                 (branchMapping ? " through branch " + branchMapping : "") +
+                " into..." +
                 (clobber ? " (WILL CLOBBER WRITABLE FILES)" : ""),
         };
     },

--- a/src/quickPick/QuickPickProvider.ts
+++ b/src/quickPick/QuickPickProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { isTruthy } from "../TsUtils";
+import { Display } from "../Display";
 
 export function asUri(uri: vscode.Uri | string) {
     if (typeof uri === "string") {
@@ -41,6 +42,16 @@ export function registerQuickPickProvider(
 
 const backLabel = "$(discard) Go Back";
 
+export function openLastQuickPick() {
+    const prev = quickPickStack[quickPickStack.length - 1];
+    if (prev) {
+        quickPickStack.pop();
+        showQuickPick(prev.type, ...prev.args);
+    } else {
+        Display.showImportantError("No previous quick pick available");
+    }
+}
+
 function makeStackActions(): ActionableQuickPickItem[] {
     const prev = quickPickStack[quickPickStack.length - 1];
     return [
@@ -49,8 +60,7 @@ function makeStackActions(): ActionableQuickPickItem[] {
                   label: backLabel,
                   description: "to " + prev.description,
                   performAction: () => {
-                      quickPickStack.pop();
-                      showQuickPick(prev.type, ...prev.args);
+                      openLastQuickPick();
                   },
               }
             : {

--- a/src/quickPick/QuickPickProvider.ts
+++ b/src/quickPick/QuickPickProvider.ts
@@ -72,10 +72,13 @@ export async function showQuickPick(type: string, ...args: any[]) {
             },
             () => provider.provideActions(...args)
         );
+        const curAction: ActionableQuickPickItem = {
+            label: "$(location) " + actions.placeHolder,
+        };
         const stackActions = makeStackActions();
 
         const picked = await vscode.window.showQuickPick(
-            stackActions.concat(actions.items),
+            [...stackActions, curAction, ...actions.items],
             {
                 //ignoreFocusOut: true,
                 matchOnDescription: true,


### PR DESCRIPTION
* show pending / submitted status on changelist quick pick
* ability to show / hide newer revisions when choosing or diffing a revision
* add quick pick title to the quick pick itself to avoid confusion with the back button
* add command to open last quick pick without having to find a random revision
* also adds a variety of keyboard shortcuts