### PR TITLE
Include revision in the path for perforce URIs

### DIFF
--- a/src/FileSystemActions.ts
+++ b/src/FileSystemActions.ts
@@ -97,10 +97,7 @@ export default class FileSystemActions {
         this._eventsDisposable.dispose();
     }
 
-    private static onWillSaveFile(
-        doc: TextDocument,
-        reason: TextDocumentSaveReason
-    ): Promise<boolean> {
+    private static onWillSaveFile(doc: TextDocument, reason: TextDocumentSaveReason) {
         if (
             FileSystemActions._lastSavedFileUri?.fsPath === doc.uri.fsPath &&
             reason !== TextDocumentSaveReason.Manual
@@ -147,7 +144,7 @@ export default class FileSystemActions {
     // configurable and/or the operation should be cancellable
     // in future releases.
     // https://github.com/stef-levesque/vscode-perforce/issues/110
-    private static tryEditFile(uri: Uri): Promise<boolean> {
+    private static tryEditFile(uri: Uri) {
         if (
             PerforceSCMProvider.hasOpenFile(uri) &&
             !PerforceSCMProvider.mayHaveConflictForFile(uri)

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -503,7 +503,7 @@ export class PerforceSCMProvider {
         ) as Resource[];
         const preview = selection.length === 1;
         const promises = selection.map((resource) => {
-            return commands.executeCommand<void>("vscode.open", resource.resourceUri, {
+            return commands.executeCommand<void>("vscode.open", resource.openUri, {
                 preview,
             });
         });
@@ -804,7 +804,7 @@ export class PerforceSCMProvider {
         diffType?: DiffProvider.DiffType
     ): Promise<void> {
         if (resource.FileType.base === FileType.BINARY) {
-            const uri = PerforceUri.fromUri(resource.resourceUri, { command: "fstat" });
+            const uri = PerforceUri.fromUri(resource.openUri, { command: "fstat" });
             await workspace
                 .openTextDocument(uri)
                 .then((doc) => window.showTextDocument(doc));

--- a/src/api/CommandUtils.ts
+++ b/src/api/CommandUtils.ts
@@ -1,5 +1,5 @@
 import { Utils } from "../Utils";
-import { FileSpec, isFileSpec, PerforceFile, isUri } from "./CommonTypes";
+import { PerforceFile, isUri } from "./CommonTypes";
 import * as vscode from "vscode";
 import * as PerforceUri from "../PerforceUri";
 import { PerforceService } from "../PerforceService";
@@ -127,7 +127,7 @@ function lastArgAsStrings(
     if (typeof lastArg === "number") {
         return [lastArg.toString()];
     }
-    if (isFileSpec(lastArg)) {
+    if (isUri(lastArg)) {
         return [fileSpecToArg(lastArg, options?.ignoreRevisionFragments)];
     }
     if (options?.lastArgIsFormattedArray) {
@@ -184,8 +184,8 @@ export function fragmentAsSuffix(
     return PerforceUri.revOrLabelAsSuffix(fragment);
 }
 
-function fileSpecToArg(fileSpec: FileSpec, ignoreRevisionFragments?: boolean) {
-    if (isUri(fileSpec) && PerforceUri.isDepotUri(fileSpec)) {
+function fileSpecToArg(fileSpec: vscode.Uri, ignoreRevisionFragments?: boolean) {
+    if (PerforceUri.isDepotUri(fileSpec)) {
         return (
             PerforceUri.getDepotPathFromDepotUri(fileSpec) +
             fragmentAsSuffix(
@@ -194,17 +194,16 @@ function fileSpecToArg(fileSpec: FileSpec, ignoreRevisionFragments?: boolean) {
             )
         );
     }
-    // TODO don't really like this bit
     return (
-        Utils.expansePath(PerforceUri.withoutRev(fileSpec.fsPath, fileSpec.fragment)) +
+        Utils.expansePath(PerforceUri.fsPathWithoutRev(fileSpec)) +
         fragmentAsSuffix(fileSpec.fragment, ignoreRevisionFragments)
     );
 }
 
-export function pathsToArgs(arr?: (string | FileSpec)[], options?: FlagMapperOptions) {
+export function pathsToArgs(arr?: PerforceFile[], options?: FlagMapperOptions) {
     return (
         arr?.map((path) => {
-            if (isFileSpec(path)) {
+            if (isUri(path)) {
                 return fileSpecToArg(path, options?.ignoreRevisionFragments);
             } else if (path) {
                 return path;

--- a/src/api/CommandUtils.ts
+++ b/src/api/CommandUtils.ts
@@ -181,7 +181,7 @@ export function fragmentAsSuffix(
     if (ignoreRevisionFragments) {
         return "";
     }
-    return fragment ? (fragment.startsWith("@") ? fragment : "#" + fragment) : "";
+    return PerforceUri.revOrLabelAsSuffix(fragment);
 }
 
 function fileSpecToArg(fileSpec: FileSpec, ignoreRevisionFragments?: boolean) {
@@ -194,8 +194,9 @@ function fileSpecToArg(fileSpec: FileSpec, ignoreRevisionFragments?: boolean) {
             )
         );
     }
+    // TODO don't really like this bit
     return (
-        Utils.expansePath(fileSpec.fsPath) +
+        Utils.expansePath(PerforceUri.withoutRev(fileSpec.fsPath, fileSpec.fragment)) +
         fragmentAsSuffix(fileSpec.fragment, ignoreRevisionFragments)
     );
 }

--- a/src/api/CommonTypes.ts
+++ b/src/api/CommonTypes.ts
@@ -35,20 +35,7 @@ export type FstatInfo = {
     [key: string]: string;
 };
 
-export type FileSpec =
-    | {
-          /** The filesystem path - without escaping special characters */
-          fsPath: string;
-          /** Optional suffix, e.g. 1 (converts to #1), @=2 */
-          fragment?: string;
-      }
-    | Uri;
-
-export type PerforceFile = FileSpec | string;
-
-export function isFileSpec(obj: any): obj is FileSpec {
-    return obj && obj.fsPath;
-}
+export type PerforceFile = Uri | string;
 
 export function isUri(obj: any): obj is Uri {
     return obj && obj.fsPath && obj.scheme !== undefined;

--- a/src/api/commands/basicOps.ts
+++ b/src/api/commands/basicOps.ts
@@ -61,7 +61,9 @@ const revertFlags = flagMapper<RevertOptions>(
         ["a", "unchanged"],
         ["c", "chnum"],
     ],
-    "paths"
+    "paths",
+    undefined,
+    { ignoreRevisionFragments: true }
 );
 
 export const revert = makeSimpleCommand("revert", revertFlags, () => {
@@ -341,7 +343,9 @@ export type AddOptions = {
     chnum?: string;
     files: PerforceFile[];
 };
-const addFlags = flagMapper<AddOptions>([["c", "chnum"]], "files");
+const addFlags = flagMapper<AddOptions>([["c", "chnum"]], "files", undefined, {
+    ignoreRevisionFragments: true,
+});
 
 export const add = makeSimpleCommand("add", addFlags, () => {
     return { logStdOut: true };
@@ -351,7 +355,9 @@ export type EditOptions = {
     chnum?: string;
     files: PerforceFile[];
 };
-const editFlags = flagMapper<EditOptions>([["c", "chnum"]], "files");
+const editFlags = flagMapper<EditOptions>([["c", "chnum"]], "files", undefined, {
+    ignoreRevisionFragments: true,
+});
 
 export const edit = makeSimpleCommand("edit", editFlags, () => {
     return { logStdOut: true };

--- a/src/quickPick/FileQuickPick.ts
+++ b/src/quickPick/FileQuickPick.ts
@@ -29,7 +29,7 @@ export const fileQuickPickProvider: qp.ActionableQuickPickProvider = {
         return {
             items: actions,
             placeHolder: makeRevisionSummary(changes.current),
-            recentKey: "file:" + uri.fsPath,
+            recentKey: "file:" + PerforceUri.fsPathWithoutRev(uri),
         };
     },
 };

--- a/src/quickPick/QuickPickProvider.ts
+++ b/src/quickPick/QuickPickProvider.ts
@@ -1,10 +1,11 @@
 import * as vscode from "vscode";
 import { isTruthy } from "../TsUtils";
 import { Display } from "../Display";
+import * as PerforceUri from "../PerforceUri";
 
 export function asUri(uri: vscode.Uri | string) {
     if (typeof uri === "string") {
-        return vscode.Uri.parse(uri);
+        return PerforceUri.parse(uri);
     }
     return uri;
 }

--- a/src/quickPick/ShelvedFileQuickPick.ts
+++ b/src/quickPick/ShelvedFileQuickPick.ts
@@ -10,7 +10,6 @@ import { isTruthy } from "../TsUtils";
 import { GetStatus, operationCreatesFile, Status } from "../scm/Status";
 import * as ChangeQuickPick from "./ChangeQuickPick";
 import { showQuickPickForFile } from "./FileQuickPick";
-import * as Path from "path";
 
 const nbsp = "\xa0";
 
@@ -178,7 +177,7 @@ async function makeDiffPicks(
         !operationCreatesFile(status)
             ? {
                   label: "$(list-flat) Go to source revision",
-                  description: Path.basename(uri.fsPath) + "#" + operation.revision,
+                  description: PerforceUri.fsPathWithoutRev(uri),
                   performAction: () => showQuickPickForFile(uri),
               }
             : undefined,
@@ -186,7 +185,7 @@ async function makeDiffPicks(
             ? {
                   label: "$(list-flat) Go to moved-from revision",
                   description:
-                      Path.basename(movedFrom.fsPath) +
+                      PerforceUri.basenameWithoutRev(movedFrom) +
                       "#" +
                       PerforceUri.getRevOrAtLabel(movedFrom),
                   performAction: () => showQuickPickForFile(movedFrom),

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -527,8 +527,9 @@ export class Model implements Disposable {
                 );
                 return;
             }
-            opts.paths = [{ fsPath: input.resourceUri.fsPath }];
-            message += "to file " + Path.basename(input.resourceUri.fsPath) + "?";
+            opts.paths = [input.resourceUri];
+            message +=
+                "to file " + PerforceUri.basenameWithoutRev(input.resourceUri) + "?";
         } else if (isResourceGroup(input)) {
             opts.paths = ["//..."];
             opts.chnum = input.chnum;
@@ -682,7 +683,7 @@ export class Model implements Disposable {
     async showResolveWarningForFile(input: Resource) {
         const resolveButton = "Resolve file";
         const chosen = await vscode.window.showWarningMessage(
-            Path.basename(input.resourceUri.fsPath) +
+            PerforceUri.basenameWithoutRev(input.resourceUri) +
                 " was unshelved, but needs resolving",
             resolveButton
         );
@@ -700,7 +701,7 @@ export class Model implements Disposable {
         }
 
         if (mode === FileShelveMode.PROMPT) {
-            const file = Path.basename(input.resourceUri.fsPath);
+            const file = PerforceUri.basenameWithoutRev(input.resourceUri);
             const message = file + " was unshelved. Delete the shelved file?";
             const yes = "Delete " + file + "@=" + input.change;
             const always = "Always";
@@ -738,7 +739,7 @@ export class Model implements Disposable {
         }
 
         if (mode === FileShelveMode.PROMPT) {
-            const file = Path.basename(input.resourceUri.fsPath);
+            const file = PerforceUri.basenameWithoutRev(input.resourceUri);
             const message = file + " was shelved. Revert the open file?";
             const yes = "Revert " + file;
             const always = "Always";
@@ -783,7 +784,7 @@ export class Model implements Disposable {
         await p4.shelve(this._workspaceUri, {
             chnum: input.change,
             force: true,
-            paths: [{ fsPath: input.resourceUri.fsPath }],
+            paths: [input.resourceUri],
         });
         this.Refresh();
         await this.revertFileAfterUnshelve(input);
@@ -816,7 +817,8 @@ export class Model implements Disposable {
     public async DeleteShelvedFile(input: Resource): Promise<void> {
         if (!input.isShelved) {
             Display.showImportantError(
-                "Shelve cannot be used on normal file: " + Path.basename(input.uri.fsPath)
+                "Shelve cannot be used on normal file: " +
+                    PerforceUri.basenameWithoutRev(input.resourceUri)
             );
             return;
         }
@@ -1000,9 +1002,7 @@ export class Model implements Disposable {
         try {
             const output = await p4.reopenFiles(this._workspaceUri, {
                 chnum: chnum,
-                files: resources.map((resource) => {
-                    return { fsPath: resource.resourceUri.fsPath };
-                }),
+                files: resources.map((resource) => resource.resourceUri),
             });
             Display.channel.append(output);
         } catch (reason) {

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -240,7 +240,7 @@ export class Model implements Disposable {
         if (cachedHave !== undefined) {
             return cachedHave;
         }
-        const ret = await p4.haveFile(uri, { file: { fsPath: uri.fsPath } });
+        const ret = await p4.haveFile(uri, { file: uri });
 
         this._knownHaveListByPath.set(uri.fsPath, ret);
 

--- a/src/scm/Resource.ts
+++ b/src/scm/Resource.ts
@@ -61,11 +61,30 @@ export class Resource implements SourceControlResourceState {
      * Resource URI *should* be the underlying file, but for shelved files, a depot path is used.
      * This is used for display in the SCM provider - so the depot path does not include a revision
      *
+     * **DO NOT USE** this function - so we are free to change the display without impacting other areas.
+     * Use `actionUriNoRev` instead
+     *
      * this keeps them together in the workspace tree, and for some operations there may not be a matching file in the workspace
      */
     get resourceUri(): Uri {
         return this._resourceUri;
     }
+
+    /**
+     * The file to use for performing perforce actions that don't require a revision,
+     * could be depot or local file
+     *
+     * Currently, resource URI has no rev, but this should be used instead of
+     * resource URI for clarity and so we can change the display in future
+     */
+    get actionUriNoRev(): Uri {
+        return this._resourceUri;
+    }
+
+    get basenameWithoutRev(): string {
+        return PerforceUri.basenameWithoutRev(this.uri);
+    }
+
     get decorations(): SourceControlResourceDecorations {
         return DecorationProvider.getDecorations(
             this._statuses,

--- a/src/search/Filters.ts
+++ b/src/search/Filters.ts
@@ -422,7 +422,7 @@ export class FileFilterRoot extends SelfExpandingTreeItem<
         }
         const filePath = PerforceUri.isDepotUri(openUri)
             ? PerforceUri.getDepotPathFromDepotUri(openUri)
-            : openUri.fsPath;
+            : PerforceUri.fsPathWithoutRev(openUri);
         return filePath;
     }
 

--- a/src/test/helpers/p4Commands.ts
+++ b/src/test/helpers/p4Commands.ts
@@ -32,6 +32,7 @@ function resourceToString(resource: Resource) {
             status: resource.status,
             isShelved: resource.isShelved,
             resourceUri: resource.resourceUri?.toString(),
+            actionUriNoRev: resource.actionUriNoRev?.toString(),
             openUri: resource.openUri?.toString(),
             underlyingUri: resource.underlyingUri?.toString(),
             fromFile: resource.fromFile?.toString(),

--- a/src/test/helpers/p4Commands.ts
+++ b/src/test/helpers/p4Commands.ts
@@ -32,6 +32,7 @@ function resourceToString(resource: Resource) {
             status: resource.status,
             isShelved: resource.isShelved,
             resourceUri: resource.resourceUri?.toString(),
+            openUri: resource.openUri?.toString(),
             underlyingUri: resource.underlyingUri?.toString(),
             fromFile: resource.fromFile?.toString(),
         },
@@ -152,6 +153,13 @@ export default function (chai: Chai.ChaiStatic, _utils: Chai.ChaiUtils) {
 
             assertP4UriMatches(
                 Assertion,
+                resource.openUri,
+                expected.localFile,
+                "Resource " + i + " resource URI : " + resourceToString(resource)
+            );
+
+            assertP4UriMatches(
+                Assertion,
                 resource.resourceUri,
                 expected.localFile,
                 "Resource " + i + " resource URI : " + resourceToString(resource)
@@ -193,6 +201,18 @@ export default function (chai: Chai.ChaiStatic, _utils: Chai.ChaiUtils) {
             assertP4UriMatches(
                 Assertion,
                 resource.resourceUri,
+                PerforceUri.fromDepotPath(
+                    expected.suppressFstatClientFile
+                        ? resource.model.workspaceUri
+                        : expected.localFile,
+                    expected.depotPath,
+                    ""
+                ),
+                "Resource " + i + " resource URI : " + resourceToString(resource)
+            );
+            assertP4UriMatches(
+                Assertion,
+                resource.openUri,
                 PerforceUri.fromDepotPath(
                     expected.suppressFstatClientFile
                         ? resource.model.workspaceUri

--- a/src/test/helpers/testUtils.ts
+++ b/src/test/helpers/testUtils.ts
@@ -69,6 +69,7 @@ export function perforceLocalUriMatcher(file: StubFile) {
         throw new Error("Can't make a local file matcher without a local file");
     }
     return PerforceUri.fromUri(file.localFile).with({
+        path: file.localFile.path + "#" + file.depotRevision,
         fragment: file.depotRevision.toString(),
     });
 }
@@ -108,6 +109,7 @@ export function perforceFromFileUriMatcher(file: StubFile) {
 export function perforceShelvedUriMatcher(file: StubFile, chnum: string) {
     return PerforceUri.fromUri(
         vscode.Uri.parse("perforce:" + file.depotPath).with({
+            path: file.depotPath.replace("//depot", "") + "@=" + chnum,
             fragment: "@=" + chnum,
         }),
         { depot: true, workspace: getWorkspaceUri().fsPath }
@@ -118,5 +120,5 @@ export function perforceLocalShelvedUriMatcher(file: StubFile, chnum: string) {
     if (!file.localFile) {
         throw new Error("Can't make a local file matcher without a local file");
     }
-    return PerforceUri.fromUri(file.localFile.with({ fragment: "@=" + chnum }));
+    return PerforceUri.fromUriWithRevision(file.localFile, "@=" + chnum);
 }

--- a/src/test/suite/diffProvider.test.ts
+++ b/src/test/suite/diffProvider.test.ts
@@ -276,10 +276,12 @@ describe("Diff Provider", () => {
                 };
                 stubModel.have.resolves(have);
 
-                const expectedLeft = PerforceUri.withArgs(have.depotUri, {
-                    haveRev: "4",
-                    rev: "3",
-                }).with({ fragment: "3" });
+                const expectedLeft = PerforceUri.withArgs(
+                    PerforceUri.fromUriWithRevision(have.depotUri, "3"),
+                    {
+                        haveRev: "4",
+                    }
+                ).with({ fragment: "3" });
                 const expectedRight = PerforceUri.withArgs(have.depotUri, {
                     haveRev: "4",
                 });

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -1123,6 +1123,7 @@ describe("Model & ScmProvider modules (integration)", () => {
 
                 expect(out).to.deep.equal(
                     basicFiles.add().localFile.with({
+                        path: basicFiles.add().localFile.path + "#have",
                         scheme: "perforce",
                         fragment: "have",
                         query: "command=print&p4Args=-q&rev=have",
@@ -1141,6 +1142,7 @@ describe("Model & ScmProvider modules (integration)", () => {
 
                 expect(out).to.deep.equal(
                     vscode.Uri.parse(basicFiles.moveDelete().depotPath).with({
+                        path: "/testArea/testFolderOld/movedFrom.txt#4",
                         scheme: "perforce",
                         fragment: "4",
                         query:
@@ -1466,7 +1468,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
                     chnum: "1",
                     force: true,
-                    paths: [{ fsPath: basicFiles.edit().localFile.fsPath }],
+                    paths: [sinon.match({ fsPath: basicFiles.edit().localFile.fsPath })],
                 });
 
                 expect(warn).to.have.been.calledOnce;
@@ -1489,7 +1491,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
                     chnum: "1",
                     force: true,
-                    paths: [{ fsPath: basicFiles.edit().localFile.fsPath }],
+                    paths: [sinon.match({ fsPath: basicFiles.edit().localFile.fsPath })],
                 });
 
                 expect(warn).to.have.been.calledOnce;
@@ -1589,7 +1591,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
                     chnum: "1",
                     force: true,
-                    paths: [{ fsPath: basicFiles.edit().localFile.fsPath }],
+                    paths: [sinon.match({ fsPath: basicFiles.edit().localFile.fsPath })],
                 });
                 expect(items.stubModel.revert).to.have.been.calledWithMatch(
                     workspaceUri,
@@ -1642,7 +1644,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
                     chnum: "1",
                     force: true,
-                    paths: [{ fsPath: basicFiles.edit().localFile.fsPath }],
+                    paths: [sinon.match({ fsPath: basicFiles.edit().localFile.fsPath })],
                 });
 
                 expect(warn).not.to.have.been.called;
@@ -1692,7 +1694,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
                     chnum: "1",
                     force: true,
-                    paths: [{ fsPath: basicFiles.edit().localFile.fsPath }],
+                    paths: [sinon.match({ fsPath: basicFiles.edit().localFile.fsPath })],
                 });
 
                 expect(warn).to.have.been.calledTwice;
@@ -1703,7 +1705,9 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
                     chnum: "1",
                     force: true,
-                    paths: [{ fsPath: basicFiles.delete().localFile.fsPath }],
+                    paths: [
+                        sinon.match({ fsPath: basicFiles.delete().localFile.fsPath }),
+                    ],
                 });
                 expect(items.stubModel.revert).to.have.been.calledWith(workspaceUri, {
                     paths: [
@@ -1786,7 +1790,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                         "a.txt#4 ⟷ a.txt (workspace)"
                     );
                     expect(items.execute).to.be.calledWithMatch(
-                        { fsPath: file.localFile.fsPath },
+                        { fsPath: file.localFile.fsPath + "#4" },
                         "print",
                         sinon.match.any,
                         ["-q", file.localFile.fsPath + "#4"]
@@ -1814,7 +1818,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                         "a.txt#4 ⟷ a.txt"
                     );
                     expect(items.execute).to.be.calledWithMatch(
-                        { fsPath: file1.localFile.fsPath },
+                        { fsPath: file1.localFile.fsPath + "#4" },
                         "print",
                         sinon.match.any,
                         ["-q", file1.localFile.fsPath + "#4"]
@@ -1920,7 +1924,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     );
 
                     expect(items.execute).to.be.calledWithMatch(
-                        { fsPath: file.localFile.fsPath },
+                        { fsPath: file.localFile.fsPath + "#7" },
                         "print",
                         sinon.match.any,
                         ["-q", file.localFile.fsPath + "#7"]
@@ -1989,7 +1993,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                         "a.txt@=1 ⟷ a.txt (workspace)"
                     );
                     expect(items.execute).to.be.calledWithMatch(
-                        { fsPath: file.localFile.fsPath },
+                        { fsPath: file.localFile.fsPath + "@=1" },
                         "print",
                         sinon.match.any,
                         ["-q", file.localFile.fsPath + "@=1"]
@@ -2497,8 +2501,8 @@ describe("Model & ScmProvider modules (integration)", () => {
                     {
                         chnum: "2",
                         files: [
-                            { fsPath: basicFiles.add().localFile.fsPath },
-                            { fsPath: basicFiles.edit().localFile.fsPath },
+                            sinon.match({ fsPath: basicFiles.add().localFile.fsPath }),
+                            sinon.match({ fsPath: basicFiles.edit().localFile.fsPath }),
                         ],
                     }
                 );
@@ -2519,7 +2523,9 @@ describe("Model & ScmProvider modules (integration)", () => {
                     workspaceUri,
                     {
                         chnum: "default",
-                        files: [{ fsPath: basicFiles.edit().localFile.fsPath }],
+                        files: [
+                            sinon.match({ fsPath: basicFiles.edit().localFile.fsPath }),
+                        ],
                     }
                 );
             });
@@ -2557,8 +2563,8 @@ describe("Model & ScmProvider modules (integration)", () => {
                     {
                         chnum: "99",
                         files: [
-                            { fsPath: basicFiles.add().localFile.fsPath },
-                            { fsPath: basicFiles.edit().localFile.fsPath },
+                            sinon.match({ fsPath: basicFiles.add().localFile.fsPath }),
+                            sinon.match({ fsPath: basicFiles.edit().localFile.fsPath }),
                         ],
                     }
                 );
@@ -2743,7 +2749,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 await PerforceSCMProvider.Revert(resource as Resource);
 
                 expect(items.stubModel.revert).to.have.been.calledWith(workspaceUri, {
-                    paths: [{ fsPath: basicFiles.edit().localFile.fsPath }],
+                    paths: [sinon.match({ fsPath: basicFiles.edit().localFile.fsPath })],
                     unchanged: undefined,
                 });
             });
@@ -2767,11 +2773,13 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(warn).to.have.been.calledTwice;
 
                 expect(items.stubModel.revert).to.have.been.calledWith(workspaceUri, {
-                    paths: [{ fsPath: basicFiles.add().localFile.fsPath }],
+                    paths: [sinon.match({ fsPath: basicFiles.add().localFile.fsPath })],
                     unchanged: undefined,
                 });
                 expect(items.stubModel.revert).to.have.been.calledWith(workspaceUri, {
-                    paths: [{ fsPath: basicFiles.delete().localFile.fsPath }],
+                    paths: [
+                        sinon.match({ fsPath: basicFiles.delete().localFile.fsPath }),
+                    ],
                     unchanged: undefined,
                 });
             });
@@ -2792,7 +2800,9 @@ describe("Model & ScmProvider modules (integration)", () => {
 
                 expect(items.stubModel.revert).to.have.been.calledOnce;
                 expect(items.stubModel.revert).to.have.been.calledWith(workspaceUri, {
-                    paths: [{ fsPath: basicFiles.moveAdd().localFile.fsPath }],
+                    paths: [
+                        sinon.match({ fsPath: basicFiles.moveAdd().localFile.fsPath }),
+                    ],
                     unchanged: undefined,
                 });
 
@@ -2814,7 +2824,7 @@ describe("Model & ScmProvider modules (integration)", () => {
 
                 expect(warn).not.to.have.been.called;
                 expect(items.stubModel.revert).to.have.been.calledWith(workspaceUri, {
-                    paths: [{ fsPath: basicFiles.edit().localFile.fsPath }],
+                    paths: [sinon.match({ fsPath: basicFiles.edit().localFile.fsPath })],
                     unchanged: true,
                 });
             });

--- a/src/test/suite/perforceApi.test.ts
+++ b/src/test/suite/perforceApi.test.ts
@@ -522,13 +522,13 @@ describe("Perforce API", () => {
         it("Can submit a single specified file", async () => {
             await p4.submitChangelist(ws, {
                 description: "my description",
-                file: { fsPath: "C:\\MyFile.txt" },
+                file: vscode.Uri.file("C:\\MyFile.txt"),
             });
 
             expect(execute).to.have.been.calledWith(ws, "submit", sinon.match.any, [
                 "-d",
                 "my description",
-                "C:\\MyFile.txt",
+                "c:\\MyFile.txt",
             ]);
         });
     });
@@ -538,7 +538,7 @@ describe("Perforce API", () => {
                 p4.revert(ws, {
                     unchanged: true,
                     chnum: "1",
-                    paths: [{ fsPath: "c:\\my f#ile.txt" }],
+                    paths: [vscode.Uri.file("C:\\my f#ile.txt")],
                 })
             ).to.eventually.equal("revert -a -c 1 c:\\my f%23ile.txt");
         });

--- a/src/test/suite/perforceCommands.test.ts
+++ b/src/test/suite/perforceCommands.test.ts
@@ -84,6 +84,7 @@ describe("Perforce Command Module (integration)", () => {
             await PerforceCommands.diff(5);
             expect(execCommand.lastCall).to.be.vscodeDiffCall(
                 PerforceUri.fromUri(localFile).with({
+                    path: localFile.path + "#5",
                     fragment: "5",
                 }),
                 localFile,


### PR DESCRIPTION
* This allows the revision to be displayed in the editor title when a specific revision is opened
* Affects a lot of areas that used fsPath
* don't include revision in resource URIs on the scm provider
  * prevents @= labels on shelved files (though, this isn't necessarily bad...)
  * instead, an `openUri` param is stored in the Resource which is the one to open for diffs etc.
* Add helper PerforceUri functions to get various bits of URIs
* Messes with the parsing since # is the fragment identifier, so a new parse function is added that sorts it out

~TODO: can possibly now remove filespec type that's just an fsPath~

~might be a good idea to remove all references to `resourceUri` so that we can change how items are displayed in the scm provider without affecting any other behaviour~