### PR TITLE
Add slash to the beginning of the "EMPTY" path

### DIFF
--- a/src/FileSystemProvider.ts
+++ b/src/FileSystemProvider.ts
@@ -92,7 +92,7 @@ export class PerforceFileSystemProvider implements FileSystemProvider, Disposabl
     }
 
     public async provideTextDocumentContent(uri: Uri): Promise<string> {
-        if (uri.path === "EMPTY") {
+        if (uri.path === "/EMPTY") {
             return "";
         }
 

--- a/src/PerforceUri.ts
+++ b/src/PerforceUri.ts
@@ -38,7 +38,7 @@ export function revOrLabelAsSuffix(revOrAtLabel: string | undefined) {
         : "";
 }
 export function emptyFileUri() {
-    return vscode.Uri.parse("perforce:EMPTY");
+    return vscode.Uri.parse("perforce:/EMPTY");
 }
 
 function uriWithoutRev(uri: vscode.Uri) {

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -1848,7 +1848,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     await PerforceSCMProvider.Open(resource);
 
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
-                        vscode.Uri.parse("perforce:EMPTY"),
+                        vscode.Uri.parse("perforce:/EMPTY"),
                         file.localFile,
                         "new.txt#0 ⟷ new.txt (workspace)"
                     );
@@ -1899,7 +1899,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     await PerforceSCMProvider.Open(resource);
 
                     expect(execCommand.lastCall).to.be.vscodeDiffCall(
-                        vscode.Uri.parse("perforce:EMPTY"),
+                        vscode.Uri.parse("perforce:/EMPTY"),
                         file.localFile,
                         "branched.txt#0 ⟷ branched.txt (workspace)"
                     );


### PR DESCRIPTION
Fixes error opening diff for files open for add

(the `FileSystemProvider` doesn't accept relative paths, and just throws an error instead)

fixes #156 