### PR TITLE
Add job quick pick

### DIFF
--- a/package.json
+++ b/package.json
@@ -843,11 +843,11 @@
                     "when": "0"
                 },
                 {
-                    "command": "perforce.loginScm",
+                    "command": "perforce.login",
                     "when": "0"
                 },
                 {
-                    "command": "perforce.logoutScm",
+                    "command": "perforce.logout",
                     "when": "0"
                 },
                 {
@@ -1363,11 +1363,11 @@
             },
             {
                 "key": "alt+p enter",
-                "command": "perforce.login"
+                "command": "perforce.loginScm"
             },
             {
                 "key": "alt+p q",
-                "command": "perforce.logout"
+                "command": "perforce.logoutScm"
             },
             {
                 "key": "alt+p a",

--- a/package.json
+++ b/package.json
@@ -732,6 +732,16 @@
                 "title": "Re-open last quick pick menu",
                 "category": "Perforce",
                 "icon": "$(list-flat)"
+            },
+            {
+                "command": "perforce.goToChangelist",
+                "title": "Go to changelist...",
+                "category": "Perforce"
+            },
+            {
+                "command": "perforce.goToJob",
+                "title": "Go to job...",
+                "category": "Perforce"
             }
         ],
         "menus": {
@@ -963,8 +973,18 @@
                     "when": "scmProvider == perforce"
                 },
                 {
+                    "command": "perforce.goToJob",
+                    "group": "4_more@1",
+                    "when": "scmProvider == perforce"
+                },
+                {
+                    "command": "perforce.goToChangelist",
+                    "group": "4_more@2",
+                    "when": "scmProvider == perforce"
+                },
+                {
                     "command": "perforce.showLastQuickPick",
-                    "group": "4_more",
+                    "group": "4_more@3",
                     "when": "scmProvider == perforce"
                 }
             ],

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -5,11 +5,13 @@ import {
     EventEmitter,
     Uri,
     commands,
+    env,
 } from "vscode";
 
 import { debounce } from "./Debounce";
 import * as p4 from "./api/PerforceApi";
 import * as PerforceUri from "./PerforceUri";
+import { isPositiveOrZero } from "./TsUtils";
 
 let _statusBarItem: StatusBarItem;
 
@@ -232,5 +234,38 @@ export namespace Display {
             return true;
         } catch {}
         return false;
+    }
+
+    async function trimmedClipValue() {
+        const clipValue = await env.clipboard.readText();
+        return clipValue.trim();
+    }
+
+    export async function requestChangelistNumber() {
+        const clipValue = await trimmedClipValue();
+        const value = isPositiveOrZero(clipValue) ? clipValue : undefined;
+
+        return await window.showInputBox({
+            placeHolder: "Changelist number",
+            prompt: "Enter a changelist number",
+            value,
+            validateInput: (value) => {
+                if (!isPositiveOrZero(value)) {
+                    return "must be a positive number";
+                }
+            },
+        });
+    }
+
+    export async function requestJobId() {
+        const clipValue = await trimmedClipValue();
+        const value = /^[a-zA-Z]+[0-9]+[a-zA-Z0-9]*$/.test(clipValue)
+            ? clipValue
+            : undefined;
+        return await window.showInputBox({
+            placeHolder: "job00000n",
+            prompt: "Enter a job",
+            value,
+        });
     }
 }

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -372,6 +372,14 @@ export class PerforceSCMProvider {
             PerforceSCMProvider.Logout.bind(this)
         );
         commands.registerCommand(
+            "perforce.goToChangelist",
+            PerforceSCMProvider.GoToChangelist.bind(this)
+        );
+        commands.registerCommand(
+            "perforce.goToJob",
+            PerforceSCMProvider.GoToJob.bind(this)
+        );
+        commands.registerCommand(
             "perforce.openReviewTool",
             PerforceSCMProvider.OpenChangelistInReviewTool.bind(this)
         );
@@ -412,14 +420,55 @@ export class PerforceSCMProvider {
         );
     }
 
+    static async chooseScmProvider(sourceControl?: SourceControl) {
+        if (!this.isSourceControl(sourceControl)) {
+            if (this.instances.length === 1) {
+                return this.instances[0];
+            }
+            const items = this.instances.map((instance) => {
+                const label =
+                    instance._clientRoot.clientName +
+                    " / " +
+                    instance._clientRoot.userName;
+                return { label, value: instance };
+            });
+            const chosen = await window.showQuickPick(items, {
+                placeHolder: "Choose a context for this operation",
+            });
+            if (chosen) {
+                return chosen.value;
+            }
+        } else {
+            return this.GetInstance(sourceControl);
+        }
+    }
+
     public static async Login(sourceControl?: SourceControl) {
-        const perforceProvider = PerforceSCMProvider.GetInstance(sourceControl);
+        const perforceProvider = await PerforceSCMProvider.chooseScmProvider(
+            sourceControl
+        );
         await perforceProvider?._model.Login();
     }
 
     public static async Logout(sourceControl?: SourceControl) {
-        const perforceProvider = PerforceSCMProvider.GetInstance(sourceControl);
+        const perforceProvider = await PerforceSCMProvider.chooseScmProvider(
+            sourceControl
+        );
         await perforceProvider?._model.Logout();
+    }
+
+    public static async GoToChangelist(sourceControl?: SourceControl) {
+        const perforceProvider = await PerforceSCMProvider.chooseScmProvider(
+            sourceControl
+        );
+        await perforceProvider?._model.GoToChangelist();
+    }
+
+    public static async GoToJob(sourceControl?: SourceControl) {
+        const perforceProvider = await PerforceSCMProvider.chooseScmProvider(
+            sourceControl
+        );
+        await perforceProvider?._model.GoToJob();
     }
 
     public static async OpenFile(...resourceStates: SourceControlResourceState[]) {

--- a/src/api/PerforceApi.ts
+++ b/src/api/PerforceApi.ts
@@ -7,4 +7,5 @@ export * from "./commands/basicOps";
 export * from "./commands/filelog";
 export * from "./commands/changes";
 export * from "./commands/integrated";
+export * from "./commands/job";
 export * from "./CommonTypes";

--- a/src/api/SpecParser.ts
+++ b/src/api/SpecParser.ts
@@ -1,0 +1,27 @@
+import {
+    removeLeadingNewline,
+    splitIntoLines,
+    removeIndent,
+    splitIntoSections,
+} from "./CommandUtils";
+import { RawField } from "./CommonTypes";
+import { pipe } from "@arrows/composition";
+
+const parseRawField = pipe(removeLeadingNewline, splitIntoLines, removeIndent);
+
+function parseRawFields(parts: string[]): RawField[] {
+    return parts.map((field) => {
+        const colPos = field.indexOf(":");
+        const name = field.slice(0, colPos);
+        const value = parseRawField(field.slice(colPos + 2));
+        return { name, value };
+    });
+}
+
+export const getBasicField = (fields: RawField[], field: string) =>
+    fields.find((i) => i.name === field)?.value;
+
+const excludeNonFields = (parts: string[]) =>
+    parts.filter((part) => !part.startsWith("#") && part !== "");
+
+export const parseSpecOutput = pipe(splitIntoSections, excludeNonFields, parseRawFields);

--- a/src/api/commands/job.ts
+++ b/src/api/commands/job.ts
@@ -1,0 +1,84 @@
+import { pipe } from "@arrows/composition";
+import {
+    flagMapper,
+    makeSimpleCommand,
+    asyncOuputHandler,
+    splitIntoLines,
+} from "../CommandUtils";
+import { RawField } from "../CommonTypes";
+import { getBasicField, parseSpecOutput } from "../SpecParser";
+import { isTruthy } from "../../TsUtils";
+
+export type Job = {
+    job?: string;
+    status?: string;
+    user?: string;
+    description?: string;
+    rawFields: RawField[];
+};
+
+function mapToJobFields(rawFields: RawField[]): Job {
+    return {
+        job: getBasicField(rawFields, "Job")?.[0].trim(),
+        status: getBasicField(rawFields, "Status")?.[0].trim(),
+        user: getBasicField(rawFields, "User")?.[0].trim(),
+        description: getBasicField(rawFields, "Description")?.join("\n"),
+        rawFields,
+    };
+}
+
+const parseJobSpec = pipe(parseSpecOutput, mapToJobFields);
+
+export type JobOptions = {
+    existingJob?: string;
+};
+
+const jobFlags = flagMapper<JobOptions>([], "existingJob", ["-o"], {
+    lastArgIsFormattedArray: true,
+});
+
+const outputJob = makeSimpleCommand("job", jobFlags);
+
+export const getJob = asyncOuputHandler(outputJob, parseJobSpec);
+
+export type JobFix = {
+    job: string;
+    chnum: string;
+    date: string;
+    user: string;
+    client: string;
+    status: string;
+};
+
+function parseJobFix(line: string): JobFix | undefined {
+    const matches = /^(\S*) fixed by change (\d+) on (\S*) by (\S*?)@(\S*) \((.*?)\)$/.exec(
+        line
+    );
+    if (matches) {
+        const [, job, chnum, date, user, client, status] = matches;
+        return {
+            job,
+            chnum,
+            date,
+            user,
+            client,
+            status,
+        };
+    }
+}
+
+function parseFixesOutuput(output: string) {
+    // example:
+    // job000001 fixed by change 53 on 2020/04/04 by zogge@default (closed)
+    const lines = splitIntoLines(output);
+    return lines.map(parseJobFix).filter(isTruthy);
+}
+
+export type FixesOptions = {
+    job?: string;
+};
+
+const fixesFlags = flagMapper<FixesOptions>([["j", "job"]]);
+const fixesCommand = makeSimpleCommand("fixes", fixesFlags);
+
+export const fixes = asyncOuputHandler(fixesCommand, parseFixesOutuput);

--- a/src/quickPick/ChangeQuickPick.ts
+++ b/src/quickPick/ChangeQuickPick.ts
@@ -13,6 +13,7 @@ import { focusChangelist } from "../search/ChangelistTreeView";
 import { PerforceSCMProvider } from "../ScmProvider";
 import { pluralise, isTruthy } from "../TsUtils";
 import { showQuickPickForShelvedFile } from "./ShelvedFileQuickPick";
+import { showQuickPickForJob } from "./JobQuickPick";
 
 const nbsp = "\xa0";
 
@@ -256,27 +257,9 @@ function makeClipboardPicks(
     change: DescribedChangelist
 ): qp.ActionableQuickPickItem[] {
     return [
-        {
-            label: "$(clippy) Copy change number to clipboard",
-            description: change.chnum,
-            performAction: () => {
-                vscode.env.clipboard.writeText(change.chnum);
-            },
-        },
-        {
-            label: "$(clippy) Copy user to clipboard",
-            description: change.user,
-            performAction: () => {
-                vscode.env.clipboard.writeText(change.user);
-            },
-        },
-        {
-            label: "$(clippy) Copy change description to clipboard",
-            description: change.description.join(" ").slice(0, 32),
-            performAction: () => {
-                vscode.env.clipboard.writeText(change.description.join("\n"));
-            },
-        },
+        qp.makeClipPick("change number", change.chnum),
+        qp.makeClipPick("user", change.user),
+        qp.makeClipPick("change description", change.description.join("\n")),
     ];
 }
 
@@ -399,6 +382,9 @@ function makeJobPicks(
             return {
                 label: nbsp.repeat(3) + "$(tools) " + job.id,
                 description: job.description.join(" "),
+                performAction: () => {
+                    showQuickPickForJob(uri, job.id);
+                },
             };
         })
     );

--- a/src/quickPick/FileQuickPick.ts
+++ b/src/quickPick/FileQuickPick.ts
@@ -482,14 +482,10 @@ function makeClipboardPicks(
     changes: ChangeDetails
 ): qp.ActionableQuickPickItem[] {
     return [
-        {
-            label: "$(clippy) Copy depot path to clipboard",
-            performAction: () => {
-                vscode.env.clipboard.writeText(
-                    changes.current.file + "#" + changes.current.revision
-                );
-            },
-        },
+        qp.makeClipPick(
+            "depot path",
+            changes.current.file + "#" + changes.current.revision
+        ),
     ];
 }
 

--- a/src/quickPick/JobQuickPick.ts
+++ b/src/quickPick/JobQuickPick.ts
@@ -1,0 +1,91 @@
+import * as vscode from "vscode";
+
+import * as PerforceUri from "../PerforceUri";
+import * as p4 from "../api/PerforceApi";
+
+import * as qp from "./QuickPickProvider";
+import { showQuickPickForChangelist } from "./ChangeQuickPick";
+import { Job } from "../api/PerforceApi";
+
+const nbsp = "\xa0";
+
+export const jobQuickPickProvider: qp.ActionableQuickPickProvider = {
+    provideActions: async (
+        resourceOrStr: vscode.Uri | string,
+        job: string
+    ): Promise<qp.ActionableQuickPick> => {
+        const resource = qp.asUri(resourceOrStr);
+        const jobInfo = await p4.getJob(resource, { existingJob: job });
+        const clipItems = makeClipboardPicks(jobInfo);
+
+        const fixItems = await makeFixesPicks(resource, job);
+
+        const showJobItem = {
+            label: "$(file) Show job",
+            description: "Open the full job spec in the editor",
+            performAction: () => {
+                const uri = PerforceUri.forCommand(resource, "job", "-o").with({
+                    path: job,
+                });
+                vscode.window.showTextDocument(uri);
+            },
+        };
+
+        return {
+            items: [...clipItems, showJobItem, ...fixItems],
+            placeHolder:
+                "Job " +
+                jobInfo.job +
+                " (" +
+                jobInfo.status +
+                ") by " +
+                jobInfo.user +
+                " : " +
+                jobInfo.description,
+        };
+    },
+};
+
+export async function showQuickPickForJob(resource: vscode.Uri, job: string) {
+    await qp.showQuickPick("job", resource, job);
+}
+
+async function makeFixesPicks(
+    resource: vscode.Uri,
+    job: string
+): Promise<qp.ActionableQuickPickItem[]> {
+    const fixes = await p4.fixes(resource, { job });
+    const described =
+        fixes.length > 0
+            ? await p4.describe(resource, {
+                  omitDiffs: true,
+                  chnums: fixes.map((fix) => fix.chnum),
+              })
+            : [];
+    const fixedByItem = {
+        label: "Fixed by changelists: " + fixes.length,
+    };
+    const fixItems = fixes.map((fix) => {
+        const change = described.find((d) => d.chnum === fix.chnum);
+        return {
+            label:
+                nbsp.repeat(3) +
+                (change?.isPending ? "$(tools) " : "$(check) ") +
+                fix.chnum,
+            description:
+                "$(person) " + fix.user + "@" + fix.client + " $(calendar) " + fix.date,
+            performAction: () => {
+                showQuickPickForChangelist(resource, fix.chnum);
+            },
+        };
+    });
+    return [fixedByItem, ...fixItems];
+}
+
+function makeClipboardPicks(jobInfo: Job): qp.ActionableQuickPickItem[] {
+    return [
+        qp.makeClipPick("job id", jobInfo.job),
+        qp.makeClipPick("description", jobInfo.description),
+        qp.makeClipPick("user", jobInfo.user),
+    ];
+}

--- a/src/quickPick/JobQuickPick.ts
+++ b/src/quickPick/JobQuickPick.ts
@@ -73,7 +73,12 @@ async function makeFixesPicks(
                 (change?.isPending ? "$(tools) " : "$(check) ") +
                 fix.chnum,
             description:
-                "$(person) " + fix.user + "@" + fix.client + " $(calendar) " + fix.date,
+                "$(person) " +
+                fix.user +
+                " $(calendar) " +
+                fix.date +
+                " $(book) " +
+                change?.description.join(" "),
             performAction: () => {
                 showQuickPickForChangelist(resource, fix.chnum);
             },

--- a/src/quickPick/QuickPickProvider.ts
+++ b/src/quickPick/QuickPickProvider.ts
@@ -124,3 +124,19 @@ export async function showQuickPick(type: string, ...args: any[]) {
 export function toRevString(startRev: string | undefined, endRev: string) {
     return startRev ? startRev + "," + endRev : endRev;
 }
+
+export function makeClipPick(
+    name: string,
+    value: string | undefined
+): ActionableQuickPickItem {
+    const val = value ?? "";
+    return {
+        label: "$(clippy) Copy " + name + " to clipboard",
+        description: val,
+        performAction: (reopen) => {
+            vscode.env.clipboard.writeText(val);
+            vscode.window.setStatusBarMessage("Copied to clipboard");
+            reopen();
+        },
+    };
+}

--- a/src/quickPick/QuickPicks.ts
+++ b/src/quickPick/QuickPicks.ts
@@ -2,6 +2,7 @@ import * as QuickPickProvider from "./QuickPickProvider";
 import * as FileQuickPick from "./FileQuickPick";
 import * as ShelvedFileQuickPick from "./ShelvedFileQuickPick";
 import * as ChangeQuickPick from "./ChangeQuickPick";
+import * as JobQuickPick from "./JobQuickPick";
 import * as IntegrationQuickPick from "./IntegrationQuickPick";
 import * as ChangeSearchQuickPick from "./ChangeSearchQuickPick";
 
@@ -32,6 +33,7 @@ export function registerQuickPicks() {
         "changeResults",
         ChangeSearchQuickPick.changeSearchQuickPickProvider
     );
+    QuickPickProvider.registerQuickPickProvider("job", JobQuickPick.jobQuickPickProvider);
     QuickPickProvider.registerQuickPickProvider(
         "integ",
         IntegrationQuickPick.integrationQuickPickProvider

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -26,6 +26,8 @@ import { DebouncedFunction, debounce } from "../Debounce";
 import * as p4 from "../api/PerforceApi";
 import { ChangeInfo, ChangeSpec } from "../api/CommonTypes";
 import { isTruthy, pluralise } from "../TsUtils";
+import { showQuickPickForChangelist } from "../quickPick/ChangeQuickPick";
+import { showQuickPickForJob } from "../quickPick/JobQuickPick";
 
 function isResourceGroup(arg: any): arg is SourceControlResourceGroup {
     return arg && arg.id !== undefined;
@@ -169,6 +171,20 @@ export class Model implements Disposable {
 
     public Logout() {
         return Display.doLogoutFlow(this._workspaceUri);
+    }
+
+    public async GoToChangelist() {
+        const chnum = await Display.requestChangelistNumber();
+        if (chnum) {
+            showQuickPickForChangelist(this._workspaceUri, chnum);
+        }
+    }
+
+    public async GoToJob() {
+        const job = await Display.requestJobId();
+        if (job) {
+            showQuickPickForJob(this._workspaceUri, job);
+        }
     }
 
     public async Sync(): Promise<void> {

--- a/src/search/ChangelistTreeView.ts
+++ b/src/search/ChangelistTreeView.ts
@@ -17,13 +17,13 @@ import {
     makeFilterLabelText,
 } from "./Filters";
 import {
-    showQuickPickForChangelist,
     getOperationIcon,
+    showQuickPickForChangelist,
 } from "../quickPick/ChangeQuickPick";
 import { Display } from "../Display";
 import * as p4 from "../api/PerforceApi";
 import { ChangeInfo } from "../api/CommonTypes";
-import { isPositiveOrZero, dedupe } from "../TsUtils";
+import { dedupe } from "../TsUtils";
 import { ProviderSelection } from "./ProviderSelection";
 import { configAccessor } from "../ConfigService";
 import { showQuickPickForChangeSearch } from "../quickPick/ChangeSearchQuickPick";
@@ -120,19 +120,8 @@ class GoToChangelist extends SelfExpandingTreeItem<any> {
             throw new Error("No context for changelist search");
         }
 
-        const clipValue = await vscode.env.clipboard.readText();
-        const value = isPositiveOrZero(clipValue) ? clipValue : undefined;
+        const chnum = await Display.requestChangelistNumber();
 
-        const chnum = await vscode.window.showInputBox({
-            placeHolder: "Changelist number",
-            prompt: "Enter a changelist number",
-            value,
-            validateInput: (value) => {
-                if (!isPositiveOrZero(value)) {
-                    return "must be a positive number";
-                }
-            },
-        });
         if (chnum !== undefined) {
             showQuickPickForChangelist(selectedClient.configSource, chnum);
         }


### PR DESCRIPTION
* Shows the list of changelists that fix the job etc.
* Common function for clipboard operations
  * now reopens the quick pick after copying
* add 'fixes' and 'job' commands to API
* add "go to job" and "go to changelist" to the scm provider
  * if run from the command palette and there are multiple scm providers, asks for one first
* make loginScm the default from the command palette so it can prompt