### PR TITLE
Add command to close a perforce client

### DIFF
--- a/package.json
+++ b/package.json
@@ -373,6 +373,11 @@
                 "category": "Perforce"
             },
             {
+                "command": "perforce.closeScm",
+                "title": "Close Perforce Client",
+                "category": "Perforce"
+            },
+            {
                 "command": "perforce.loginScm",
                 "title": "Log in to Perforce",
                 "category": "Perforce"
@@ -1043,6 +1048,17 @@
                 {
                     "command": "perforce.refreshChangeSpec",
                     "when": "resourceExtname == .changespec"
+                },
+                {
+                    "command": "perforce.closeScm",
+                    "when": "0"
+                }
+            ],
+            "scm/sourceControl": [
+                {
+                    "command": "perforce.closeScm",
+                    "group": "navigation",
+                    "when": "scmProvider == perforce"
                 }
             ],
             "scm/title": [

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -259,6 +259,21 @@ export class PerforceSCMProvider {
         return this.instances.length;
     }
 
+    public static forceClose(sourceControl?: any) {
+        const scmProvider = this.GetInstance(sourceControl);
+        if (!scmProvider) {
+            return;
+        }
+        Display.channel.appendLine(
+            "Closing perforce client " +
+                scmProvider.clientRoot.clientName +
+                " @ " +
+                scmProvider.clientRoot.clientRoot.fsPath
+        );
+        scmProvider.dispose();
+        this._onDidChangeScmProviders.fire();
+    }
+
     public static registerCommands() {
         // SCM commands
         commands.registerCommand(
@@ -394,6 +409,10 @@ export class PerforceSCMProvider {
         commands.registerCommand(
             "perforce.openReviewTool",
             PerforceSCMProvider.OpenChangelistInReviewTool.bind(this)
+        );
+        commands.registerCommand(
+            "perforce.closeScm",
+            PerforceSCMProvider.forceClose.bind(this)
         );
     }
 


### PR DESCRIPTION
Only enabled for right click on scm provider.

This is a basic implementation so far - still need to consider some options for whether to force things to go away and not come back.

I think this is actually slightly nicer than the git implementation currently - In the git version, just opening an editor tab that has a file in a repo will always re-activate the repo. Currently as in this PR it won't re-open until you open a new file in the perforce client.

Fixes #174