### PR TITLE
Replace content provider with FileSystemProvider, display file revisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1588,7 +1588,17 @@
                 "command": "perforce.submitSingle",
                 "when": "editorTextFocus"
             }
-        ]
+        ],
+        "resourceLabelFormatters": [
+            {
+              "scheme": "perforce",
+              "formatting": {
+                "label": "${path}${authority}",
+                "separator": "/",
+                "workspaceSuffix": "Perforce"
+              }
+            }
+          ]
     },
     "dependencies": {},
     "devDependencies": {

--- a/src/ContentProvider.ts
+++ b/src/ContentProvider.ts
@@ -3,7 +3,6 @@ import {
     workspace,
     Uri,
     Disposable,
-    Event,
     EventEmitter,
     FileSystemProvider,
     FileChangeEvent,
@@ -117,68 +116,15 @@ export class PerforceFileSystemProvider implements FileSystemProvider, Disposabl
     }
 }
 
-export class PerforceContentProvider {
-    private onDidChangeEmitter = new EventEmitter<Uri>();
-
-    get onDidChange(): Event<Uri> {
-        return this.onDidChangeEmitter.event;
+let _perforceContentProvider: PerforceFileSystemProvider | undefined;
+export function perforceContentProvider() {
+    if (!_perforceContentProvider) {
+        _perforceContentProvider = new PerforceFileSystemProvider();
     }
-
-    private disposables: Disposable[] = [];
-    dispose(): void {
-        this.disposables.forEach((d) => d.dispose());
-    }
-
-    constructor() {
-        this.disposables.push(
-            workspace.registerTextDocumentContentProvider("perforce", this)
-        );
-    }
-
-    public requestUpdatedDocument(uri: Uri) {
-        this.onDidChangeEmitter.fire(uri);
-    }
-
-    private getResourceForUri(uri: Uri): Uri | undefined {
-        if (PerforceUri.isUsableForWorkspace(uri)) {
-            return uri;
-        }
-        // just for printing the output of a command that doesn't relate to a specific file
-        if (window.activeTextEditor && !window.activeTextEditor.document.isUntitled) {
-            return window.activeTextEditor.document.uri;
-        }
-        return workspace.workspaceFolders?.[0].uri;
-    }
-
-    public async provideTextDocumentContent(uri: Uri): Promise<string> {
-        if (uri.path === "EMPTY") {
-            return "";
-        }
-
-        const allArgs = PerforceUri.decodeUriQuery(uri.query ?? "");
-        const args = ((allArgs["p4Args"] as string) ?? "-q").split(" ");
-        const command = (allArgs["command"] as string) ?? "print";
-
-        const resource = this.getResourceForUri(uri);
-
-        if (!resource) {
-            Display.channel.appendLine(
-                `Can't find proper workspace to provide content for ${uri}`
-            );
-            throw new Error(`Can't find proper workspace for command ${command} `);
-        }
-
-        // TODO - don't export this stuff from the API,
-        // change the uri scheme so that it's not just running arbitrary commands
-        const fileArgs = uri.fsPath ? pathsToArgs([uri]).filter(isTruthy) : [];
-        const allP4Args = args.concat(fileArgs);
-
-        return runPerforceCommand(resource, command, allP4Args, { hideStdErr: true });
-    }
+    return _perforceContentProvider;
 }
 
-let _perforceContentProvider: PerforceFileSystemProvider;
-export function perforceContentProvider() {
+export function initPerforceContentProvider() {
     if (!_perforceContentProvider) {
         _perforceContentProvider = new PerforceFileSystemProvider();
     }

--- a/src/ContentProvider.ts
+++ b/src/ContentProvider.ts
@@ -1,8 +1,121 @@
-import { window, workspace, Uri, Disposable, Event, EventEmitter } from "vscode";
+import {
+    window,
+    workspace,
+    Uri,
+    Disposable,
+    Event,
+    EventEmitter,
+    FileSystemProvider,
+    FileChangeEvent,
+    FileType,
+    FileSystemError,
+    FileChangeType,
+} from "vscode";
 import { Display } from "./Display";
 import * as PerforceUri from "./PerforceUri";
 import { runPerforceCommand, pathsToArgs } from "./api/CommandUtils";
 import { isTruthy } from "./TsUtils";
+import { TextEncoder } from "util";
+
+export class PerforceFileSystemProvider implements FileSystemProvider, Disposable {
+    private _onDidChangeFileEmitter = new EventEmitter<FileChangeEvent[]>();
+    constructor() {
+        this.disposables.push(
+            workspace.registerFileSystemProvider("perforce", this, {
+                isReadonly: true,
+                isCaseSensitive: true,
+            })
+        );
+    }
+    private disposables: Disposable[] = [];
+    dispose(): void {
+        this.disposables.forEach((d) => d.dispose());
+    }
+
+    get onDidChangeFile() {
+        return this._onDidChangeFileEmitter.event;
+    }
+
+    watch(_uri: Uri, _options: { recursive: boolean; excludes: string[] }): Disposable {
+        return {
+            dispose: () => {
+                /**/
+            },
+        };
+    }
+    stat(_uri: Uri): import("vscode").FileStat | Thenable<import("vscode").FileStat> {
+        const now = new Date().getTime();
+        return { type: FileType.File, ctime: now, mtime: now, size: 0 };
+    }
+    readDirectory(_uri: Uri): [string, FileType][] {
+        throw FileSystemError.NoPermissions();
+    }
+    createDirectory(_uri: Uri): void | Thenable<void> {
+        throw FileSystemError.NoPermissions();
+    }
+    async readFile(uri: Uri) {
+        const content = await this.provideTextDocumentContent(uri);
+        return new TextEncoder().encode(content);
+    }
+    writeFile(
+        _uri: Uri,
+        _content: Uint8Array,
+        _options: { create: boolean; overwrite: boolean }
+    ): void | Thenable<void> {
+        throw FileSystemError.NoPermissions();
+    }
+    delete(_uri: Uri, _options: { recursive: boolean }): void | Thenable<void> {
+        throw FileSystemError.NoPermissions();
+    }
+    rename(
+        _oldUri: Uri,
+        _newUri: Uri,
+        _options: { overwrite: boolean }
+    ): void | Thenable<void> {
+        throw FileSystemError.NoPermissions();
+    }
+
+    public requestUpdatedDocument(uri: Uri) {
+        this._onDidChangeFileEmitter.fire([{ type: FileChangeType.Changed, uri: uri }]);
+    }
+
+    private getResourceForUri(uri: Uri): Uri | undefined {
+        if (PerforceUri.isUsableForWorkspace(uri)) {
+            return uri;
+        }
+        // just for printing the output of a command that doesn't relate to a specific file
+        if (window.activeTextEditor && !window.activeTextEditor.document.isUntitled) {
+            return window.activeTextEditor.document.uri;
+        }
+        return workspace.workspaceFolders?.[0].uri;
+    }
+
+    public async provideTextDocumentContent(uri: Uri): Promise<string> {
+        if (uri.path === "EMPTY") {
+            return "";
+        }
+
+        const allArgs = PerforceUri.decodeUriQuery(uri.query ?? "");
+        const args = ((allArgs["p4Args"] as string) ?? "-q").split(" ");
+        const command = (allArgs["command"] as string) ?? "print";
+
+        const resource = this.getResourceForUri(uri);
+
+        if (!resource) {
+            Display.channel.appendLine(
+                `Can't find proper workspace to provide content for ${uri}`
+            );
+            throw new Error(`Can't find proper workspace for command ${command} `);
+        }
+
+        // TODO - don't export this stuff from the API,
+        // change the uri scheme so that it's not just running arbitrary commands
+        const fileArgs = uri.fsPath ? pathsToArgs([uri]).filter(isTruthy) : [];
+        const allP4Args = args.concat(fileArgs);
+
+        return runPerforceCommand(resource, command, allP4Args, { hideStdErr: true });
+    }
+}
 
 export class PerforceContentProvider {
     private onDidChangeEmitter = new EventEmitter<Uri>();
@@ -64,10 +177,10 @@ export class PerforceContentProvider {
     }
 }
 
-let _perforceContentProvider: PerforceContentProvider;
+let _perforceContentProvider: PerforceFileSystemProvider;
 export function perforceContentProvider() {
     if (!_perforceContentProvider) {
-        _perforceContentProvider = new PerforceContentProvider();
+        _perforceContentProvider = new PerforceFileSystemProvider();
     }
     return _perforceContentProvider;
 }

--- a/src/FileSystemProvider.ts
+++ b/src/FileSystemProvider.ts
@@ -9,6 +9,7 @@ import {
     FileType,
     FileSystemError,
     FileChangeType,
+    FileStat,
 } from "vscode";
 import { Display } from "./Display";
 import * as PerforceUri from "./PerforceUri";
@@ -42,8 +43,9 @@ export class PerforceFileSystemProvider implements FileSystemProvider, Disposabl
             },
         };
     }
-    stat(_uri: Uri): import("vscode").FileStat | Thenable<import("vscode").FileStat> {
+    stat(_uri: Uri): FileStat {
         const now = new Date().getTime();
+        // TODO not ideal - empty size may cause hidden problems but don't want to get the file content twice..
         return { type: FileType.File, ctime: now, mtime: now, size: 0 };
     }
     readDirectory(_uri: Uri): [string, FileType][] {
@@ -116,17 +118,17 @@ export class PerforceFileSystemProvider implements FileSystemProvider, Disposabl
     }
 }
 
-let _perforceContentProvider: PerforceFileSystemProvider | undefined;
-export function perforceContentProvider() {
-    if (!_perforceContentProvider) {
-        _perforceContentProvider = new PerforceFileSystemProvider();
+let _perforceFileSystemProvider: PerforceFileSystemProvider | undefined;
+export function perforceFsProvider() {
+    if (!_perforceFileSystemProvider) {
+        _perforceFileSystemProvider = new PerforceFileSystemProvider();
     }
-    return _perforceContentProvider;
+    return _perforceFileSystemProvider;
 }
 
-export function initPerforceContentProvider() {
-    if (!_perforceContentProvider) {
-        _perforceContentProvider = new PerforceFileSystemProvider();
+export function initPerforceFsProvider() {
+    if (!_perforceFileSystemProvider) {
+        _perforceFileSystemProvider = new PerforceFileSystemProvider();
     }
-    return _perforceContentProvider;
+    return _perforceFileSystemProvider;
 }

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -276,7 +276,7 @@ export namespace PerforceCommands {
     }
 
     function didChangeHaveRev(uri: Uri) {
-        perforceContentProvider().requestUpdatedDocument(
+        perforceContentProvider()?.requestUpdatedDocument(
             PerforceUri.fromUriWithRevision(uri, "have")
         );
     }

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -663,11 +663,8 @@ export namespace PerforceCommands {
         await DiffProvider.diffNext(fromDoc);
     }
 
-    async function diffFiles(leftFile: string, rightFile: string) {
-        await DiffProvider.diffFiles(
-            PerforceUri.parse(leftFile),
-            PerforceUri.parse(rightFile)
-        );
+    async function diffFiles(leftFile: Uri, rightFile: Uri) {
+        await DiffProvider.diffFiles(leftFile, rightFile);
     }
 
     function getOpenDocUri(): Uri | undefined {
@@ -694,8 +691,8 @@ export namespace PerforceCommands {
         await QuickPicks.showQuickPickForFile(fromDoc);
     }
 
-    export async function annotate(file?: string) {
-        const uri = file ? PerforceUri.parse(file) : getOpenDocUri();
+    export async function annotate(file?: Uri) {
+        const uri = file ?? getOpenDocUri();
 
         if (!uri) {
             return false;

--- a/src/PerforceCommands.ts
+++ b/src/PerforceCommands.ts
@@ -27,7 +27,7 @@ import {
     chooseRecentQuickPick,
 } from "./quickPick/QuickPickProvider";
 import { splitBy, pluralise, isTruthy } from "./TsUtils";
-import { perforceContentProvider } from "./ContentProvider";
+import { perforceFsProvider } from "./FileSystemProvider";
 import { showRevChooserForFile } from "./quickPick/FileQuickPick";
 import { changeSpecEditor, jobSpecEditor } from "./SpecEditor";
 
@@ -276,7 +276,7 @@ export namespace PerforceCommands {
     }
 
     function didChangeHaveRev(uri: Uri) {
-        perforceContentProvider()?.requestUpdatedDocument(
+        perforceFsProvider()?.requestUpdatedDocument(
             PerforceUri.fromUriWithRevision(uri, "have")
         );
     }

--- a/src/PerforceUri.ts
+++ b/src/PerforceUri.ts
@@ -38,20 +38,10 @@ export function revOrLabelAsSuffix(revOrAtLabel: string | undefined) {
         : "";
 }
 
-export function withoutRev(path: string, _revOrAtLabel: string | undefined) {
-    // removed as it prevents syntax highlighting on the opened file - TODO: consider an option
-    /*const revStr = revOrLabelAsUriSuffix(revOrAtLabel);
-    if (revStr && path.endsWith(revStr)) {
-        return path.slice(0, -revStr.length);
-    }
-    return path;*/
-    return path;
-}
-
 function uriWithoutRev(uri: vscode.Uri) {
-    const path = withoutRev(uri.path, getRevOrAtLabel(uri));
-    const authority = decodeUriQuery(uri.query).authority ?? uri.authority;
-    return uri.with({ path: path, authority: authority });
+    const queryAuth = decodeUriQuery(uri.query).authority;
+    const authority = queryAuth === "null" ? "" : queryAuth ?? uri.authority;
+    return uri.with({ authority: authority });
 }
 
 export function fsPathWithoutRev(uri: vscode.Uri) {
@@ -70,16 +60,12 @@ export function basenameWithRev(uri: vscode.Uri, overrideRev?: string) {
 }
 
 function uriWithRev(uri: vscode.Uri, revOrAtLabel: string | undefined) {
-    /*return uri.with({
-        path: uri.path + revOrLabelAsUriSuffix(revOrAtLabel),
-        fragment: revOrAtLabel,
-    });*/
     const args = decodeUriQuery(uri.query);
-    const authority = args.authority ?? uri.authority;
+    const origAuthority = args.authority ?? uri.authority ?? "";
     return uri.with({
         authority: revOrLabelAsSuffix(revOrAtLabel),
         fragment: revOrAtLabel,
-        query: encodeQuery({ ...args, authority }),
+        query: encodeQuery({ ...args, authority: origAuthority || "null" }),
     });
 }
 
@@ -97,43 +83,12 @@ function encodeParam(param: string, value?: string | boolean) {
 }
 
 export function parse(uri: string) {
-    // because we're adding fragment identifiers to strings, we need to customise parsing
-    // the URI might look like this for revision 1
-    // perforce:/my/path#1?a=b#1
-    // standard uri parsing produces { path: /my/path, fragment: #1?a=b#1 }
-    // we want: path: /my/path#1 query: a=b, fragment: #1
+    // this function is here if needed - provides a common location for this
+    // so that we can customise parsing if needed later
     const parsed = vscode.Uri.parse(uri);
-    /*const queryIndex = parsed.fragment.indexOf("?");
-    const fragmentIndex = parsed.fragment.indexOf("#");
-    if (queryIndex >= 0 || fragmentIndex >= 0) {
-        return parsed.with({
-            path:
-                parsed.path +
-                "#" +
-                parsed.fragment.slice(0, queryIndex >= 0 ? queryIndex : fragmentIndex),
-            fragment: fragmentIndex > 0 ? parsed.fragment.slice(fragmentIndex + 1) : "",
-            query:
-                queryIndex >= 0
-                    ? parsed.fragment.slice(
-                          queryIndex + 1,
-                          fragmentIndex > 0 ? fragmentIndex : undefined
-                      )
-                    : undefined,
-        });
-    }*/
+
     return parsed;
 }
-
-/*
-export function fromFsOrDepotPath(
-    workspace: vscode.Uri,
-    fsOrDepotPath: string,
-    revision: string | undefined,
-    isDepotPath: boolean
-) {
-    return isDepotPath ? fromDepotPath(workspace, fsOrDepotPath, revision) : fromUr;
-}
-*/
 
 export function fromDepotPath(
     workspace: vscode.Uri,

--- a/src/PerforceUri.ts
+++ b/src/PerforceUri.ts
@@ -10,6 +10,7 @@ export type UriArguments = {
     haveRev?: string;
     diffStartFile?: string;
     depotName?: string;
+    authority?: string;
     rev?: string;
 };
 
@@ -49,7 +50,8 @@ export function withoutRev(path: string, _revOrAtLabel: string | undefined) {
 
 function uriWithoutRev(uri: vscode.Uri) {
     const path = withoutRev(uri.path, getRevOrAtLabel(uri));
-    return uri.with({ path: path });
+    const authority = decodeUriQuery(uri.query).authority ?? uri.authority;
+    return uri.with({ path: path, authority: authority });
 }
 
 export function fsPathWithoutRev(uri: vscode.Uri) {
@@ -72,8 +74,12 @@ function uriWithRev(uri: vscode.Uri, revOrAtLabel: string | undefined) {
         path: uri.path + revOrLabelAsUriSuffix(revOrAtLabel),
         fragment: revOrAtLabel,
     });*/
+    const args = decodeUriQuery(uri.query);
+    const authority = args.authority ?? uri.authority;
     return uri.with({
+        authority: revOrLabelAsSuffix(revOrAtLabel),
         fragment: revOrAtLabel,
+        query: encodeQuery({ ...args, authority }),
     });
 }
 
@@ -97,7 +103,7 @@ export function parse(uri: string) {
     // standard uri parsing produces { path: /my/path, fragment: #1?a=b#1 }
     // we want: path: /my/path#1 query: a=b, fragment: #1
     const parsed = vscode.Uri.parse(uri);
-    const queryIndex = parsed.fragment.indexOf("?");
+    /*const queryIndex = parsed.fragment.indexOf("?");
     const fragmentIndex = parsed.fragment.indexOf("#");
     if (queryIndex >= 0 || fragmentIndex >= 0) {
         return parsed.with({
@@ -114,7 +120,7 @@ export function parse(uri: string) {
                       )
                     : undefined,
         });
-    }
+    }*/
     return parsed;
 }
 

--- a/src/annotations/AnnotationProvider.ts
+++ b/src/annotations/AnnotationProvider.ts
@@ -100,7 +100,10 @@ export class AnnotationProvider {
     private async loadEditor() {
         AnnotationProvider._onWillLoadEditor.fire(this._p4Uri);
         const ranges = await this.getOpenFileRangesIfSameFile();
-        this._editor = await vscode.window.showTextDocument(this._p4Uri);
+        this._editor = await vscode.window.showTextDocument(this._p4Uri, {
+            label: "hello",
+            description: "hello",
+        } as vscode.TextDocumentShowOptions);
 
         if (ranges) {
             this._editor.revealRange(ranges[0]);

--- a/src/annotations/AnnotationProvider.ts
+++ b/src/annotations/AnnotationProvider.ts
@@ -100,10 +100,7 @@ export class AnnotationProvider {
     private async loadEditor() {
         AnnotationProvider._onWillLoadEditor.fire(this._p4Uri);
         const ranges = await this.getOpenFileRangesIfSameFile();
-        this._editor = await vscode.window.showTextDocument(this._p4Uri, {
-            label: "hello",
-            description: "hello",
-        } as vscode.TextDocumentShowOptions);
+        this._editor = await vscode.window.showTextDocument(this._p4Uri);
 
         if (ranges) {
             this._editor.revealRange(ranges[0]);

--- a/src/annotations/MarkdownGenerator.ts
+++ b/src/annotations/MarkdownGenerator.ts
@@ -73,7 +73,7 @@ function makeQuickPickChangeURI(underlying: vscode.Uri, change: p4.FileLogItem) 
 }
 
 export function makeAnnotateURI(underlying: vscode.Uri, change: p4.FileLogItem) {
-    const args = makePerforceURI(underlying, change).toString();
+    const args = makePerforceURI(underlying, change);
     return (
         makeCommandURI("perforce.annotate", args) +
         ' "Show annotations for ' +

--- a/src/annotations/MarkdownGenerator.ts
+++ b/src/annotations/MarkdownGenerator.ts
@@ -53,19 +53,14 @@ function makeQuickPickFileURI(underlying: vscode.Uri, change: p4.FileLogItem) {
         makeCommandURI(
             "perforce.showQuickPick",
             "file",
-            makePerforceURI(underlying, change).toString()
+            makePerforceURI(underlying, change)
         ) + ' "Show more actions for this file"'
     );
 }
 
 function makeQuickPickChangeURI(underlying: vscode.Uri, change: p4.FileLogItem) {
     return (
-        makeCommandURI(
-            "perforce.showQuickPick",
-            "change",
-            underlying.toString(),
-            change.chnum
-        ) +
+        makeCommandURI("perforce.showQuickPick", "change", underlying, change.chnum) +
         ' "Show actions for changelist ' +
         change.chnum +
         '"'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import { PerforceCommands } from "./PerforceCommands";
-import { PerforceContentProvider, perforceContentProvider } from "./ContentProvider";
+import { perforceContentProvider, PerforceFileSystemProvider } from "./ContentProvider";
 import FileSystemActions from "./FileSystemActions";
 import { PerforceSCMProvider } from "./ScmProvider";
 import { PerforceService } from "./PerforceService";
@@ -21,7 +21,7 @@ import { createSpecEditor } from "./SpecEditor";
 
 let _isRegistered = false;
 const _disposable: vscode.Disposable[] = [];
-let _perforceContentProvider: PerforceContentProvider | undefined;
+let _perforceContentProvider: PerforceFileSystemProvider | undefined;
 const _dirsWithNoClient = new Set<string>();
 
 function logInitProgress(uri: vscode.Uri, message: string) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,7 @@
 "use strict";
 
 import { PerforceCommands } from "./PerforceCommands";
-import {
-    PerforceFileSystemProvider,
-    initPerforceContentProvider,
-} from "./ContentProvider";
+import { PerforceFileSystemProvider, initPerforceFsProvider } from "./FileSystemProvider";
 import FileSystemActions from "./FileSystemActions";
 import { PerforceSCMProvider } from "./ScmProvider";
 import { PerforceService } from "./PerforceService";
@@ -512,7 +509,7 @@ function doOneTimeRegistration() {
         Display.initialize(_disposable);
         ContextVars.initialize(_disposable);
 
-        _perforceContentProvider = initPerforceContentProvider();
+        _perforceContentProvider = initPerforceFsProvider();
         _disposable.push(_perforceContentProvider);
 
         _disposable.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,10 @@
 "use strict";
 
 import { PerforceCommands } from "./PerforceCommands";
-import { perforceContentProvider, PerforceFileSystemProvider } from "./ContentProvider";
+import {
+    PerforceFileSystemProvider,
+    initPerforceContentProvider,
+} from "./ContentProvider";
 import FileSystemActions from "./FileSystemActions";
 import { PerforceSCMProvider } from "./ScmProvider";
 import { PerforceService } from "./PerforceService";
@@ -490,7 +493,14 @@ export async function activate(ctx: vscode.ExtensionContext) {
 }
 
 function doOneTimeRegistration() {
-    if (!_isRegistered) {
+    // don't activate all the 'standard' stuff when running from the test framework
+    // any required modules are stubbed or constructed within the tests, we can't
+    // stub the modules loaded here due to webpack
+    const inTestMode = vscode.workspace
+        .getConfiguration("perforce")
+        .get("testModeNoActivate");
+
+    if (!_isRegistered && !inTestMode) {
         _isRegistered = true;
 
         QuickPicks.registerQuickPicks();
@@ -502,7 +512,7 @@ function doOneTimeRegistration() {
         Display.initialize(_disposable);
         ContextVars.initialize(_disposable);
 
-        _perforceContentProvider = perforceContentProvider();
+        _perforceContentProvider = initPerforceContentProvider();
         _disposable.push(_perforceContentProvider);
 
         _disposable.push(

--- a/src/test/helpers/testUtils.ts
+++ b/src/test/helpers/testUtils.ts
@@ -68,9 +68,7 @@ export function perforceLocalUriMatcher(file: StubFile) {
     if (!file.localFile) {
         throw new Error("Can't make a local file matcher without a local file");
     }
-    return PerforceUri.fromUri(file.localFile).with({
-        fragment: file.depotRevision.toString(),
-    });
+    return PerforceUri.fromUriWithRevision(file.localFile, file.depotRevision.toString());
 }
 
 /**
@@ -97,20 +95,6 @@ export function perforceFromFileUriMatcher(file: StubFile) {
         file.localFile,
         file.resolveFromDepotPath,
         file.resolveEndFromRev?.toString()
-    );
-}
-
-/**
- * Matches against a perforce URI, using the depot path for the file AND containing a fragment for the shelved changelist number
- * @param file
- * @param chnum
- */
-export function perforceShelvedUriMatcher(file: StubFile, chnum: string) {
-    return PerforceUri.fromUri(
-        vscode.Uri.parse("perforce:" + file.depotPath).with({
-            fragment: "@=" + chnum,
-        }),
-        { depot: true, workspace: getWorkspaceUri().fsPath }
     );
 }
 

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -6,8 +6,8 @@ export function run(): Promise<void> {
     // Create the mocha test
     const mocha = new Mocha({
         ui: "bdd",
+        color: true,
     });
-    mocha.useColors(true);
     mocha.reporter("cypress-multi-reporters", {
         reporterEnabled: "mocha-junit-reporter, spec",
         mochaJunitReporterReporterOptions: {

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -7,7 +7,7 @@ import * as vscode from "vscode";
 
 import sinon from "sinon";
 import { PerforceSCMProvider } from "../../ScmProvider";
-import { initPerforceContentProvider } from "../../ContentProvider";
+import { initPerforceFsProvider } from "../../FileSystemProvider";
 import { Display, ActiveStatusEvent, ActiveEditorStatus } from "../../Display";
 import * as PerforceUri from "../../PerforceUri";
 import { Resource } from "../../scm/Resource";
@@ -213,7 +213,7 @@ describe("Model & ScmProvider modules (integration)", () => {
 
     before(async () => {
         await vscode.commands.executeCommand("workbench.action.closeAllEditors");
-        initPerforceContentProvider();
+        initPerforceFsProvider();
     });
     describe("Refresh / Initialize", function () {
         let stubModel: StubPerforceModel;

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -7,7 +7,7 @@ import * as vscode from "vscode";
 
 import sinon from "sinon";
 import { PerforceSCMProvider } from "../../ScmProvider";
-import { PerforceContentProvider } from "../../ContentProvider";
+import { initPerforceContentProvider } from "../../ContentProvider";
 import { Display, ActiveStatusEvent, ActiveEditorStatus } from "../../Display";
 import * as PerforceUri from "../../PerforceUri";
 import { Resource } from "../../scm/Resource";
@@ -20,7 +20,6 @@ import {
     getLocalFile,
     perforceLocalUriMatcher,
     perforceDepotUriMatcher,
-    perforceShelvedUriMatcher,
     perforceFromFileUriMatcher,
     perforceLocalShelvedUriMatcher,
 } from "../helpers/testUtils";
@@ -211,15 +210,10 @@ describe("Model & ScmProvider modules (integration)", () => {
 
     let items: TestItems;
     let subscriptions: vscode.Disposable[] = [];
-    const outerSubs: vscode.Disposable[] = [];
 
     before(async () => {
         await vscode.commands.executeCommand("workbench.action.closeAllEditors");
-        const doc = new PerforceContentProvider();
-        outerSubs.push(doc);
-    });
-    after(() => {
-        outerSubs.forEach((d) => d.dispose());
+        initPerforceContentProvider();
     });
     describe("Refresh / Initialize", function () {
         let stubModel: StubPerforceModel;
@@ -1126,7 +1120,8 @@ describe("Model & ScmProvider modules (integration)", () => {
                         path: basicFiles.add().localFile.path,
                         scheme: "perforce",
                         fragment: "have",
-                        query: "command=print&p4Args=-q&rev=have",
+                        authority: "#have",
+                        query: "command=print&p4Args=-q&rev=have&authority=null",
                     })
                 );
             });
@@ -1145,8 +1140,9 @@ describe("Model & ScmProvider modules (integration)", () => {
                         path: "/testArea/testFolderOld/movedFrom.txt",
                         scheme: "perforce",
                         fragment: "4",
+                        authority: "#4",
                         query:
-                            "command=print&p4Args=-q&depot&workspace=" +
+                            "command=print&p4Args=-q&authority=depot&depot&workspace=" +
                             encodeURIComponent(basicFiles.moveAdd().localFile.fsPath) +
                             "&depotName=depot&rev=4",
                     })
@@ -1941,11 +1937,17 @@ describe("Model & ScmProvider modules (integration)", () => {
 
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
                         perforceDepotUriMatcher(file),
-                        perforceShelvedUriMatcher(file, "1"),
+                        PerforceUri.fromDepotPath(file.localFile, file.depotPath, "@=1"),
                         "a.txt#1 ⟷ a.txt@=1"
                     );
                     expect(items.execute).to.be.calledWithMatch(
-                        { fsPath: perforceShelvedUriMatcher(file, "1").fsPath },
+                        {
+                            fsPath: PerforceUri.fromDepotPath(
+                                file.localFile,
+                                file.depotPath,
+                                "@=1"
+                            ).fsPath,
+                        },
                         "print",
                         sinon.match.any,
                         ["-q", file.depotPath + "@=1"]
@@ -1967,12 +1969,18 @@ describe("Model & ScmProvider modules (integration)", () => {
                     await PerforceSCMProvider.OpenvShelved(resource);
 
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
-                        perforceShelvedUriMatcher(file, "1"),
+                        PerforceUri.fromDepotPath(file.localFile, file.depotPath, "@=1"),
                         file.localFile,
                         "a.txt@=1 ⟷ a.txt (workspace)"
                     );
                     expect(items.execute).to.be.calledWithMatch(
-                        { fsPath: perforceShelvedUriMatcher(file, "1").fsPath },
+                        {
+                            fsPath: PerforceUri.fromDepotPath(
+                                file.localFile,
+                                file.depotPath,
+                                "@=1"
+                            ).fsPath,
+                        },
                         "print",
                         sinon.match.any,
                         ["-q", file.depotPath + "@=1"]

--- a/src/test/suite/perforceApi.test.ts
+++ b/src/test/suite/perforceApi.test.ts
@@ -1298,7 +1298,7 @@ describe("Perforce API", () => {
         });
     });
     describe("integrated", () => {
-        it("Uses the correct arguements", async () => {
+        it("Uses the correct arguments", async () => {
             execute.callsFake(
                 execWithStdOut(
                     "//depot/branches/branch1/newFile.txt#1 - edit into //depot/branches/branch2/newFile.txt#2"

--- a/src/test/suite/perforceCommands.test.ts
+++ b/src/test/suite/perforceCommands.test.ts
@@ -10,7 +10,7 @@ import { stubExecute, StubPerforceModel } from "../helpers/StubPerforceModel";
 import p4Commands from "../helpers/p4Commands";
 import { PerforceCommands } from "../../PerforceCommands";
 import * as PerforceUri from "../../PerforceUri";
-import { PerforceContentProvider } from "../../ContentProvider";
+import { initPerforceContentProvider } from "../../ContentProvider";
 import { Display } from "../../Display";
 import { getLocalFile } from "../helpers/testUtils";
 import { PerforceSCMProvider } from "../../ScmProvider";
@@ -33,13 +33,9 @@ describe("Perforce Command Module (integration)", () => {
 
     let refresh: sinon.SinonSpy;
 
-    const doc = new PerforceContentProvider();
-
     before(async () => {
         await vscode.commands.executeCommand("workbench.action.closeAllEditors");
-    });
-    after(() => {
-        doc.dispose();
+        initPerforceContentProvider();
     });
 
     beforeEach(() => {
@@ -83,10 +79,7 @@ describe("Perforce Command Module (integration)", () => {
             await vscode.window.showTextDocument(localFile);
             await PerforceCommands.diff(5);
             expect(execCommand.lastCall).to.be.vscodeDiffCall(
-                PerforceUri.fromUri(localFile).with({
-                    path: localFile.path,
-                    fragment: "5",
-                }),
+                PerforceUri.fromUriWithRevision(localFile, "5"),
                 localFile,
                 "new.txt#5 ⟷ new.txt (workspace)"
             );

--- a/src/test/suite/perforceCommands.test.ts
+++ b/src/test/suite/perforceCommands.test.ts
@@ -10,7 +10,7 @@ import { stubExecute, StubPerforceModel } from "../helpers/StubPerforceModel";
 import p4Commands from "../helpers/p4Commands";
 import { PerforceCommands } from "../../PerforceCommands";
 import * as PerforceUri from "../../PerforceUri";
-import { initPerforceContentProvider } from "../../ContentProvider";
+import { initPerforceFsProvider } from "../../FileSystemProvider";
 import { Display } from "../../Display";
 import { getLocalFile } from "../helpers/testUtils";
 import { PerforceSCMProvider } from "../../ScmProvider";
@@ -35,7 +35,7 @@ describe("Perforce Command Module (integration)", () => {
 
     before(async () => {
         await vscode.commands.executeCommand("workbench.action.closeAllEditors");
-        initPerforceContentProvider();
+        initPerforceFsProvider();
     });
 
     beforeEach(() => {

--- a/src/test/suite/unit/index.ts
+++ b/src/test/suite/unit/index.ts
@@ -6,6 +6,7 @@ export function run(): Promise<void> {
     // Create the mocha test
     const mocha = new Mocha({
         ui: "bdd",
+        color: true,
     });
     mocha.reporter("cypress-multi-reporters", {
         reporterEnabled: "mocha-junit-reporter, spec",
@@ -13,7 +14,6 @@ export function run(): Promise<void> {
             mochaFile: "./reports/junit-unit.xml",
         },
     });
-    mocha.useColors(true);
 
     const testsRoot = __dirname;
 

--- a/test-fixtures/core/.vscode/settings.json
+++ b/test-fixtures/core/.vscode/settings.json
@@ -7,6 +7,7 @@
     "perforce.activationMode": "autodetect",
     "perforce.promptBeforeSubmit": false,
     "perforce.fileShelveMode": "prompt",
+    "perforce.testModeNoActivate": true,
     "files.exclude": {
         "**/.git": true,
         "**/.svn": true,


### PR DESCRIPTION
Allows perforce revisions to be displayed in the header without affecting the file path, so syntax highlighting works

This uses the `resourceLabelFormatters` option - which only supports `FileSystemProvider` (not TextDocumentContentProvider) and has a limited number of variables that can be used

As such we do have to rewrite the `authority` of the URI so that we can display it after the file name - but as the previous implementation changed all the usages of possible perforce URIs to use common functions, this is reasonably trivial.

~TODO - rename content provider file~
Perforce URI might need a little tidying up when I read over the code again...