### PR TITLE
remove revisions / labels from URI

### DIFF
--- a/src/DiffProvider.ts
+++ b/src/DiffProvider.ts
@@ -303,7 +303,7 @@ function getLeftResource(
                     "@=" + resource.change // still need to specify because the resource could be either the open or workspace file
                 );
                 return {
-                    title: Path.basename(leftUri.fsPath),
+                    title: PerforceUri.basenameWithRev(leftUri, "@=" + resource.change),
                     uri: leftUri,
                 };
             case Status.DELETE:
@@ -323,7 +323,7 @@ function getLeftResource(
                 // diff against the old file if it is known (always a depot path)
                 return {
                     title: resource.fromFile
-                        ? Path.basename(resource.fromFile.fsPath)
+                        ? PerforceUri.basenameWithRev(resource.fromFile)
                         : "Depot Version",
                     uri: resource.fromFile ?? emptyDoc,
                 };
@@ -336,7 +336,7 @@ function getLeftResource(
                     resource.workingRevision
                 );
                 return {
-                    title: Path.basename(leftUri.fsPath),
+                    title: PerforceUri.basenameWithRev(leftUri),
                     uri: leftUri,
                 };
         }
@@ -372,7 +372,7 @@ function getRightResource(resource: Resource, diffType: DiffType): Uri | undefin
 
 function getTitle(resource: Resource, leftTitle: string, diffType: DiffType): string {
     const basename = PerforceUri.basenameWithoutRev(resource.openUri);
-    const basenameWithRev = Path.basename(resource.openUri.fsPath);
+    const basenameWithRev = PerforceUri.basenameWithRev(resource.openUri);
 
     let text = "";
     switch (diffType) {

--- a/src/PerforceUri.ts
+++ b/src/PerforceUri.ts
@@ -37,11 +37,13 @@ export function revOrLabelAsSuffix(revOrAtLabel: string | undefined) {
         : "";
 }
 
-export function withoutRev(path: string, revOrAtLabel: string | undefined) {
-    const revStr = revOrLabelAsSuffix(revOrAtLabel);
+export function withoutRev(path: string, _revOrAtLabel: string | undefined) {
+    // removed as it prevents syntax highlighting on the opened file - TODO: consider an option
+    /*const revStr = revOrLabelAsUriSuffix(revOrAtLabel);
     if (revStr && path.endsWith(revStr)) {
         return path.slice(0, -revStr.length);
     }
+    return path;*/
     return path;
 }
 
@@ -58,9 +60,19 @@ export function basenameWithoutRev(uri: vscode.Uri) {
     return Path.basename(fsPathWithoutRev(uri));
 }
 
+export function basenameWithRev(uri: vscode.Uri, overrideRev?: string) {
+    return (
+        Path.basename(fsPathWithoutRev(uri)) +
+        revOrLabelAsSuffix(overrideRev ?? getRevOrAtLabel(uri))
+    );
+}
+
 function uriWithRev(uri: vscode.Uri, revOrAtLabel: string | undefined) {
+    /*return uri.with({
+        path: uri.path + revOrLabelAsUriSuffix(revOrAtLabel),
+        fragment: revOrAtLabel,
+    });*/
     return uri.with({
-        path: uri.path + revOrLabelAsSuffix(revOrAtLabel),
         fragment: revOrAtLabel,
     });
 }

--- a/src/test/helpers/testUtils.ts
+++ b/src/test/helpers/testUtils.ts
@@ -69,7 +69,6 @@ export function perforceLocalUriMatcher(file: StubFile) {
         throw new Error("Can't make a local file matcher without a local file");
     }
     return PerforceUri.fromUri(file.localFile).with({
-        path: file.localFile.path + "#" + file.depotRevision,
         fragment: file.depotRevision.toString(),
     });
 }
@@ -109,7 +108,6 @@ export function perforceFromFileUriMatcher(file: StubFile) {
 export function perforceShelvedUriMatcher(file: StubFile, chnum: string) {
     return PerforceUri.fromUri(
         vscode.Uri.parse("perforce:" + file.depotPath).with({
-            path: file.depotPath.replace("//depot", "") + "@=" + chnum,
             fragment: "@=" + chnum,
         }),
         { depot: true, workspace: getWorkspaceUri().fsPath }

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -1123,7 +1123,7 @@ describe("Model & ScmProvider modules (integration)", () => {
 
                 expect(out).to.deep.equal(
                     basicFiles.add().localFile.with({
-                        path: basicFiles.add().localFile.path + "#have",
+                        path: basicFiles.add().localFile.path,
                         scheme: "perforce",
                         fragment: "have",
                         query: "command=print&p4Args=-q&rev=have",
@@ -1142,7 +1142,7 @@ describe("Model & ScmProvider modules (integration)", () => {
 
                 expect(out).to.deep.equal(
                     vscode.Uri.parse(basicFiles.moveDelete().depotPath).with({
-                        path: "/testArea/testFolderOld/movedFrom.txt#4",
+                        path: "/testArea/testFolderOld/movedFrom.txt",
                         scheme: "perforce",
                         fragment: "4",
                         query:
@@ -1790,7 +1790,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                         "a.txt#4 ⟷ a.txt (workspace)"
                     );
                     expect(items.execute).to.be.calledWithMatch(
-                        { fsPath: file.localFile.fsPath + "#4" },
+                        { fsPath: file.localFile.fsPath },
                         "print",
                         sinon.match.any,
                         ["-q", file.localFile.fsPath + "#4"]
@@ -1818,7 +1818,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                         "a.txt#4 ⟷ a.txt"
                     );
                     expect(items.execute).to.be.calledWithMatch(
-                        { fsPath: file1.localFile.fsPath + "#4" },
+                        { fsPath: file1.localFile.fsPath },
                         "print",
                         sinon.match.any,
                         ["-q", file1.localFile.fsPath + "#4"]
@@ -1924,7 +1924,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     );
 
                     expect(items.execute).to.be.calledWithMatch(
-                        { fsPath: file.localFile.fsPath + "#7" },
+                        { fsPath: file.localFile.fsPath },
                         "print",
                         sinon.match.any,
                         ["-q", file.localFile.fsPath + "#7"]
@@ -1993,7 +1993,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                         "a.txt@=1 ⟷ a.txt (workspace)"
                     );
                     expect(items.execute).to.be.calledWithMatch(
-                        { fsPath: file.localFile.fsPath + "@=1" },
+                        { fsPath: file.localFile.fsPath },
                         "print",
                         sinon.match.any,
                         ["-q", file.localFile.fsPath + "@=1"]

--- a/src/test/suite/perforceCommands.test.ts
+++ b/src/test/suite/perforceCommands.test.ts
@@ -84,7 +84,7 @@ describe("Perforce Command Module (integration)", () => {
             await PerforceCommands.diff(5);
             expect(execCommand.lastCall).to.be.vscodeDiffCall(
                 PerforceUri.fromUri(localFile).with({
-                    path: localFile.path + "#5",
+                    path: localFile.path,
                     fragment: "5",
                 }),
                 localFile,

--- a/src/test/suite/perforceUri.test.ts
+++ b/src/test/suite/perforceUri.test.ts
@@ -64,7 +64,7 @@ describe("Perforce Uris", () => {
             const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
             expect(uri.scheme).to.equal("perforce");
             expect(uri.authority).to.equal("depot");
-            expect(uri.path).to.equal("/my/path/file.txt#2");
+            expect(uri.path).to.equal("/my/path/file.txt");
             expect(uri.query).to.equal(
                 "command=print&p4Args=-q&depot&" + workspaceArg + "&depotName=depot&rev=2"
             );
@@ -85,7 +85,7 @@ describe("Perforce Uris", () => {
         it("Produces a perforce URI with an added revision / label fragment", () => {
             const uri = PerforceUri.fromUriWithRevision(localUri, "@=99");
             expect(uri.scheme).to.equal("perforce");
-            expect(uri.fsPath).to.equal(localUri.fsPath + "@=99");
+            expect(uri.fsPath).to.equal(localUri.fsPath);
             expect(uri.query).to.equal("command=print&p4Args=-q&rev=%40%3D99");
             expect(uri.fragment).to.equal("@=99");
         });
@@ -230,7 +230,7 @@ describe("Perforce Uris", () => {
             expect(uri.path).to.equal("/a/myFile");
         });
     });
-    describe("withoutRev", () => {
+    /*describe("withoutRev", () => {
         it("Removes a revision from a path if it matches the fragment", () => {
             const path = "/my/path#2";
             expect(PerforceUri.withoutRev(path, "2")).to.equal("/my/path");
@@ -262,5 +262,5 @@ describe("Perforce Uris", () => {
             const withoutRev = PerforceUri.fsPathWithoutRev(uri);
             expect(withoutRev).to.equal(uri.fsPath);
         });
-    });
+    });*/
 });


### PR DESCRIPTION
these were causing syntax highlighting to break for the opened file

can consider if there's another way of doing this, but I can't find anything