### PR TITLE
Combo box for changelist search filters

### DIFF
--- a/src/ComboBoxInput.ts
+++ b/src/ComboBoxInput.ts
@@ -22,19 +22,19 @@ function insertItem<T>(items: T[], newItems: T[], insertBeforeIndex?: number): T
 export async function showComboBoxInput<T extends vscode.QuickPickItem>(
     items: T[],
     options: ComboBoxInputOptions,
-    provideInputOptions: (value: string) => T[]
+    provideInputItems: (value: string) => T[]
 ) {
     const quickPick = vscode.window.createQuickPick<T>();
     quickPick.matchOnDescription = options.matchOnDescription ?? false;
     quickPick.matchOnDetail = options.matchOnDetail ?? false;
     quickPick.ignoreFocusOut = options.ignoreFocusOut ?? false;
     quickPick.placeholder = options.placeHolder;
-    const def = provideInputOptions("");
+    const def = provideInputItems("");
     quickPick.items = insertItem(items, def, options.insertBeforeIndex);
 
     let providedItems = new Set<T>(def);
     quickPick.onDidChangeValue((value) => {
-        const provided = provideInputOptions(value);
+        const provided = provideInputItems(value);
         quickPick.items = quickPick.items
             .filter((item) => !providedItems.has(item))
             .concat(provided);

--- a/src/ComboBoxInput.ts
+++ b/src/ComboBoxInput.ts
@@ -1,0 +1,56 @@
+import * as vscode from "vscode";
+
+export interface ComboBoxInputOptions {
+    matchOnDescription?: boolean;
+    matchOnDetail?: boolean;
+    placeHolder?: string;
+    ignoreFocusOut?: boolean;
+    insertBeforeIndex?: number;
+}
+
+function insertItem<T>(items: T[], newItems: T[], insertBeforeIndex?: number): T[] {
+    if (insertBeforeIndex === undefined) {
+        return [...items, ...newItems];
+    }
+    return [
+        ...items.slice(0, insertBeforeIndex),
+        ...newItems,
+        ...items.slice(insertBeforeIndex),
+    ];
+}
+
+export async function showComboBoxInput<T extends vscode.QuickPickItem>(
+    items: T[],
+    options: ComboBoxInputOptions,
+    provideInputOptions: (value: string) => T[]
+) {
+    const quickPick = vscode.window.createQuickPick<T>();
+    quickPick.matchOnDescription = options.matchOnDescription ?? false;
+    quickPick.matchOnDetail = options.matchOnDetail ?? false;
+    quickPick.ignoreFocusOut = options.ignoreFocusOut ?? false;
+    quickPick.placeholder = options.placeHolder;
+    const def = provideInputOptions("");
+    quickPick.items = insertItem(items, def, options.insertBeforeIndex);
+
+    let providedItems = new Set<T>(def);
+    quickPick.onDidChangeValue((value) => {
+        const provided = provideInputOptions(value);
+        quickPick.items = quickPick.items
+            .filter((item) => !providedItems.has(item))
+            .concat(provided);
+        providedItems = new Set(provided);
+        quickPick.activeItems = provided.slice(-1);
+    });
+
+    const promise = new Promise<T | undefined>((resolve) => {
+        quickPick.onDidAccept(() => {
+            resolve(quickPick.selectedItems[0]);
+            quickPick.hide();
+        });
+        quickPick.onDidHide(() => {
+            resolve(undefined);
+        });
+    });
+    quickPick.show();
+    return promise;
+}

--- a/src/api/CommandUtils.ts
+++ b/src/api/CommandUtils.ts
@@ -80,38 +80,25 @@ export function concatIfOutputIsDefined<T, R>(...fns: ((arg: T) => R | undefined
 
 export type CmdlineArgs = (string | undefined)[];
 
-function argWithValue(
-    flagName: string,
-    value: string,
-    options?: FlagOptions
-): CmdlineArgs {
-    if (options?.withoutSpace) {
-        return [flagName + value];
-    } else {
-        return [flagName, value];
-    }
-}
-
 function makeFlag(
     flag: string,
-    value: string | boolean | number | undefined,
-    options?: FlagOptions
+    value: string | boolean | number | undefined
 ): CmdlineArgs {
     const flagName = "-" + flag;
     if (typeof value === "string") {
-        return argWithValue(flagName, value, options);
+        return [flagName, value];
     } else if (typeof value === "number") {
-        return argWithValue(flagName, value.toString(), options);
+        return [flagName, value.toString()];
     }
     return value ? [flagName] : [];
 }
 
 export function makeFlags(
-    pairs: [string, string | boolean | number | undefined, FlagOptions?][],
+    pairs: [string, string | boolean | number | undefined][],
     lastArgs?: (string | undefined)[]
 ): CmdlineArgs {
     return pairs
-        .flatMap((pair) => makeFlag(pair[0], pair[1], pair[2]))
+        .flatMap((pair) => makeFlag(pair[0], pair[1]))
         .concat(...(lastArgs ?? []));
 }
 
@@ -154,10 +141,6 @@ type FlagMapperOptions = {
     ignoreRevisionFragments?: boolean;
 };
 
-type FlagOptions = {
-    withoutSpace?: boolean;
-};
-
 /**
  * Create a function that maps an object of type P into an array of command arguments
  * @param flagNames A set of tuples - flag name to output (e.g. "c" produces "-c") and key from the object to use.
@@ -167,7 +150,7 @@ type FlagOptions = {
  * @param fixedPrefix A fixed set of args to always put first in the perforce command
  */
 export function flagMapper<P extends FlagDefinition<P>>(
-    flagNames: [string, keyof P, FlagOptions?][],
+    flagNames: [string, keyof P][],
     lastArg?: keyof P,
     fixedPrefix?: CmdlineArgs,
     options?: FlagMapperOptions
@@ -179,7 +162,6 @@ export function flagMapper<P extends FlagDefinition<P>>(
                     return [
                         fn[0],
                         params[fn[1]] as string | boolean | number | undefined,
-                        fn[2],
                     ];
                 }),
                 lastArg

--- a/src/api/PerforceApi.ts
+++ b/src/api/PerforceApi.ts
@@ -8,4 +8,6 @@ export * from "./commands/filelog";
 export * from "./commands/changes";
 export * from "./commands/integrated";
 export * from "./commands/job";
+export * from "./commands/client";
+export * from "./commands/users";
 export * from "./CommonTypes";

--- a/src/api/commands/client.ts
+++ b/src/api/commands/client.ts
@@ -12,7 +12,7 @@ export interface ClientsOptions {
 }
 
 const clientsFlags = flagMapper<ClientsOptions>([
-    ["E", "nameFilter", { withoutSpace: true }],
+    ["E", "nameFilter"],
     ["m", "max"],
 ]);
 

--- a/src/api/commands/client.ts
+++ b/src/api/commands/client.ts
@@ -1,0 +1,46 @@
+import {
+    flagMapper,
+    makeSimpleCommand,
+    splitIntoLines,
+    asyncOuputHandler,
+} from "../CommandUtils";
+import { isTruthy } from "../../TsUtils";
+
+export interface ClientsOptions {
+    nameFilter?: string;
+    max?: number;
+}
+
+const clientsFlags = flagMapper<ClientsOptions>([
+    ["E", "nameFilter", { withoutSpace: true }],
+    ["m", "max"],
+]);
+
+const clientsCommand = makeSimpleCommand("clients", clientsFlags);
+
+export type ClientInfo = {
+    client: string;
+    date: string;
+    root: string;
+    description: string;
+};
+
+function parseClientLine(line: string) {
+    const matches = /^Client (\S*) (\S*) root (.*) '(.*)'$/.exec(line);
+    if (matches) {
+        const [, client, date, root, description] = matches;
+        return {
+            client,
+            date,
+            root,
+            description,
+        };
+    }
+}
+
+function parseClientsOutput(output: string) {
+    const lines = splitIntoLines(output);
+    return lines.map(parseClientLine).filter(isTruthy);
+}
+
+export const clients = asyncOuputHandler(clientsCommand, parseClientsOutput);

--- a/src/api/commands/users.ts
+++ b/src/api/commands/users.ts
@@ -1,0 +1,47 @@
+import {
+    flagMapper,
+    makeSimpleCommand,
+    splitIntoLines,
+    asyncOuputHandler,
+} from "../CommandUtils";
+import { isTruthy } from "../../TsUtils";
+
+export interface UsersOptions {
+    userFilters?: string[];
+    max?: number;
+}
+
+const usersFlags = flagMapper<UsersOptions>([["m", "max"]], "userFilters", undefined, {
+    lastArgIsFormattedArray: true,
+});
+
+const usersCommand = makeSimpleCommand("users", usersFlags);
+
+export type UserInfo = {
+    user: string;
+    email: string;
+    fullName: string;
+    accessDate: string;
+};
+
+function parseUsersLine(line: string) {
+    // example:
+    // Amanda.Snozzlefwitch <am@snoz.lol> (Amanda Snozzlefwitch) accessed 2020/05/07
+    const matches = /^(.*) <(.*)> \((.*)\) \S* (.*)$/.exec(line);
+    if (matches) {
+        const [, user, email, fullName, accessDate] = matches;
+        return {
+            user,
+            email,
+            fullName,
+            accessDate,
+        };
+    }
+}
+
+function parseUsersOutput(output: string) {
+    const lines = splitIntoLines(output);
+    return lines.map(parseUsersLine).filter(isTruthy);
+}
+
+export const users = asyncOuputHandler(usersCommand, parseUsersOutput);

--- a/src/search/Filters.ts
+++ b/src/search/Filters.ts
@@ -330,7 +330,7 @@ class ClientFilter extends FilterItem<string> {
             async (value) => {
                 const clients = await p4.clients(client.configSource, {
                     max: 200,
-                    nameFilter: value,
+                    nameFilter: value.replace("*", "..."),
                 });
                 return clients.map((c) => c.client);
             }

--- a/src/search/Filters.ts
+++ b/src/search/Filters.ts
@@ -172,21 +172,20 @@ async function showFilterTextInput(
     };
 }
 
-async function pickFromProviderOrCustom<T>(
+async function pickFromProviderOrCustom(
     placeHolder: string,
     currentValue: string | undefined,
     client: ClientRoot | undefined,
     clientValue: string | undefined,
-    readableKey: string,
-    readableValue: string | undefined
+    readableKey: string
 ) {
     const current: PickWithValue<SearchFilterValue<string>> | undefined =
         client && clientValue !== undefined
             ? {
                   label: "$(person) Current " + readableKey,
-                  description: readableValue,
+                  description: clientValue,
                   value: {
-                      label: readableValue ?? "",
+                      label: clientValue ?? "",
                       value: clientValue,
                   },
               }
@@ -213,6 +212,9 @@ async function pickFromProviderOrCustom<T>(
         { placeHolder, matchOnDescription: true, insertBeforeIndex: 1 },
         (value) => {
             return [
+                {
+                    label: "$(search) Search for " + readableKey + ": " + value,
+                },
                 {
                     label: value
                         ? "$(edit) Entered " + readableKey + ": " + value
@@ -251,8 +253,7 @@ class UserFilter extends FilterItem<string> {
             this.value,
             this._provider.client,
             this._provider.client?.userName,
-            "user",
-            this._provider.client?.userName
+            "user"
         );
     }
 }
@@ -272,8 +273,7 @@ class ClientFilter extends FilterItem<string> {
             this.value,
             this._provider.client,
             this._provider.client?.clientName,
-            "perforce client",
-            this._provider.client?.clientName
+            "perforce client"
         );
     }
 }


### PR DESCRIPTION
Uses a custom quick pick input to accept typed input as well as choosing an option

e.g. when entering a client, the user is presented with the options:
 * Current user
 * Enter a user
 * Reset filter

Previously to enter a custom user, this required clicking on "enter a user" and then entering the value

Now when the user starts typing, the "enter a user" item changes into one that represents the value being typed.

This also applies to the "client" and "files" filters.

For the "client" and "user" filters, if * is entered in the value then it performs a search for those items