### PR TITLE
Add option to sync the workspace folder only

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ You can specify how you want the extension to activate by setting the parameter 
 |`perforce.scmFileChanges`          |`boolean`  |Open file changes when selected in SCM Explorer
 |`perforce.ignoredChangelistPrefix` |`string`   |Specifies the prefix of the changelists to be ignored.
 |`perforce.hideNonWorkspaceFiles`   |`enum`     |Controls how files outside of the current VS Code workspace are shown in the SCM Provider
+|`perforce.syncMode`                |`enum`     |Controls whether to sync the whole perforce client or just the VS code workspace when using the default sync command
 |`perforce.fileShelveMode`          |`enum`     |Controls behaviour when shelving or unshelving an individual file from the SCM view
 |`perforce.hideShelvedFiles`        |`boolean`  |Hide shelved files in the SCM Explorer.
 |`perforce.hideEmptyChangelists`    |`boolean`  |Hide changelists with no file in the SCM Explorer.

--- a/package.json
+++ b/package.json
@@ -264,7 +264,7 @@
                         "Only sync the workspace folder(s) that are open in VS Code (i.e. perform a p4 sync with a set of paths). NOTE: If you open a file from the same client but outside of the VS Code workspace, this will NOT be synced. If you open a file from another perforce client and the SCM provider is auto detected, the WHOLE perforce client will be synced"
                     ],
                     "default": "whole client",
-                    "description": "Controls the set of files to sync when using the default sync command. If you use a very large perforce client workspace and only open a small part of the workspace, this can prevent accidentally syncing a large number of files"
+                    "description": "Controls the set of files to sync when using the default sync command. If you use a very large perforce client workspace and only open a small part of it in VS Code, this can prevent accidentally syncing a large number of files"
                 },
                 "perforce.hideShelvedFiles": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -253,6 +253,19 @@
                     "default": "show all files",
                     "description": "Controls how files outside of the current VS Code workspace are shown in the SCM Provider.\n\nNote: even if you open non-workspace files in the editor, they will not be considered as workspace files.\n\nWARNING: If you select to hide all non-workspace files, and then submit changelists other than the default, it will submit files that are not visible! It is recommended to hide changelists instead"
                 },
+                "perforce.syncMode": {
+                    "type": "string",
+                    "enum": [
+                        "whole client",
+                        "workspace only"
+                    ],
+                    "enumDescriptions": [
+                        "Always sync the whole perforce client workspace (i.e. perform a bare p4 sync), even if the VS Code workspace is only a subset of the perforce client workspace",
+                        "Only sync the workspace folder(s) that are open in VS Code (i.e. perform a p4 sync with a set of paths). NOTE: If you open a file from the same client but outside of the VS Code workspace, this will NOT be synced. If you open a file from another perforce client and the SCM provider is auto detected, the WHOLE perforce client will be synced"
+                    ],
+                    "default": "whole client",
+                    "description": "Controls the set of files to sync when using the default sync command. If you use a very large perforce client workspace and only open a small part of the workspace, this can prevent accidentally syncing a large number of files"
+                },
                 "perforce.hideShelvedFiles": {
                     "type": "boolean",
                     "default": false,

--- a/src/ConfigService.ts
+++ b/src/ConfigService.ts
@@ -161,10 +161,10 @@ export class ConfigAccessor {
 
     public get syncMode(): SyncMode {
         const mode = this.getConfigItem<string>("syncMode");
-        if (mode === "whole client") {
-            return SyncMode.WHOLE_CLIENT;
-        } else {
+        if (mode === "workspace only") {
             return SyncMode.WORKSPACE_ONLY;
+        } else {
+            return SyncMode.WHOLE_CLIENT;
         }
     }
 }

--- a/src/ConfigService.ts
+++ b/src/ConfigService.ts
@@ -13,6 +13,11 @@ export enum FileShelveMode {
     PROMPT,
 }
 
+export enum SyncMode {
+    WHOLE_CLIENT,
+    WORKSPACE_ONLY,
+}
+
 export class ConfigAccessor {
     constructor() {
         /**/
@@ -152,6 +157,15 @@ export class ConfigAccessor {
 
     public get annotateFollowBranches(): boolean {
         return this.getConfigItem("annotate.followBranches") ?? false;
+    }
+
+    public get syncMode(): SyncMode {
+        const mode = this.getConfigItem<string>("syncMode");
+        if (mode === "whole client") {
+            return SyncMode.WHOLE_CLIENT;
+        } else {
+            return SyncMode.WORKSPACE_ONLY;
+        }
     }
 }
 

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -550,7 +550,7 @@ export class PerforceSCMProvider {
                           Uri.file(Path.join(dir, "..."))
                       )
                     : undefined;
-            perforceProvider?._model.Sync(dirs);
+            perforceProvider._model.Sync(dirs);
         }
     }
 

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -17,7 +17,7 @@ import { Resource } from "./scm/Resource";
 import { Status } from "./scm/Status";
 import { mapEvent } from "./Utils";
 import { FileType } from "./scm/FileTypes";
-import { configAccessor } from "./ConfigService";
+import { configAccessor, SyncMode } from "./ConfigService";
 import * as DiffProvider from "./DiffProvider";
 import * as PerforceUri from "./PerforceUri";
 import { ClientRoot } from "./extension";
@@ -543,7 +543,15 @@ export class PerforceSCMProvider {
 
     public static Sync(sourceControl: SourceControl) {
         const perforceProvider = PerforceSCMProvider.GetInstance(sourceControl);
-        perforceProvider?._model.Sync();
+        if (perforceProvider) {
+            const dirs =
+                this._config.syncMode === SyncMode.WORKSPACE_ONLY
+                    ? [...perforceProvider._contributingDirs].map((dir) =>
+                          Uri.file(Path.join(dir, "..."))
+                      )
+                    : undefined;
+            perforceProvider?._model.Sync(dirs);
+        }
     }
 
     public static async Refresh(sourceControl: SourceControl) {

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -195,7 +195,7 @@ export class Model implements Disposable {
         }
     }
 
-    public async Sync(): Promise<void> {
+    public async Sync(paths?: Uri[]): Promise<void> {
         const loggedin = await p4.isLoggedIn(this._workspaceUri);
         if (!loggedin) {
             return;
@@ -206,7 +206,7 @@ export class Model implements Disposable {
                 location: ProgressLocation.SourceControl,
                 title: "Syncing...",
             },
-            () => this.syncUpdate()
+            () => this.syncUpdate(paths)
         );
     }
 
@@ -1022,9 +1022,11 @@ export class Model implements Disposable {
         this._onDidChange.fire();
     }
 
-    private async syncUpdate(): Promise<void> {
+    private async syncUpdate(paths?: Uri[]): Promise<void> {
         try {
-            const output = await p4.sync(this._workspaceUri, {});
+            const output = await p4.sync(this._workspaceUri, {
+                files: paths,
+            });
             Display.channel.append(output);
             this.Refresh();
         } catch (reason) {


### PR DESCRIPTION
- uses contributing dirs to work out which dirs in the workspace are relevant - that is, the set of dirs where we detected a perforce client. So, it should work when the perforce client was found underneath the workspace, using a p4config, and it should work when the client is above, because we detect it from the workspace root.
- if there are no contributing dirs, we auto-detected from a single file
  - in this case, we just sync the whole perforce client

There is a caveat that it probably won't work if you force activation of the scm provider even when it doesn't relate to your vs code workspace at-all

I did consider adding in a "sync workspace" option on to the menu as well, however, I think this would get confusing if the client is auto detected from a client outside of the workspace - we would probably want to hide the item for this kind of scm provider. However we don't have the context variables to do that (I'm not sure this is possible). Though we could consider showing the menu item and just showing an error if there is no workspace to sync

fixes #169