### PR TITLE
Don't check case for case-insensitive servers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,8 @@
     "editor.tabSize": 4,
     "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
     // Turn off tsc task auto detection since we have the necessary task as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "typescript.tsc.autoDetect": "off",
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,8 +47,17 @@ async function findClientRoot(uri: vscode.Uri): Promise<ClientRoot | undefined> 
             const clientName = info.get("Client name") ?? "unknown";
             const serverAddress = info.get("Server address") ?? "";
             const userName = info.get("User name") ?? "";
-            const isInRoot = isInClientRoot(uri, Utils.normalize(rootStr));
-            const isAboveRoot = isClientRootIn(uri, Utils.normalize(rootStr));
+            const caseInsensitive = info.get("Case Handling") === "insensitive";
+            const isInRoot = isInClientRoot(
+                uri,
+                Utils.normalize(rootStr),
+                caseInsensitive
+            );
+            const isAboveRoot = isClientRootIn(
+                uri,
+                Utils.normalize(rootStr),
+                caseInsensitive
+            );
             return {
                 configSource: uri,
                 clientRoot: vscode.Uri.file(rootStr),
@@ -67,14 +76,29 @@ function setActivationContext(key: string, reason: string | boolean) {
     vscode.commands.executeCommand("setContext", "perforce.activation." + key, reason);
 }
 
-function isInClientRoot(testFile: vscode.Uri, rootFsPath: string) {
-    const wksRootN = Utils.normalize(testFile.fsPath);
-    return wksRootN.startsWith(rootFsPath);
+function startsWithInsensitive(a: string, b: string, caseInsensitive: boolean) {
+    if (caseInsensitive) {
+        return a.toUpperCase().startsWith(b.toUpperCase());
+    }
+    return a.startsWith(b);
 }
 
-function isClientRootIn(workspace: vscode.Uri, rootFsPath: string) {
+function isInClientRoot(
+    testFile: vscode.Uri,
+    rootFsPath: string,
+    caseInsensitive: boolean
+) {
+    const wksRootN = Utils.normalize(testFile.fsPath);
+    return startsWithInsensitive(wksRootN, rootFsPath, caseInsensitive);
+}
+
+function isClientRootIn(
+    workspace: vscode.Uri,
+    rootFsPath: string,
+    caseInsensitive: boolean
+) {
     const wksRootN = Utils.normalize(workspace.fsPath);
-    return rootFsPath.startsWith(wksRootN);
+    return startsWithInsensitive(rootFsPath, wksRootN, caseInsensitive);
 }
 
 async function findP4ConfigFiles(


### PR DESCRIPTION
when intialising workspace, the check for whether one dir is in another now ignore case, if p4 info tells us the server is not case sensitive.

I _think_ this is the only place that needs changing - in other locations, generally we're either working with what the command line gives us and those paths should be correct, or we're working with local file paths which the server should interpret correctly if it is case insensitive.

I also believe this applies equally to linux and windows clients - the insensitivity is done by perforce, not by the OS.

Tested on windows with case insensitive and case sensitive server - case sensitive server correctly did **not** create a workspace when the case was different. Case insensitive server correctly **did** create a worskpace

fixes #164 