### PR TITLE
Persist search filters in a memento

### DIFF
--- a/package.json
+++ b/package.json
@@ -823,6 +823,11 @@
                 "command": "perforce.newJobSpec",
                 "title": "Create job in editor...",
                 "category": "Perforce"
+            },
+            {
+                "command": "perforce.clearMementos",
+                "title": "Clear persisted memento data",
+                "category": "Perforce"
             }
         ],
         "menus": {

--- a/src/MementoItem.ts
+++ b/src/MementoItem.ts
@@ -1,5 +1,19 @@
 import * as vscode from "vscode";
 
+// keys for workspace mementos - any global ones should use a different enum
+export enum MementoKeys {
+    SEARCH_STATUS = "changeSearch.statusFilter",
+    SEARCH_USER = "changeSearch.userFilter",
+    SEARCH_CLIENT = "changeSearch.clientFilter",
+    SEARCH_FILES = "changeSearch.fileFilters",
+    SEARCH_AUTO_REFRESH = "changeSearch.autoRefresh",
+}
+
+export enum GlobalMementoKeys {
+    SPEC_CHANGELIST_MAP = "changeMap",
+    SPEC_JOB_MAP = "jobMap",
+}
+
 export class MementoItem<T> {
     constructor(private _key: string, private _memento: vscode.Memento) {}
 
@@ -10,4 +24,18 @@ export class MementoItem<T> {
     public get value() {
         return this._memento.get<T>(this._key);
     }
+}
+
+export async function clearAllMementos(
+    memento: vscode.Memento,
+    globalMemento: vscode.Memento
+) {
+    await Promise.all(
+        Object.values(MementoKeys).map((key) => memento.update(key, undefined))
+    );
+    await Promise.all(
+        Object.values(GlobalMementoKeys).map((key) =>
+            globalMemento.update(key, undefined)
+        )
+    );
 }

--- a/src/MementoItem.ts
+++ b/src/MementoItem.ts
@@ -1,0 +1,13 @@
+import * as vscode from "vscode";
+
+export class MementoItem<T> {
+    constructor(private _key: string, private _memento: vscode.Memento) {}
+
+    public async save(value?: T) {
+        await this._memento.update(this._key, value);
+    }
+
+    public get value() {
+        return this._memento.get<T>(this._key);
+    }
+}

--- a/src/MementoItem.ts
+++ b/src/MementoItem.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-// keys for workspace mementos - any global ones should use a different enum
+// keys for workspace level mementos
 export enum MementoKeys {
     SEARCH_STATUS = "changeSearch.statusFilter",
     SEARCH_USER = "changeSearch.userFilter",
@@ -9,6 +9,7 @@ export enum MementoKeys {
     SEARCH_AUTO_REFRESH = "changeSearch.autoRefresh",
 }
 
+// keys for global mementos
 export enum GlobalMementoKeys {
     SPEC_CHANGELIST_MAP = "changeMap",
     SPEC_JOB_MAP = "jobMap",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import * as p4 from "./api/PerforceApi";
 import { isTruthy } from "./TsUtils";
 import { registerChangelistSearch } from "./search/ChangelistTreeView";
 import { createSpecEditor } from "./SpecEditor";
+import { clearAllMementos } from "./MementoItem";
 
 let _isRegistered = false;
 const _disposable: vscode.Disposable[] = [];
@@ -457,6 +458,9 @@ export async function activate(ctx: vscode.ExtensionContext) {
     );
 
     checkForSlevesque(ctx);
+    _disposable.push(
+        vscode.commands.registerCommand("perforce.clearMementos", () => clearMementos())
+    );
 
     const activationMode = vscode.workspace
         .getConfiguration("perforce")
@@ -752,5 +756,17 @@ function onDidCloseTextDocument(event: vscode.TextDocument) {
         );
         const removed = PerforceSCMProvider.disposeInstancesWithoutContributors();
         logFileMessage(event.uri, "Removed " + removed.length + " SCM providers");
+    }
+}
+
+async function clearMementos() {
+    const ok = "Clear workspace state";
+    const choice = await vscode.window.showWarningMessage(
+        "This will clear persisted cache data. This only applies to a small number of items such as search filters and change specifications.\nThis option is only here in case of unexpected bugs.\nYou will probably need to restart VS Code to see any effect. Continue?",
+        { modal: true },
+        ok
+    );
+    if (choice === ok) {
+        await clearAllMementos(_context.workspaceState, _context.globalState);
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -444,7 +444,10 @@ async function checkForSlevesque(ctx: vscode.ExtensionContext) {
     }
 }
 
+let _context: vscode.ExtensionContext;
+
 export async function activate(ctx: vscode.ExtensionContext) {
+    _context = ctx;
     // ALWAYS register the edit and save command
     PerforceCommands.registerImportantCommands(_disposable);
     createSpecEditor(ctx);
@@ -524,7 +527,7 @@ function doOneTimeRegistration() {
         // todo: fix dependency / order of operations issues
         PerforceCommands.registerCommands();
         PerforceSCMProvider.registerCommands();
-        registerChangelistSearch();
+        registerChangelistSearch(_context);
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -449,6 +449,11 @@ let _context: vscode.ExtensionContext;
 
 export async function activate(ctx: vscode.ExtensionContext) {
     _context = ctx;
+    // register FIRST in case any memento state causes exceptions later, preventing it
+    // from being registered
+    _disposable.push(
+        vscode.commands.registerCommand("perforce.clearMementos", () => clearMementos())
+    );
     // ALWAYS register the edit and save command
     PerforceCommands.registerImportantCommands(_disposable);
     createSpecEditor(ctx);
@@ -458,10 +463,6 @@ export async function activate(ctx: vscode.ExtensionContext) {
     );
 
     checkForSlevesque(ctx);
-    _disposable.push(
-        vscode.commands.registerCommand("perforce.clearMementos", () => clearMementos())
-    );
-
     const activationMode = vscode.workspace
         .getConfiguration("perforce")
         .get("activationMode");

--- a/src/search/ChangelistTreeView.ts
+++ b/src/search/ChangelistTreeView.ts
@@ -31,7 +31,7 @@ import { DescribedChangelist } from "../api/PerforceApi";
 import * as PerforceUri from "../PerforceUri";
 import { operationCreatesFile, GetStatus, operationDeletesFile } from "../scm/Status";
 import * as DiffProvider from "../DiffProvider";
-import { MementoItem } from "../MementoItem";
+import { MementoItem, MementoKeys } from "../MementoItem";
 
 class ChooseProviderTreeItem extends SelfExpandingTreeItem<any> {
     constructor(private _providerSelection: ProviderSelection) {
@@ -595,7 +595,7 @@ class ChangelistTreeRoot extends SelfExpandingTreeRoot<any> {
         this._allResults = new AllResultsTree();
         this._runSearch = new RunSearch(
             this,
-            new MementoItem("changeSearch.autoRefresh", memento)
+            new MementoItem(MementoKeys.SEARCH_AUTO_REFRESH, memento)
         );
         this._subscriptions.push(
             this._filterRoot.onDidChangeFilters(() => {

--- a/src/search/ChangelistTreeView.ts
+++ b/src/search/ChangelistTreeView.ts
@@ -31,6 +31,7 @@ import { DescribedChangelist } from "../api/PerforceApi";
 import * as PerforceUri from "../PerforceUri";
 import { operationCreatesFile, GetStatus, operationDeletesFile } from "../scm/Status";
 import * as DiffProvider from "../DiffProvider";
+import { MementoItem } from "../MementoItem";
 
 class ChooseProviderTreeItem extends SelfExpandingTreeItem<any> {
     constructor(private _providerSelection: ProviderSelection) {
@@ -145,9 +146,12 @@ class GoToChangelist extends SelfExpandingTreeItem<any> {
 class RunSearch extends SelfExpandingTreeItem<any> {
     private _autoRefresh: boolean;
 
-    constructor(private _root: ChangelistTreeRoot) {
-        super(RunSearch.makeLabel(false));
-        this._autoRefresh = false;
+    constructor(
+        private _root: ChangelistTreeRoot,
+        private _memento: MementoItem<boolean>
+    ) {
+        super(RunSearch.makeLabel(!!_memento.value));
+        this._autoRefresh = !!_memento.value;
     }
 
     private static makeLabel(autoRefresh: boolean) {
@@ -162,6 +166,7 @@ class RunSearch extends SelfExpandingTreeItem<any> {
         this._autoRefresh = autoRefresh;
         this.label = RunSearch.makeLabel(this._autoRefresh);
         this.didChange();
+        this._memento.save(autoRefresh);
     }
 
     get command(): vscode.Command {
@@ -581,14 +586,17 @@ class ChangelistTreeRoot extends SelfExpandingTreeRoot<any> {
     private _providerSelection: ProviderSelection;
     private _runSearch: RunSearch;
 
-    constructor() {
+    constructor(memento: vscode.Memento) {
         super();
         this._providerSelection = new ProviderSelection();
         this._subscriptions.push(this._providerSelection);
         this._chooseProvider = new ChooseProviderTreeItem(this._providerSelection);
-        this._filterRoot = new FilterRootItem(this._providerSelection);
+        this._filterRoot = new FilterRootItem(this._providerSelection, memento);
         this._allResults = new AllResultsTree();
-        this._runSearch = new RunSearch(this);
+        this._runSearch = new RunSearch(
+            this,
+            new MementoItem("changeSearch.autoRefresh", memento)
+        );
         this._subscriptions.push(
             this._filterRoot.onDidChangeFilters(() => {
                 if (this._runSearch.autoRefresh) {
@@ -636,7 +644,7 @@ export function focusChangelist(resource: vscode.Uri, described: DescribedChange
     changelistTree.focusChangelist(resource, described);
 }
 
-export function registerChangelistSearch() {
+export function registerChangelistSearch(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
         "perforce.changeSearch.chooseProvider",
         (arg: ChooseProviderTreeItem) => arg.chooseProvider()
@@ -726,7 +734,7 @@ export function registerChangelistSearch() {
         (arg: Diffable) => vscode.window.showTextDocument(arg.perforceUri)
     );
 
-    changelistTree = new ChangelistTreeRoot();
+    changelistTree = new ChangelistTreeRoot(context.workspaceState);
     const treeDataProvider = new SelfExpandingTreeProvider(changelistTree);
     const treeView = vscode.window.createTreeView("perforce.searchChangelists", {
         treeDataProvider,

--- a/src/search/Filters.ts
+++ b/src/search/Filters.ts
@@ -426,7 +426,6 @@ export class FileFilterRoot extends SelfExpandingTreeItem<
         this.loadFromMemento();
     }
 
-    // needs to happen after constructor is done!
     private loadFromMemento() {
         this._memento.value?.forEach((saved) =>
             this.addSelectedFilterWithoutEvent(new FileFilterValue(saved))

--- a/src/search/Filters.ts
+++ b/src/search/Filters.ts
@@ -11,6 +11,7 @@ import { configAccessor } from "../ConfigService";
 import { showComboBoxInput } from "../ComboBoxInput";
 import * as p4 from "../api/PerforceApi";
 import { Display } from "../Display";
+import { MementoItem } from "../MementoItem";
 
 type SearchFilterValue<T> = {
     label: string;
@@ -30,6 +31,8 @@ export type Filters = {
     files?: PerforceFile[];
 };
 
+type StringMemento = MementoItem<SearchFilterValue<string>>;
+
 type PickWithValue<T> = vscode.QuickPickItem & { value?: T };
 
 export abstract class FilterItem<T> extends SelfExpandingTreeItem<any> {
@@ -39,11 +42,14 @@ export abstract class FilterItem<T> extends SelfExpandingTreeItem<any> {
         return this._didChangeFilter.event;
     }
 
-    constructor(protected readonly _filter: SearchFilter) {
+    constructor(
+        protected readonly _filter: SearchFilter,
+        private _mementoItem: MementoItem<SearchFilterValue<T>>
+    ) {
         super(_filter.name + ":", vscode.TreeItemCollapsibleState.None);
         this._didChangeFilter = new vscode.EventEmitter();
         this._subscriptions.push(this._didChangeFilter);
-        this.setValue(undefined);
+        this.setValueWithoutEvent(_mementoItem.value);
     }
 
     get command(): vscode.Command {
@@ -54,15 +60,20 @@ export abstract class FilterItem<T> extends SelfExpandingTreeItem<any> {
         };
     }
 
-    private setValue(value?: SearchFilterValue<T>) {
-        const didChange = this._selected !== value;
-
+    private setValueWithoutEvent(value?: SearchFilterValue<T>) {
         this._selected = value;
         if (value && value.value !== undefined) {
             this.description = this._selected?.label;
         } else {
             this.description = "<" + this._filter.defaultText + ">";
         }
+        this._mementoItem.save(value);
+    }
+
+    private setValue(value?: SearchFilterValue<T>) {
+        const didChange = this._selected !== value;
+
+        this.setValueWithoutEvent(value);
 
         if (didChange) {
             this._didChangeFilter.fire();
@@ -106,12 +117,15 @@ export abstract class FilterItem<T> extends SelfExpandingTreeItem<any> {
     }
 }
 class StatusFilter extends FilterItem<ChangelistStatus> {
-    constructor() {
-        super({
-            name: "Status",
-            placeHolder: "Filter by changelist status",
-            defaultText: "all",
-        });
+    constructor(memento: MementoItem<SearchFilterValue<ChangelistStatus>>) {
+        super(
+            {
+                name: "Status",
+                placeHolder: "Filter by changelist status",
+                defaultText: "all",
+            },
+            memento
+        );
     }
 
     async chooseValue() {
@@ -277,12 +291,15 @@ async function pickFromProviderOrCustom(
 }
 
 class UserFilter extends FilterItem<string> {
-    constructor(private _provider: ProviderSelection) {
-        super({
-            name: "User",
-            placeHolder: "Filter by username",
-            defaultText: "any",
-        });
+    constructor(private _provider: ProviderSelection, memento: StringMemento) {
+        super(
+            {
+                name: "User",
+                placeHolder: "Filter by username",
+                defaultText: "any",
+            },
+            memento
+        );
     }
 
     public async chooseValue(): Promise<SearchFilterValue<string> | undefined> {
@@ -308,12 +325,15 @@ class UserFilter extends FilterItem<string> {
 }
 
 class ClientFilter extends FilterItem<string> {
-    constructor(private _provider: ProviderSelection) {
-        super({
-            name: "Client",
-            placeHolder: "Filter by perforce client",
-            defaultText: "any",
-        });
+    constructor(private _provider: ProviderSelection, memento: StringMemento) {
+        super(
+            {
+                name: "Client",
+                placeHolder: "Filter by perforce client",
+                defaultText: "any",
+            },
+            memento
+        );
     }
 
     public async chooseValue(): Promise<SearchFilterValue<string> | undefined> {
@@ -386,7 +406,10 @@ export class FileFilterRoot extends SelfExpandingTreeItem<
         return this._didChangeFilter.event;
     }
 
-    constructor(private _provider: ProviderSelection) {
+    constructor(
+        private _provider: ProviderSelection,
+        private _memento: MementoItem<string[]>
+    ) {
         super("Files", vscode.TreeItemCollapsibleState.Expanded, {
             reverseChildren: true,
         });
@@ -400,6 +423,14 @@ export class FileFilterRoot extends SelfExpandingTreeItem<
         );
         this._didChangeFilter = new vscode.EventEmitter();
         this._subscriptions.push(this._didChangeFilter);
+        this.loadFromMemento();
+    }
+
+    // needs to happen after constructor is done!
+    private loadFromMemento() {
+        this._memento.value?.forEach((saved) =>
+            this.addSelectedFilterWithoutEvent(new FileFilterValue(saved))
+        );
     }
 
     get contextValue() {
@@ -534,17 +565,34 @@ export class FileFilterRoot extends SelfExpandingTreeItem<
     async addNewFilter() {
         const value = await this.pickNewFilter();
         if (value) {
-            const val = new FileFilterValue(value);
-            this.addChild(val);
-            this.didChange();
-            this._didChangeFilter.fire();
-            this._subscriptions.push(
-                val.onDisposed(() => {
-                    this._didChangeFilter.fire();
-                })
-            );
-            val.reveal();
+            this.addSelectedFilter(value);
+            this.saveDefault();
         }
+    }
+
+    private addSelectedFilterWithoutEvent(val: FileFilterValue) {
+        this.addChild(val);
+        this._subscriptions.push(
+            val.onDisposed(() => {
+                this._didChangeFilter.fire();
+                this.saveDefault();
+            }),
+            val.onChanged(() => {
+                this._didChangeFilter.fire();
+                this.saveDefault();
+            })
+        );
+    }
+
+    private addSelectedFilter(value: string) {
+        const val = new FileFilterValue(value);
+
+        this.addSelectedFilterWithoutEvent(val);
+
+        this.didChange();
+        this._didChangeFilter.fire();
+
+        val.reveal();
     }
 
     get value(): string[] {
@@ -563,6 +611,11 @@ export class FileFilterRoot extends SelfExpandingTreeItem<
             this._didChangeFilter.fire();
         }
         this.didChange();
+        this.saveDefault();
+    }
+
+    private saveDefault() {
+        this._memento.save(this.value);
     }
 }
 
@@ -577,15 +630,26 @@ export class FilterRootItem extends SelfExpandingTreeItem<any> {
         return this._didChangeFilters.event;
     }
 
-    constructor(provider: ProviderSelection) {
+    constructor(provider: ProviderSelection, memento: vscode.Memento) {
         super("Filters", vscode.TreeItemCollapsibleState.Expanded);
-        this._statusFilter = new StatusFilter();
+        this._statusFilter = new StatusFilter(
+            new MementoItem("changeSearch.statusFilter", memento)
+        );
         this.addChild(this._statusFilter);
-        this._userFilter = new UserFilter(provider);
+        this._userFilter = new UserFilter(
+            provider,
+            new MementoItem("changeSearch.userFilter", memento)
+        );
         this.addChild(this._userFilter);
-        this._clientFilter = new ClientFilter(provider);
+        this._clientFilter = new ClientFilter(
+            provider,
+            new MementoItem("changeSearch.clientFilter", memento)
+        );
         this.addChild(this._clientFilter);
-        this._fileFilter = new FileFilterRoot(provider);
+        this._fileFilter = new FileFilterRoot(
+            provider,
+            new MementoItem("changeSearch.fileFilters", memento)
+        );
         this.addChild(this._fileFilter);
         this._didChangeFilters = new vscode.EventEmitter();
 
@@ -597,8 +661,6 @@ export class FilterRootItem extends SelfExpandingTreeItem<any> {
         ]);
 
         this._subscriptions.push(this._didChangeFilters);
-        //this.addChild(new FilterItem("User"));
-        //this.addChild(new FilterItem("Paths"));
     }
 
     subscribeToChanges(filters: (FilterItem<any> | FileFilterRoot)[]) {

--- a/src/search/Filters.ts
+++ b/src/search/Filters.ts
@@ -11,7 +11,7 @@ import { configAccessor } from "../ConfigService";
 import { showComboBoxInput } from "../ComboBoxInput";
 import * as p4 from "../api/PerforceApi";
 import { Display } from "../Display";
-import { MementoItem } from "../MementoItem";
+import { MementoItem, MementoKeys } from "../MementoItem";
 
 type SearchFilterValue<T> = {
     label: string;
@@ -633,22 +633,22 @@ export class FilterRootItem extends SelfExpandingTreeItem<any> {
     constructor(provider: ProviderSelection, memento: vscode.Memento) {
         super("Filters", vscode.TreeItemCollapsibleState.Expanded);
         this._statusFilter = new StatusFilter(
-            new MementoItem("changeSearch.statusFilter", memento)
+            new MementoItem(MementoKeys.SEARCH_STATUS, memento)
         );
         this.addChild(this._statusFilter);
         this._userFilter = new UserFilter(
             provider,
-            new MementoItem("changeSearch.userFilter", memento)
+            new MementoItem(MementoKeys.SEARCH_USER, memento)
         );
         this.addChild(this._userFilter);
         this._clientFilter = new ClientFilter(
             provider,
-            new MementoItem("changeSearch.clientFilter", memento)
+            new MementoItem(MementoKeys.SEARCH_CLIENT, memento)
         );
         this.addChild(this._clientFilter);
         this._fileFilter = new FileFilterRoot(
             provider,
-            new MementoItem("changeSearch.fileFilters", memento)
+            new MementoItem(MementoKeys.SEARCH_FILES, memento)
         );
         this.addChild(this._fileFilter);
         this._didChangeFilters = new vscode.EventEmitter();


### PR DESCRIPTION
Saves the filters + auto search setting in a memento for the workspace, so that filters are not forgotten between sessions.

~TODO - may want a command to clear the mementos in case of any bugs - could a dodgy memento state cause the search to fail to load properly and is there a way out of it?~