### PR TITLE
Use an absolute URI for displaying command output

### DIFF
--- a/src/PerforceUri.ts
+++ b/src/PerforceUri.ts
@@ -136,7 +136,7 @@ export function getUsableWorkspace(uri: vscode.Uri) {
 }
 
 export function forCommand(resource: vscode.Uri, command: string, p4Args: string) {
-    return fromUri(vscode.Uri.parse("perforce:"), {
+    return fromUri(vscode.Uri.parse("perforce:/Command_Output"), {
         command: command,
         p4Args: p4Args,
         workspace: resource.fsPath,

--- a/src/quickPick/JobQuickPick.ts
+++ b/src/quickPick/JobQuickPick.ts
@@ -30,9 +30,7 @@ export const jobQuickPickProvider: qp.ActionableQuickPickProvider = {
             label: "$(file) Show job",
             description: "Open the full job spec in the editor",
             performAction: () => {
-                const uri = PerforceUri.forCommand(resource, "job", "-o").with({
-                    path: job,
-                });
+                const uri = PerforceUri.forCommand(resource, "job", "-o " + job);
                 vscode.window.showTextDocument(uri);
             },
         };

--- a/src/test/suite/perforceUri.test.ts
+++ b/src/test/suite/perforceUri.test.ts
@@ -55,7 +55,7 @@ describe("Perforce Uris", () => {
         it("Produces a URI for an arbitrary command", () => {
             const uri = PerforceUri.forCommand(localUri, "set", "-q");
             expect(uri.scheme).to.equal("perforce");
-            expect(uri.fsPath).to.equal("");
+            expect(uri.path).to.equal("/Command_Output");
             expect(uri.query).to.equal("command=set&p4Args=-q&" + workspaceArg);
         });
     });


### PR DESCRIPTION
Fixes issue with filesystem provider not being able to use relative URIs

Also add whitelist to prevent arbitrary commands from being run

fixes #162 