### PR TITLE
Shorten extension configuration name

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         ],
         "configuration": {
             "type": "object",
-            "title": "VS Code Perforce Configuration",
+            "title": "Perforce",
             "properties": {
                 "perforce.bottleneck.maxConcurrent": {
                     "scope": "application",


### PR DESCRIPTION
This is the string that appears as the name of the extension in the sidebar in Settings under _Extensions_. Long configuration names are discouraged as they are usually clipped. Additionally, the config name should not contain "VS Code", namely because it will sort it with the rest of the V's while users will expect a Perforce extension to be near the rest of the P's in this list.