### PR TITLE
Create new changelist and jobs using the spec editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -786,12 +786,12 @@
             },
             {
                 "command": "perforce.newChangeSpec",
-                "title": "New changelist in spec editor...",
+                "title": "Create changelist in editor...",
                 "category": "Perforce"
             },
             {
                 "command": "perforce.newJobSpec",
-                "title": "New job in spec editor...",
+                "title": "Create job in editor...",
                 "category": "Perforce"
             }
         ],

--- a/package.json
+++ b/package.json
@@ -622,7 +622,7 @@
                 "icon": "$(edit)"
             },
             {
-                "command": "perforce.editChangespec",
+                "command": "perforce.editChangeSpec",
                 "title": "Edit changelist spec",
                 "category": "Perforce",
                 "icon": "$(edit)"
@@ -783,6 +783,16 @@
                 "title": "Refresh change spec from perforce (overwrites local edits)",
                 "category": "Perforce",
                 "icon": "$(refresh)"
+            },
+            {
+                "command": "perforce.newChangeSpec",
+                "title": "New changelist in spec editor...",
+                "category": "Perforce"
+            },
+            {
+                "command": "perforce.newJobSpec",
+                "title": "New job in spec editor...",
+                "category": "Perforce"
             }
         ],
         "menus": {
@@ -804,7 +814,7 @@
                     "when": "0"
                 },
                 {
-                    "command": "perforce.editChangespec",
+                    "command": "perforce.editChangeSpec",
                     "when": "0"
                 },
                 {
@@ -1034,23 +1044,33 @@
                     "when": "scmProvider == perforce"
                 },
                 {
+                    "command": "perforce.newChangeSpec",
+                    "group": "4_spec@1",
+                    "when": "scmProvider == perforce"
+                },
+                {
+                    "command": "perforce.newJobSpec",
+                    "group": "4_spec@2",
+                    "when": "scmProvider == perforce"
+                },
+                {
                     "command": "perforce.goToJob",
-                    "group": "4_more@1",
+                    "group": "5_more@1",
                     "when": "scmProvider == perforce"
                 },
                 {
                     "command": "perforce.goToChangelist",
-                    "group": "4_more@2",
+                    "group": "5_more@2",
                     "when": "scmProvider == perforce"
                 },
                 {
                     "command": "perforce.showLastQuickPick",
-                    "group": "4_more@3",
+                    "group": "5_more@3",
                     "when": "scmProvider == perforce"
                 },
                 {
                     "command": "perforce.showRecentQuickPick",
-                    "group": "4_more@4",
+                    "group": "5_more@4",
                     "when": "scmProvider == perforce"
                 }
             ],
@@ -1091,7 +1111,7 @@
                     "group": "1_modification@2"
                 },
                 {
-                    "command": "perforce.editChangespec",
+                    "command": "perforce.editChangeSpec",
                     "when": "scmProvider == perforce && scmResourceGroup != default",
                     "group": "1_modification@3"
                 },

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -292,7 +292,7 @@ export class PerforceSCMProvider {
             PerforceSCMProvider.EditChangelist.bind(this)
         );
         commands.registerCommand(
-            "perforce.editChangespec",
+            "perforce.editChangeSpec",
             PerforceSCMProvider.EditChangeSpec.bind(this)
         );
         commands.registerCommand(

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -293,7 +293,15 @@ export class PerforceSCMProvider {
         );
         commands.registerCommand(
             "perforce.editChangespec",
-            PerforceSCMProvider.EditChangespec.bind(this)
+            PerforceSCMProvider.EditChangeSpec.bind(this)
+        );
+        commands.registerCommand(
+            "perforce.newChangeSpec",
+            PerforceSCMProvider.NewChangeSpec.bind(this)
+        );
+        commands.registerCommand(
+            "perforce.newJobSpec",
+            PerforceSCMProvider.NewJobSpec.bind(this)
         );
         commands.registerCommand(
             "perforce.describe",
@@ -475,6 +483,20 @@ export class PerforceSCMProvider {
         await perforceProvider?._model.GoToJob();
     }
 
+    public static async NewChangeSpec(sourceControl?: SourceControl) {
+        const perforceProvider = await PerforceSCMProvider.chooseScmProvider(
+            sourceControl
+        );
+        await perforceProvider?._model.NewChangeSpec();
+    }
+
+    public static async NewJobSpec(sourceControl?: SourceControl) {
+        const perforceProvider = await PerforceSCMProvider.chooseScmProvider(
+            sourceControl
+        );
+        await perforceProvider?._model.NewJobSpec();
+    }
+
     public static async OpenFile(...resourceStates: SourceControlResourceState[]) {
         const selection = resourceStates.filter(
             (s) => s instanceof Resource
@@ -550,10 +572,10 @@ export class PerforceSCMProvider {
         }
     }
 
-    public static async EditChangespec(input: ResourceGroup) {
+    public static async EditChangeSpec(input: ResourceGroup) {
         const model: Model = input.model;
         if (model) {
-            await model.EditChangespec(input);
+            await model.EditChangeSpec(input);
         }
     }
 

--- a/src/SpecEditor.ts
+++ b/src/SpecEditor.ts
@@ -32,7 +32,16 @@ abstract class SpecEditor {
         this._subscriptions.forEach((sub) => sub.dispose());
     }
 
+    /**
+     * Get the full spec text for the item
+     * @param item the id for the item (e.g. changelist or job), or "new" to create a new item
+     * @returns the full text of the object
+     */
     protected abstract getSpecText(resource: vscode.Uri, item: string): Promise<string>;
+    /**
+     * Input the spec text
+     * @returns The new item if it has changed - for example when creating a new changelist
+     */
     protected abstract inputSpecText(
         resource: vscode.Uri,
         item: string,
@@ -134,6 +143,11 @@ abstract class SpecEditor {
         SpecEditor.checkTabSettings();
     }
 
+    /**
+     * Open a new editor containing a spec to edit
+     * @param resource context for running perforce commands
+     * @param item the id of the item (e.g. changelist number of job)
+     */
     async editSpec(resource: vscode.Uri, item: string) {
         await vscode.window.withProgress(
             {
@@ -156,7 +170,7 @@ abstract class SpecEditor {
         return Path.basename(file).split(".")[0];
     }
 
-    async validateAndGetResource(doc: vscode.TextDocument) {
+    private async validateAndGetResource(doc: vscode.TextDocument) {
         const file = doc.uri;
         const filename = Path.basename(file.fsPath);
         if (!this.isValidSpecFilename(filename)) {
@@ -271,7 +285,6 @@ class JobSpecEditor extends SpecEditor {
     }
     protected async inputSpecText(resource: vscode.Uri, item: string, text: string) {
         const output = await p4.inputRawJobSpec(resource, { input: text });
-        // TODO parse job output ahnd return new job name
         Display.showMessage(output.rawOutput);
         return output.job ?? item;
     }

--- a/src/SpecEditor.ts
+++ b/src/SpecEditor.ts
@@ -190,7 +190,12 @@ abstract class SpecEditor {
                 },
                 () => this.inputSpecText(resource, item, text)
             );
-            if (newItem && newItem !== item) {
+
+            if (
+                newItem &&
+                newItem !== item &&
+                vscode.window.activeTextEditor?.document === doc
+            ) {
                 vscode.commands.executeCommand("workbench.action.closeActiveEditor");
             }
             // re-open with new values - old job specs are not valid because of the timestamp

--- a/src/api/commands/job.ts
+++ b/src/api/commands/job.ts
@@ -87,7 +87,21 @@ export type InputRawJobSpecOptions = {
     input: string;
 };
 
-export const inputRawJobSpec = makeSimpleCommand(
+export type CreatedJob = {
+    rawOutput: string;
+    job?: string;
+};
+
+function parseCreatedJob(createdStr: string): CreatedJob {
+    const matches = /Job (\S*) (saved|not changed)/.exec(createdStr);
+
+    return {
+        rawOutput: createdStr,
+        job: matches?.[1],
+    };
+}
+
+const inputRawJobCommand = makeSimpleCommand(
     "job",
     () => ["-i"],
     (options: InputRawJobSpecOptions) => {
@@ -96,3 +110,5 @@ export const inputRawJobSpec = makeSimpleCommand(
         };
     }
 );
+
+export const inputRawJobSpec = asyncOuputHandler(inputRawJobCommand, parseCreatedJob);

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -28,7 +28,7 @@ import { ChangeInfo, ChangeSpec } from "../api/CommonTypes";
 import { isTruthy, pluralise } from "../TsUtils";
 import { showQuickPickForChangelist } from "../quickPick/ChangeQuickPick";
 import { showQuickPickForJob } from "../quickPick/JobQuickPick";
-import { changeSpecEditor } from "../SpecEditor";
+import { changeSpecEditor, jobSpecEditor } from "../SpecEditor";
 
 function isResourceGroup(arg: any): arg is SourceControlResourceGroup {
     return arg && arg.id !== undefined;
@@ -356,9 +356,17 @@ export class Model implements Disposable {
         this._sourceControl.inputBox.value = "#" + id + "\n" + change.description ?? "";
     }
 
-    public async EditChangespec(input: ResourceGroup): Promise<void> {
+    public async EditChangeSpec(input: ResourceGroup): Promise<void> {
         this.assertIsNotDefault(input);
         await changeSpecEditor.editSpec(this._workspaceUri, input.chnum);
+    }
+
+    public async NewChangeSpec(): Promise<void> {
+        await changeSpecEditor.editSpec(this._workspaceUri, "new");
+    }
+
+    public async NewJobSpec(): Promise<void> {
+        await jobSpecEditor.editSpec(this._workspaceUri, "new");
     }
 
     public async Describe(input: ResourceGroup): Promise<void> {


### PR DESCRIPTION
Adds "Create changelist in editor..." and "Create job in editor..." to scm navigation menu

Runs `p4 change -o` / `p4 job -o` without a parameter to get default spec

For a new item, closes the 'new' editor and reopens with the new changelist / job id