### PR TITLE
Add ability to edit change and job specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,12 +107,12 @@
                 "perforce.scm.activateOnFileOpen": {
                     "type": "boolean",
                     "description": "Controls whether the extension attempts to create an SCM provider each time a file outside of a known perforce client workspace is opened",
-                    "default": "true"
+                    "default": true
                 },
                 "perforce.scm.deactivateOnFileClose": {
                     "type": "boolean",
                     "description": "Controls whether an SCM provider is de-activated when there are no more related files or folders open in the editor",
-                    "default": "true"
+                    "default": true
                 },
                 "perforce.editOnFileSave": {
                     "type": "boolean",
@@ -292,13 +292,13 @@
                 },
                 "perforce.enableP4ConfigScanOnStartup": {
                     "type": "boolean",
-                    "default": "true",
+                    "default": true,
                     "description": "Whether to scan the workspace for perforce P4CONFIG files, in order to find perforce clients to show in the SCM Provider view. Disabling this setting is NOT generally recommeded, but if you have a very large workspace containing many directories, and you do NOT have P4CONFIG files outside of the workspace root, this can reduce startup time",
                     "scope": "resource"
                 },
                 "perforce.warnOnMissingP4CONFIG": {
                     "type": "boolean",
-                    "default": "true",
+                    "default": true,
                     "description": "When enabled, if a .p4config file is found in the workspace, but P4CONFIG is not set in the environment, a warning will be shown. This is due to a change in behaviour of handling these files in v4 which may break backward compatibility"
                 },
                 "perforce.changelistSearch.maxResults": {
@@ -309,18 +309,23 @@
                 },
                 "perforce.explorer.showSyncCommands": {
                     "type": "boolean",
-                    "default": "true",
+                    "default": true,
                     "description": "Whether to show sync commands on the explorer context menu"
                 },
                 "perforce.explorer.showBasicOpCommands": {
                     "type": "boolean",
-                    "default": "true",
+                    "default": true,
                     "description": "Whether to show basic operation commands on the explorer context menu (add / edit / revert)"
                 },
                 "perforce.explorer.showFileOpCommands": {
                     "type": "boolean",
-                    "default": "true",
+                    "default": true,
                     "description": "Whether to show file operation commands on the explorer context menu (move / rename etc)"
+                },
+                "perforce.specEditor.showIndentWarning": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to show a warning when editing a change or job spec and the editor is set to use spaces instead of tabs"
                 }
             }
         },
@@ -617,6 +622,12 @@
                 "icon": "$(edit)"
             },
             {
+                "command": "perforce.editChangespec",
+                "title": "Edit changelist",
+                "category": "Perforce",
+                "icon": "$(edit)"
+            },
+            {
                 "command": "perforce.resolveChangelist",
                 "title": "Resolve changelist...",
                 "category": "Perforce"
@@ -748,6 +759,30 @@
                 "command": "perforce.goToJob",
                 "title": "Go to job...",
                 "category": "Perforce"
+            },
+            {
+                "command": "perforce.saveJobSpec",
+                "title": "Save Job Spec",
+                "category": "Perforce",
+                "icon": "$(cloud-upload)"
+            },
+            {
+                "command": "perforce.saveChangeSpec",
+                "title": "Save Change Spec",
+                "category": "Perforce",
+                "icon": "$(cloud-upload)"
+            },
+            {
+                "command": "perforce.refreshJobSpec",
+                "title": "Refresh Job Spec from perforce",
+                "category": "Perforce",
+                "icon": "$(refresh)"
+            },
+            {
+                "command": "perforce.refreshChangeSpec",
+                "title": "Refresh Change Spec from perforce",
+                "category": "Perforce",
+                "icon": "$(refresh)"
             }
         ],
         "menus": {
@@ -766,6 +801,10 @@
                 },
                 {
                     "command": "perforce.editChangelist",
+                    "when": "0"
+                },
+                {
+                    "command": "perforce.editChangespec",
                     "when": "0"
                 },
                 {
@@ -935,6 +974,22 @@
                 {
                     "command": "perforce.explorer.delete",
                     "when": "0"
+                },
+                {
+                    "command": "perforce.saveJobSpec",
+                    "when": "resourceExtname == .jobspec"
+                },
+                {
+                    "command": "perforce.saveChangeSpec",
+                    "when": "resourceExtname == .changespec"
+                },
+                {
+                    "command": "perforce.refreshJobSpec",
+                    "when": "resourceExtname == .jobspec"
+                },
+                {
+                    "command": "perforce.refreshChangeSpec",
+                    "when": "resourceExtname == .changespec"
                 }
             ],
             "scm/title": [
@@ -1036,14 +1091,19 @@
                     "group": "1_modification@2"
                 },
                 {
+                    "command": "perforce.editChangespec",
+                    "when": "scmProvider == perforce && scmResourceGroup != default",
+                    "group": "1_modification@3"
+                },
+                {
                     "command": "perforce.revertChangelist",
                     "when": "scmProvider == perforce",
-                    "group": "1_modification@3"
+                    "group": "1_modification@4"
                 },
                 {
                     "command": "perforce.revertUnchangedChangelist",
                     "when": "scmProvider == perforce",
-                    "group": "1_modification@4"
+                    "group": "1_modification@5"
                 },
                 {
                     "command": "perforce.resolveChangelist",
@@ -1223,6 +1283,26 @@
                     "command": "perforce.diffNext",
                     "group": "perforce@2",
                     "when": "isInDiffEditor && perforce.activation.hasScmProvider"
+                },
+                {
+                    "command": "perforce.saveJobSpec",
+                    "group": "navigation@-10",
+                    "when": "resourceExtname == .jobspec"
+                },
+                {
+                    "command": "perforce.saveChangeSpec",
+                    "group": "navigation@-10",
+                    "when": "resourceExtname == .changespec"
+                },
+                {
+                    "command": "perforce.refreshJobSpec",
+                    "group": "navigation@-11",
+                    "when": "resourceExtname == .jobspec"
+                },
+                {
+                    "command": "perforce.refreshChangeSpec",
+                    "group": "navigation@-11",
+                    "when": "resourceExtname == .changespec"
                 }
             ],
             "explorer/context": [

--- a/package.json
+++ b/package.json
@@ -623,7 +623,7 @@
             },
             {
                 "command": "perforce.editChangespec",
-                "title": "Edit changelist",
+                "title": "Edit changelist spec",
                 "category": "Perforce",
                 "icon": "$(edit)"
             },
@@ -762,25 +762,25 @@
             },
             {
                 "command": "perforce.saveJobSpec",
-                "title": "Apply job spec",
+                "title": "Apply updates to job spec",
                 "category": "Perforce",
                 "icon": "$(cloud-upload)"
             },
             {
                 "command": "perforce.saveChangeSpec",
-                "title": "Apply change spec",
+                "title": "Apply updates to change spec",
                 "category": "Perforce",
                 "icon": "$(cloud-upload)"
             },
             {
                 "command": "perforce.refreshJobSpec",
-                "title": "Refresh job spec from perforce",
+                "title": "Refresh job spec from perforce (overwrites local edits)",
                 "category": "Perforce",
                 "icon": "$(refresh)"
             },
             {
                 "command": "perforce.refreshChangeSpec",
-                "title": "Refresh change spec from perforce",
+                "title": "Refresh change spec from perforce (overwrites local edits)",
                 "category": "Perforce",
                 "icon": "$(refresh)"
             }

--- a/package.json
+++ b/package.json
@@ -762,25 +762,25 @@
             },
             {
                 "command": "perforce.saveJobSpec",
-                "title": "Save Job Spec",
+                "title": "Apply job spec",
                 "category": "Perforce",
                 "icon": "$(cloud-upload)"
             },
             {
                 "command": "perforce.saveChangeSpec",
-                "title": "Save Change Spec",
+                "title": "Apply change spec",
                 "category": "Perforce",
                 "icon": "$(cloud-upload)"
             },
             {
                 "command": "perforce.refreshJobSpec",
-                "title": "Refresh Job Spec from perforce",
+                "title": "Refresh job spec from perforce",
                 "category": "Perforce",
                 "icon": "$(refresh)"
             },
             {
                 "command": "perforce.refreshChangeSpec",
-                "title": "Refresh Change Spec from perforce",
+                "title": "Refresh change spec from perforce",
                 "category": "Perforce",
                 "icon": "$(refresh)"
             }

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -30,6 +30,7 @@ import {
 import { splitBy, pluralise, isTruthy } from "./TsUtils";
 import { perforceContentProvider } from "./ContentProvider";
 import { showRevChooserForFile } from "./quickPick/FileQuickPick";
+import { changeSpecEditor, jobSpecEditor } from "./SpecEditor";
 
 // TODO resolve
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -69,6 +70,10 @@ export namespace PerforceCommands {
         commands.registerCommand("perforce.login", login);
         commands.registerCommand("perforce.diffFiles", diffFiles);
         commands.registerCommand("perforce.menuFunctions", menuFunctions);
+        commands.registerCommand("perforce.saveJobSpec", inputOpenJobSpec);
+        commands.registerCommand("perforce.saveChangeSpec", inputOpenChangeSpec);
+        commands.registerCommand("perforce.refreshJobSpec", refreshOpenJobSpec);
+        commands.registerCommand("perforce.refreshChangeSpec", refreshOpenChangeSpec);
     }
 
     export function registerImportantCommands(subscriptions: Disposable[]) {
@@ -843,6 +848,38 @@ export namespace PerforceCommands {
         if (ok) {
             PerforceSCMProvider.RefreshAll();
         }
+    }
+
+    async function inputOpenJobSpec() {
+        const doc = window.activeTextEditor?.document;
+        if (!doc) {
+            return;
+        }
+        await jobSpecEditor.inputSpec(doc);
+    }
+
+    async function inputOpenChangeSpec() {
+        const doc = window.activeTextEditor?.document;
+        if (!doc) {
+            return;
+        }
+        await changeSpecEditor.inputSpec(doc);
+    }
+
+    async function refreshOpenJobSpec() {
+        const doc = window.activeTextEditor?.document;
+        if (!doc) {
+            return;
+        }
+        await jobSpecEditor.refreshSpec(doc);
+    }
+
+    async function refreshOpenChangeSpec() {
+        const doc = window.activeTextEditor?.document;
+        if (!doc) {
+            return;
+        }
+        await changeSpecEditor.refreshSpec(doc);
     }
 
     function showFileHistory() {

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -292,6 +292,10 @@ export class PerforceSCMProvider {
             PerforceSCMProvider.EditChangelist.bind(this)
         );
         commands.registerCommand(
+            "perforce.editChangespec",
+            PerforceSCMProvider.EditChangespec.bind(this)
+        );
+        commands.registerCommand(
             "perforce.describe",
             PerforceSCMProvider.Describe.bind(this)
         );
@@ -543,6 +547,13 @@ export class PerforceSCMProvider {
         const model: Model = input.model;
         if (model) {
             await model.EditChangelist(input);
+        }
+    }
+
+    public static async EditChangespec(input: ResourceGroup) {
+        const model: Model = input.model;
+        if (model) {
+            await model.EditChangespec(input);
         }
     }
 

--- a/src/SpecEditor.ts
+++ b/src/SpecEditor.ts
@@ -1,0 +1,233 @@
+import * as vscode from "vscode";
+import * as p4 from "./api/PerforceApi";
+import * as Path from "path";
+import { TextEncoder } from "util";
+import { Display } from "./Display";
+import { PerforceSCMProvider } from "./ScmProvider";
+
+type SpecStore = { [key: string]: string };
+
+abstract class SpecEditor {
+    private _state: vscode.Memento;
+    private _store: vscode.Uri;
+    private _hasUnresolvedPrompt: boolean;
+    private _subscriptions: vscode.Disposable[];
+    private _suppressNextSave?: vscode.TextDocument;
+
+    constructor(context: vscode.ExtensionContext, private _type: string) {
+        this._state = context.globalState;
+        this._store = vscode.Uri.file(context.globalStoragePath);
+        this._hasUnresolvedPrompt = false;
+        this._subscriptions = [];
+        this._subscriptions.push(
+            vscode.workspace.onWillSaveTextDocument((doc) => {
+                // DON'T AWAIT - WILL PREVENT SAVE
+                this.checkSavedDoc(doc);
+            })
+        );
+    }
+
+    dispose() {
+        this._subscriptions.forEach((sub) => sub.dispose());
+    }
+
+    protected abstract getSpecText(resource: vscode.Uri, item: string): Promise<string>;
+    protected abstract inputSpecText(
+        resource: vscode.Uri,
+        item: string,
+        text: string
+    ): Promise<any>;
+
+    private async setResource(specFile: vscode.Uri, resource: vscode.Uri) {
+        const cur = this._state.get<SpecStore>(this._type + "Map") ?? {};
+        cur[specFile.fsPath] = resource.fsPath;
+        await this._state.update(this._type + "Map", cur);
+    }
+
+    private getResource(file: vscode.Uri): vscode.Uri | undefined {
+        const cur = this._state.get<SpecStore>(this._type + "Map");
+        const fsPath = cur?.[file.fsPath];
+        if (fsPath) {
+            return vscode.Uri.file(fsPath);
+        }
+    }
+
+    private static async checkTabSettings() {
+        const check = vscode.workspace
+            .getConfiguration("perforce")
+            .get("specEditor.showIndentWarning");
+
+        if (
+            check &&
+            vscode.workspace.getConfiguration("editor").get("insertSpaces") &&
+            !vscode.workspace.getConfiguration("editor").get("detectIndentation")
+        ) {
+            const enable = "Enable tab detection in this workspace";
+            const ignore = "Don't show this warning";
+            const chosen = await vscode.window.showWarningMessage(
+                "WARNING - your editor is configured to use spaces and never tabs, which causes strange indentation when editing perforce spec files. Consider enabling the `editor.detectIndentation` setting",
+                enable,
+                ignore
+            );
+            if (chosen === enable) {
+                await vscode.workspace
+                    .getConfiguration("editor")
+                    .update("detectIndentation", true);
+            }
+            if (chosen === ignore) {
+                await vscode.workspace
+                    .getConfiguration("perforce")
+                    .update(
+                        "specEditor.showIndentWarning",
+                        false,
+                        vscode.ConfigurationTarget.Global
+                    );
+            }
+        }
+    }
+
+    private async createSpecFile(item: string, content: string): Promise<vscode.Uri> {
+        await vscode.workspace.fs.createDirectory(this._store);
+        const fileName = item + "." + this._type + "spec";
+        const fullFile = vscode.Uri.file(Path.join(this._store.fsPath, fileName));
+        const encoded = new TextEncoder().encode(content);
+        await vscode.workspace.fs.writeFile(fullFile, encoded);
+        return fullFile;
+    }
+
+    async editSpec(resource: vscode.Uri, item: string) {
+        const text = await this.getSpecText(resource, item);
+        const withMessage =
+            text +
+            "\n\n# When you are done editing, click the 'save spec' button\n# on this editor's toolbar to apply the edit on the perforce server";
+        const file = await this.createSpecFile(item, withMessage);
+        await this.setResource(file, resource);
+        await vscode.window.showTextDocument(file, { preview: false });
+        SpecEditor.checkTabSettings();
+    }
+
+    private get specSuffix() {
+        return this._type + "spec";
+    }
+
+    private isValidSpecFilename(file: string) {
+        return file.endsWith("." + this.specSuffix);
+    }
+
+    private getSpecItemName(file: string) {
+        return Path.basename(file).split(".")[0];
+    }
+
+    async validateAndGetResource(doc: vscode.TextDocument) {
+        const file = doc.uri;
+        const filename = Path.basename(file.fsPath);
+        if (!this.isValidSpecFilename(filename)) {
+            throw new Error(
+                "Filename " + filename + " does not end in ." + this.specSuffix
+            );
+        }
+        const item = this.getSpecItemName(filename);
+        const resource = this.getResource(file);
+        if (!resource) {
+            throw new Error("Could not find workspace details for " + item + " " + item);
+        }
+        if (doc?.isDirty) {
+            // don't ask about uploading, we're already doing that
+            this._suppressNextSave = doc;
+            await doc?.save();
+        }
+        const text = doc.getText();
+        return { item, resource, text };
+    }
+
+    async inputSpec(doc: vscode.TextDocument) {
+        try {
+            const { item, resource, text } = await this.validateAndGetResource(doc);
+            await this.inputSpecText(resource, item, text);
+            // re-open with new values - old job specs are not valid because of the timestamp
+            this.editSpec(resource, item);
+        } catch (err) {
+            Display.showImportantError(err);
+        }
+    }
+
+    async refreshSpec(doc: vscode.TextDocument) {
+        const { item, resource } = await this.validateAndGetResource(doc);
+        await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Window,
+                title: "Refreshing spec for " + this._type + " item",
+            },
+            () => this.editSpec(resource, item)
+        );
+    }
+
+    private async checkSavedDoc(event: vscode.TextDocumentWillSaveEvent) {
+        if (this._suppressNextSave === event.document) {
+            this._suppressNextSave = undefined;
+            return;
+        }
+        if (
+            !this._hasUnresolvedPrompt &&
+            event.reason === vscode.TextDocumentSaveReason.Manual
+        ) {
+            const doc = event.document;
+            if (this.isValidSpecFilename(doc.fileName) && this.getResource(doc.uri)) {
+                const item = this.getSpecItemName(doc.fileName);
+                const ok = "Apply now";
+                this._hasUnresolvedPrompt = true;
+                const chosen = await vscode.window.showInformationMessage(
+                    "Apply your changes to the spec for " +
+                        this._type +
+                        " " +
+                        item +
+                        " on the perforce server now?",
+                    ok
+                );
+                this._hasUnresolvedPrompt = false;
+                if (chosen === ok) {
+                    this.inputSpec(doc);
+                }
+            }
+        }
+    }
+}
+
+class ChangeSpecEditor extends SpecEditor {
+    constructor(context: vscode.ExtensionContext) {
+        super(context, "change");
+    }
+
+    protected getSpecText(resource: vscode.Uri, item: string) {
+        return p4.outputChange(resource, { existingChangelist: item });
+    }
+    protected async inputSpecText(resource: vscode.Uri, item: string, text: string) {
+        const output = await p4.inputRawChangeSpec(resource, { input: text });
+        Display.showMessage(output.rawOutput);
+        PerforceSCMProvider.RefreshAll();
+    }
+}
+
+class JobSpecEditor extends SpecEditor {
+    constructor(context: vscode.ExtensionContext) {
+        super(context, "job");
+    }
+
+    protected getSpecText(resource: vscode.Uri, item: string) {
+        return p4.outputJob(resource, { existingJob: item });
+    }
+    protected async inputSpecText(resource: vscode.Uri, item: string, text: string) {
+        await p4.inputRawJobSpec(resource, { input: text });
+        Display.showMessage("Job " + item + " updated");
+    }
+}
+
+export let changeSpecEditor: SpecEditor;
+export let jobSpecEditor: SpecEditor;
+
+export function createSpecEditor(context: vscode.ExtensionContext) {
+    changeSpecEditor = new ChangeSpecEditor(context);
+    jobSpecEditor = new JobSpecEditor(context);
+    context.subscriptions.push(changeSpecEditor);
+    context.subscriptions.push(jobSpecEditor);
+}

--- a/src/api/commands/changeSpec.ts
+++ b/src/api/commands/changeSpec.ts
@@ -38,7 +38,7 @@ const changeFlags = flagMapper<ChangeSpecOptions>([], "existingChangelist", ["-o
     lastArgIsFormattedArray: true,
 });
 
-const outputChange = makeSimpleCommand("change", changeFlags);
+export const outputChange = makeSimpleCommand("change", changeFlags);
 
 export const getChangeSpec = asyncOuputHandler(outputChange, parseChangeSpec);
 
@@ -70,6 +70,10 @@ export type InputChangeSpecOptions = {
     spec: ChangeSpec;
 };
 
+export type InputRawChangeSpecOptions = {
+    input: string;
+};
+
 export type CreatedChangelist = {
     rawOutput: string;
     chnum?: string;
@@ -82,6 +86,16 @@ function parseCreatedChangelist(createdStr: string): CreatedChangelist {
         chnum: matches?.[1],
     };
 }
+
+const inputRawChangeCommand = makeSimpleCommand(
+    "change",
+    () => ["-i"],
+    (options: InputRawChangeSpecOptions) => {
+        return {
+            input: options.input,
+        };
+    }
+);
 
 const inputChange = makeSimpleCommand(
     "change",
@@ -105,3 +119,7 @@ const inputChange = makeSimpleCommand(
 );
 
 export const inputChangeSpec = asyncOuputHandler(inputChange, parseCreatedChangelist);
+export const inputRawChangeSpec = asyncOuputHandler(
+    inputRawChangeCommand,
+    parseCreatedChangelist
+);

--- a/src/api/commands/job.ts
+++ b/src/api/commands/job.ts
@@ -37,7 +37,7 @@ const jobFlags = flagMapper<JobOptions>([], "existingJob", ["-o"], {
     lastArgIsFormattedArray: true,
 });
 
-const outputJob = makeSimpleCommand("job", jobFlags);
+export const outputJob = makeSimpleCommand("job", jobFlags);
 
 export const getJob = asyncOuputHandler(outputJob, parseJobSpec);
 
@@ -82,3 +82,17 @@ const fixesFlags = flagMapper<FixesOptions>([["j", "job"]]);
 const fixesCommand = makeSimpleCommand("fixes", fixesFlags);
 
 export const fixes = asyncOuputHandler(fixesCommand, parseFixesOutuput);
+
+export type InputRawJobSpecOptions = {
+    input: string;
+};
+
+export const inputRawJobSpec = makeSimpleCommand(
+    "job",
+    () => ["-i"],
+    (options: InputRawJobSpecOptions) => {
+        return {
+            input: options.input,
+        };
+    }
+);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import * as QuickPicks from "./quickPick/QuickPicks";
 import * as p4 from "./api/PerforceApi";
 import { isTruthy } from "./TsUtils";
 import { registerChangelistSearch } from "./search/ChangelistTreeView";
+import { createSpecEditor } from "./SpecEditor";
 
 let _isRegistered = false;
 const _disposable: vscode.Disposable[] = [];
@@ -446,6 +447,7 @@ async function checkForSlevesque(ctx: vscode.ExtensionContext) {
 export async function activate(ctx: vscode.ExtensionContext) {
     // ALWAYS register the edit and save command
     PerforceCommands.registerImportantCommands(_disposable);
+    createSpecEditor(ctx);
 
     ctx.subscriptions.push(
         new vscode.Disposable(() => Disposable.from(..._disposable).dispose())

--- a/src/quickPick/ChangeQuickPick.ts
+++ b/src/quickPick/ChangeQuickPick.ts
@@ -14,6 +14,7 @@ import { PerforceSCMProvider } from "../ScmProvider";
 import { pluralise, isTruthy } from "../TsUtils";
 import { showQuickPickForShelvedFile } from "./ShelvedFileQuickPick";
 import { showQuickPickForJob } from "./JobQuickPick";
+import { changeSpecEditor } from "../SpecEditor";
 
 const nbsp = "\xa0";
 
@@ -47,6 +48,7 @@ export const changeQuickPickProvider: qp.ActionableQuickPickProvider = {
         const actions = makeFocusPick(resource, change).concat(
             makeSwarmPick(change),
             makeClipboardPicks(resource, change),
+            makeEditPicks(resource, change),
             makeUnshelvePicks(resource, shelvedChange),
             makeJobPicks(resource, change),
             makeFilePicks(resource, change),
@@ -250,6 +252,21 @@ function makeSwarmPick(change: DescribedChangelist): qp.ActionableQuickPickItem[
         );
         return [];
     }
+}
+
+function makeEditPicks(
+    uri: vscode.Uri,
+    change: DescribedChangelist
+): qp.ActionableQuickPickItem[] {
+    return [
+        {
+            label: "$(edit) Edit changelist",
+            description: "Edit the full changelist spec in the editor",
+            performAction: () => {
+                changeSpecEditor.editSpec(uri, change.chnum);
+            },
+        },
+    ];
 }
 
 function makeClipboardPicks(

--- a/src/quickPick/JobQuickPick.ts
+++ b/src/quickPick/JobQuickPick.ts
@@ -7,6 +7,7 @@ import * as qp from "./QuickPickProvider";
 import { showQuickPickForChangelist } from "./ChangeQuickPick";
 import { Job } from "../api/PerforceApi";
 import { Display } from "../Display";
+import { jobSpecEditor } from "../SpecEditor";
 
 const nbsp = "\xa0";
 
@@ -35,9 +36,14 @@ export const jobQuickPickProvider: qp.ActionableQuickPickProvider = {
                 vscode.window.showTextDocument(uri);
             },
         };
+        const editJobItem = {
+            label: "$(edit) Edit job",
+            description: "Edit the full job spec in the editor",
+            performAction: () => jobSpecEditor.editSpec(resource, job),
+        };
 
         return {
-            items: [...clipItems, showJobItem, ...fixItems],
+            items: [...clipItems, showJobItem, editJobItem, ...fixItems],
             placeHolder:
                 "Job " +
                 jobInfo.job +

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -28,6 +28,7 @@ import { ChangeInfo, ChangeSpec } from "../api/CommonTypes";
 import { isTruthy, pluralise } from "../TsUtils";
 import { showQuickPickForChangelist } from "../quickPick/ChangeQuickPick";
 import { showQuickPickForJob } from "../quickPick/JobQuickPick";
+import { changeSpecEditor } from "../SpecEditor";
 
 function isResourceGroup(arg: any): arg is SourceControlResourceGroup {
     return arg && arg.id !== undefined;
@@ -353,6 +354,11 @@ export class Model implements Disposable {
         });
 
         this._sourceControl.inputBox.value = "#" + id + "\n" + change.description ?? "";
+    }
+
+    public async EditChangespec(input: ResourceGroup): Promise<void> {
+        this.assertIsNotDefault(input);
+        await changeSpecEditor.editSpec(this._workspaceUri, input.chnum);
     }
 
     public async Describe(input: ResourceGroup): Promise<void> {


### PR DESCRIPTION
Adds commands to changelist and job quick picks, and the scm provider for changelists

Opens a change or job spec in the editor, then prompts to upload the modified spec when it is saved.

To do this it creates a temporary file in the local storage area, and uses the extension Memento to store a mapping of file to workspace path (so we know which resource URI to pass in to the API when applying the updates)

~TODO - currently nothing deletes the files or memento entries - though this is probably not hugely significant (even thousands of files will probably not have any significant impact), it's not ideal for them to build up.~
* ~Not really an option to delete on file close, because even after closing an editor it can be reopened.~
* ~Could add a last accessed time to the memento and delete old entries / files on startup.~
* ~Could also add a command that clears them out manually, but unlikely anyone would run it in the real world~

auto-archives files older than 5 days on startup