### PR TITLE
Tidy up scm context menus

### DIFF
--- a/package.json
+++ b/package.json
@@ -612,6 +612,18 @@
                 "icon": "$(files)"
             },
             {
+                "command": "perforce.shelve",
+                "title": "Shelve file",
+                "category": "Perforce",
+                "icon": "$(fold-up)"
+            },
+            {
+                "command": "perforce.unshelve",
+                "title": "Unshelve file",
+                "category": "Perforce",
+                "icon": "$(fold-down)"
+            },
+            {
                 "command": "perforce.shelveChangelist",
                 "title": "Shelve changelist",
                 "category": "Perforce"
@@ -634,7 +646,8 @@
             {
                 "command": "perforce.deleteShelvedFile",
                 "title": "Delete shelved file",
-                "category": "Perforce"
+                "category": "Perforce",
+                "icon": "$(trash)"
             },
             {
                 "command": "perforce.fixJob",
@@ -920,6 +933,14 @@
                 },
                 {
                     "command": "perforce.shelveunshelve",
+                    "when": "0"
+                },
+                {
+                    "command": "perforce.shelve",
+                    "when": "0"
+                },
+                {
+                    "command": "perforce.unshelve",
                     "when": "0"
                 },
                 {
@@ -1252,27 +1273,37 @@
                 {
                     "command": "perforce.openFile",
                     "when": "scmProvider == perforce && config.perforce.scmFileChanges == true",
-                    "group": "inline"
+                    "group": "inline@2"
                 },
                 {
                     "command": "perforce.openResource",
                     "when": "scmProvider == perforce && config.perforce.scmFileChanges == false",
-                    "group": "inline"
+                    "group": "inline@3"
                 },
                 {
                     "command": "perforce.revertFile",
-                    "when": "scmProvider == perforce && scmResourceState == opened",
-                    "group": "inline"
+                    "when": "scmProvider == perforce && scmResourceState =~ /opened/",
+                    "group": "inline@10"
                 },
                 {
                     "command": "perforce.reopenFile",
-                    "when": "scmProvider == perforce",
-                    "group": "inline"
+                    "when": "scmProvider == perforce && scmResourceState =~ /opened/",
+                    "group": "inline@1"
                 },
                 {
-                    "command": "perforce.shelveunshelve",
-                    "when": "scmProvider == perforce && scmResourceGroup != default",
-                    "group": "inline"
+                    "command": "perforce.deleteShelvedFile",
+                    "when": "scmProvider == perforce && scmResourceState =~ /shelved/",
+                    "group": "inline@10"
+                },
+                {
+                    "command": "perforce.shelve",
+                    "when": "scmProvider == perforce && scmResourceState =~ /opened/ && scmResourceGroup != default",
+                    "group": "inline@15"
+                },
+                {
+                    "command": "perforce.unshelve",
+                    "when": "scmProvider == perforce && scmResourceState =~ /shelved/",
+                    "group": "inline@15"
                 },
                 {
                     "command": "perforce.openResource",
@@ -1291,17 +1322,17 @@
                 },
                 {
                     "command": "perforce.revertFile",
-                    "when": "scmProvider == perforce && scmResourceState == opened",
+                    "when": "scmProvider == perforce && scmResourceState =~ /opened/",
                     "group": "1_modification@1"
                 },
                 {
                     "command": "perforce.revertUnchangedFile",
-                    "when": "scmProvider == perforce",
+                    "when": "scmProvider == perforce && scmResourceState =~ /opened/",
                     "group": "1_modification@2"
                 },
                 {
                     "command": "perforce.reopenFile",
-                    "when": "scmProvider == perforce",
+                    "when": "scmProvider == perforce && scmResourceState =~ /opened/",
                     "group": "1_modification@3"
                 },
                 {
@@ -1310,13 +1341,18 @@
                     "group": "1_modification@4"
                 },
                 {
-                    "command": "perforce.shelveunshelve",
-                    "when": "scmProvider == perforce && scmResourceGroup != default",
+                    "command": "perforce.shelve",
+                    "when": "scmProvider == perforce && scmResourceState =~ /opened/ && scmResourceGroup != default",
+                    "group": "2_shelve@1"
+                },
+                {
+                    "command": "perforce.unshelve",
+                    "when": "scmProvider == perforce && scmResourceState =~ /shelved/",
                     "group": "2_shelve@1"
                 },
                 {
                     "command": "perforce.deleteShelvedFile",
-                    "when": "scmProvider == perforce",
+                    "when": "scmProvider == perforce && scmResourceState =~ /shelved/",
                     "group": "2_shelve@2"
                 }
             ],

--- a/package.json
+++ b/package.json
@@ -687,6 +687,16 @@
                 "category": "Perforce"
             },
             {
+                "command": "perforce.resolveFiles",
+                "title": "Resolve...",
+                "category": "Perforce"
+            },
+            {
+                "command": "perforce.reresolveFiles",
+                "title": "Re-resolve...",
+                "category": "Perforce"
+            },
+            {
                 "command": "perforce.reopenFile",
                 "title": "Move to changelist...",
                 "category": "Perforce",
@@ -921,6 +931,14 @@
                 },
                 {
                     "command": "perforce.reresolveChangelist",
+                    "when": "0"
+                },
+                {
+                    "command": "perforce.resolveFiles",
+                    "when": "0"
+                },
+                {
+                    "command": "perforce.reresolveFiles",
                     "when": "0"
                 },
                 {
@@ -1354,6 +1372,16 @@
                     "command": "perforce.deleteShelvedFile",
                     "when": "scmProvider == perforce && scmResourceState =~ /shelved/",
                     "group": "2_shelve@2"
+                },
+                {
+                    "command": "perforce.resolveFiles",
+                    "when": "scmProvider == perforce && scmResourceState =~ /unres/",
+                    "group": "3_resolve@1"
+                },
+                {
+                    "command": "perforce.reresolveFiles",
+                    "when": "scmProvider == perforce && scmResourceState =~ /reres/",
+                    "group": "3_resolve@1"
                 }
             ],
             "editor/title": [

--- a/package.json
+++ b/package.json
@@ -1232,7 +1232,7 @@
                 },
                 {
                     "command": "perforce.revertFile",
-                    "when": "scmProvider == perforce",
+                    "when": "scmProvider == perforce && scmResourceState == opened",
                     "group": "inline"
                 },
                 {
@@ -1262,7 +1262,7 @@
                 },
                 {
                     "command": "perforce.revertFile",
-                    "when": "scmProvider == perforce",
+                    "when": "scmProvider == perforce && scmResourceState == opened",
                     "group": "1_modification@1"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -606,12 +606,6 @@
                 "icon": "$(discard)"
             },
             {
-                "command": "perforce.shelveunshelve",
-                "title": "Shelve/Unshelve file",
-                "category": "Perforce",
-                "icon": "$(files)"
-            },
-            {
                 "command": "perforce.shelve",
                 "title": "Shelve file",
                 "category": "Perforce",
@@ -947,10 +941,6 @@
                 },
                 {
                     "command": "perforce.reopenFile",
-                    "when": "0"
-                },
-                {
-                    "command": "perforce.shelveunshelve",
                     "when": "0"
                 },
                 {

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -6,6 +6,8 @@ import {
     tasks,
     ShellExecution,
     Disposable,
+    ShellQuoting,
+    ShellQuotedString,
 } from "vscode";
 
 import * as PerforceUri from "./PerforceUri";
@@ -249,7 +251,13 @@ export namespace PerforceService {
     ) {
         const editor = configAccessor.resolveP4EDITOR;
         const env = editor ? { P4EDITOR: editor } : undefined;
-        const exec = new ShellExecution(cmd, allArgs, {
+        const quotedArgs = allArgs.map<ShellQuotedString>((arg) => {
+            return {
+                value: arg,
+                quoting: ShellQuoting.Strong,
+            };
+        });
+        const exec = new ShellExecution(cmd, quotedArgs, {
             cwd: spawnArgs.cwd,
             env,
         });

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -399,6 +399,14 @@ export class PerforceSCMProvider {
             PerforceSCMProvider.ReResolveChangelist.bind(this)
         );
         commands.registerCommand(
+            "perforce.resolveFiles",
+            PerforceSCMProvider.ResolveFiles.bind(this)
+        );
+        commands.registerCommand(
+            "perforce.reresolveFiles",
+            PerforceSCMProvider.ReResolveFiles.bind(this)
+        );
+        commands.registerCommand(
             "perforce.loginScm",
             PerforceSCMProvider.Login.bind(this)
         );
@@ -689,6 +697,20 @@ export class PerforceSCMProvider {
         if (model) {
             await model.ReResolveChangelist(input);
         }
+    }
+
+    public static async ResolveFiles(...resourceStates: SourceControlResourceState[]) {
+        const selection = resourceStates.filter(
+            (s) => s instanceof Resource
+        ) as Resource[];
+        await selection[0]?.model.ResolveFiles(selection);
+    }
+
+    public static async ReResolveFiles(...resourceStates: SourceControlResourceState[]) {
+        const selection = resourceStates.filter(
+            (s) => s instanceof Resource
+        ) as Resource[];
+        await selection[0]?.model.ReResolveFiles(selection);
     }
 
     public static async ShelveChangelist(input: ResourceGroup) {

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -359,6 +359,14 @@ export class PerforceSCMProvider {
             PerforceSCMProvider.ShelveOrUnshelve.bind(this)
         );
         commands.registerCommand(
+            "perforce.shelve",
+            PerforceSCMProvider.Shelve.bind(this)
+        );
+        commands.registerCommand(
+            "perforce.unshelve",
+            PerforceSCMProvider.Unshelve.bind(this)
+        );
+        commands.registerCommand(
             "perforce.deleteShelvedFile",
             PerforceSCMProvider.DeleteShelvedFile.bind(this)
         );
@@ -718,6 +726,24 @@ export class PerforceSCMProvider {
             (s) => s instanceof Resource
         ) as Resource[];
         await selection[0]?.model.ShelveOrUnshelveMultiple(selection);
+    }
+
+    public static async Shelve(
+        ...resourceStates: SourceControlResourceState[]
+    ): Promise<void> {
+        const selection = resourceStates.filter(
+            (s) => s instanceof Resource
+        ) as Resource[];
+        await selection[0]?.model.ShelveMultiple(selection);
+    }
+
+    public static async Unshelve(
+        ...resourceStates: SourceControlResourceState[]
+    ): Promise<void> {
+        const selection = resourceStates.filter(
+            (s) => s instanceof Resource
+        ) as Resource[];
+        await selection[0]?.model.UnshelveMultiple(selection);
     }
 
     public static async DeleteShelvedFile(

--- a/src/ScmProvider.ts
+++ b/src/ScmProvider.ts
@@ -355,10 +355,6 @@ export class PerforceSCMProvider {
             PerforceSCMProvider.DeleteShelvedChangelist.bind(this)
         );
         commands.registerCommand(
-            "perforce.shelveunshelve",
-            PerforceSCMProvider.ShelveOrUnshelve.bind(this)
-        );
-        commands.registerCommand(
             "perforce.shelve",
             PerforceSCMProvider.Shelve.bind(this)
         );
@@ -739,15 +735,6 @@ export class PerforceSCMProvider {
         if (model) {
             await model.DeleteShelvedChangelist(input);
         }
-    }
-
-    public static async ShelveOrUnshelve(
-        ...resourceStates: SourceControlResourceState[]
-    ): Promise<void> {
-        const selection = resourceStates.filter(
-            (s) => s instanceof Resource
-        ) as Resource[];
-        await selection[0]?.model.ShelveOrUnshelveMultiple(selection);
     }
 
     public static async Shelve(

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -596,6 +596,21 @@ export class Model implements Disposable {
         this.Refresh();
     }
 
+    public async ResolveFiles(input: Resource[]) {
+        await p4.resolve(this._workspaceUri, {
+            files: input.map((i) => i.actionUriNoRev),
+        });
+        this.Refresh();
+    }
+
+    public async ReResolveFiles(input: Resource[]) {
+        await p4.resolve(this._workspaceUri, {
+            files: input.map((i) => i.actionUriNoRev),
+            reresolve: true,
+        });
+        this.Refresh();
+    }
+
     public async ShelveChangelist(input: ResourceGroup, revert?: boolean): Promise<void> {
         if (input.isDefault) {
             throw new Error("Cannot shelve the default changelist");

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -801,19 +801,6 @@ export class Model implements Disposable {
         await this.revertFileAfterUnshelve(input);
     }
 
-    async ShelveOrUnshelve(input: Resource): Promise<void> {
-        try {
-            if (input.isShelved) {
-                await this.unshelveShelvedFile(input);
-            } else {
-                await this.shelveOpenFile(input);
-            }
-        } catch (reason) {
-            Display.showImportantError(reason.toString());
-            this.Refresh();
-        }
-    }
-
     public async ShelveMultiple(input: Resource[]) {
         if (input.some((r) => r.isShelved)) {
             Display.showModalMessage(
@@ -844,17 +831,6 @@ export class Model implements Disposable {
             Display.showImportantError(reason.toString());
             this.Refresh();
         }
-    }
-
-    public async ShelveOrUnshelveMultiple(input: Resource[]) {
-        if (input.some((r) => r.isShelved !== input[0].isShelved)) {
-            Display.showModalMessage(
-                "A mix of shelved / open files was selected. Please select only shelved or only open files for this operation"
-            );
-            return;
-        }
-        const promises = input.map((r) => this.ShelveOrUnshelve(r));
-        await Promise.all(promises);
     }
 
     public async DeleteShelvedFile(input: Resource): Promise<void> {

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -799,6 +799,38 @@ export class Model implements Disposable {
         }
     }
 
+    public async ShelveMultiple(input: Resource[]) {
+        if (input.some((r) => r.isShelved)) {
+            Display.showModalMessage(
+                "Some selected files are already shelved. Please select only unshelved files"
+            );
+            return;
+        }
+        const promises = input.map((r) => this.shelveOpenFile(r));
+        try {
+            await Promise.all(promises);
+        } catch (reason) {
+            Display.showImportantError(reason.toString());
+            this.Refresh();
+        }
+    }
+
+    public async UnshelveMultiple(input: Resource[]) {
+        if (input.some((r) => !r.isShelved)) {
+            Display.showModalMessage(
+                "Some selected files are not shelved. Please select only shelved files"
+            );
+            return;
+        }
+        const promises = input.map((r) => this.unshelveShelvedFile(r));
+        try {
+            await Promise.all(promises);
+        } catch (reason) {
+            Display.showImportantError(reason.toString());
+            this.Refresh();
+        }
+    }
+
     public async ShelveOrUnshelveMultiple(input: Resource[]) {
         if (input.some((r) => r.isShelved !== input[0].isShelved)) {
             Display.showModalMessage(

--- a/src/scm/Resource.ts
+++ b/src/scm/Resource.ts
@@ -31,6 +31,10 @@ export class Resource implements SourceControlResourceState {
     private _isUnresolved: boolean;
     private _isReresolvable: boolean;
 
+    get contextValue() {
+        return this._isShelved ? "shelved" : "opened";
+    }
+
     /**
      * The working revision of the file if open (it should be)
      *

--- a/src/scm/Resource.ts
+++ b/src/scm/Resource.ts
@@ -10,6 +10,7 @@ import { GetStatuses, Status } from "./Status";
 import { IFileType, GetFileType } from "./FileTypes";
 import { Model, FstatInfo } from "./Model";
 import * as PerforceUri from "../PerforceUri";
+import { isTruthy } from "../TsUtils";
 
 /**
  * An SCM resource represents a state of an underlying workspace resource
@@ -32,7 +33,15 @@ export class Resource implements SourceControlResourceState {
     private _isReresolvable: boolean;
 
     get contextValue() {
-        return this._isShelved ? "shelved" : "opened";
+        const keys: [boolean, string | undefined, string | undefined][] = [
+            [this._isShelved, "shelved", "opened"],
+            [this._isUnresolved, "unres", undefined],
+            [this._isReresolvable, "reres", undefined],
+        ];
+        return keys
+            .map(([val, trueKey, falseKey]) => (val ? trueKey : falseKey))
+            .filter(isTruthy)
+            .join("-");
     }
 
     /**

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -1448,7 +1448,7 @@ describe("Model & ScmProvider modules (integration)", () => {
             });
         });
 
-        describe("Shelve / Unshelve a file", () => {
+        describe("Shelve a file", () => {
             it("Shelves an open file and presents an option to revert", async () => {
                 const warn = sinon
                     .stub(vscode.window, "showWarningMessage")
@@ -1459,7 +1459,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     basicFiles.edit()
                 );
 
-                await PerforceSCMProvider.ShelveOrUnshelve(resource);
+                await PerforceSCMProvider.Shelve(resource);
 
                 expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
                     chnum: "1",
@@ -1482,7 +1482,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     basicFiles.edit()
                 );
 
-                await PerforceSCMProvider.ShelveOrUnshelve(resource);
+                await PerforceSCMProvider.Shelve(resource);
 
                 expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
                     chnum: "1",
@@ -1499,77 +1499,6 @@ describe("Model & ScmProvider modules (integration)", () => {
                         ],
                     }
                 );
-                expect(items.refresh).to.have.been.called;
-            });
-            it("Unshelves a shelved file and deletes the shelved file", async () => {
-                const warn = sinon
-                    .stub(vscode.window, "showWarningMessage")
-                    .resolvesArg(2);
-                const resource = findResourceForShelvedFile(
-                    items.instance.resources[1],
-                    basicFiles.shelveEdit()
-                );
-
-                await PerforceSCMProvider.ShelveOrUnshelve(resource);
-
-                expect(items.stubModel.unshelve).to.have.been.calledWith(workspaceUri, {
-                    toChnum: "1",
-                    shelvedChnum: "1",
-                    paths: [basicFiles.shelveEdit().depotPath],
-                });
-                expect(warn).to.have.been.calledOnce;
-                expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
-                    chnum: "1",
-                    delete: true,
-                    paths: [basicFiles.shelveEdit().depotPath],
-                });
-                expect(items.refresh).to.have.been.called;
-            });
-            it("Does not delete the shelved file if a resolve is needed", async () => {
-                const warn = sinon
-                    .stub(vscode.window, "showWarningMessage")
-                    .resolves(undefined);
-                const resource = findResourceForShelvedFile(
-                    items.instance.resources[1],
-                    basicFiles.shelveEdit()
-                );
-                items.stubModel.unshelve.resolves({
-                    files: [
-                        { depotPath: basicFiles.edit().depotPath, operation: "edit" },
-                        ,
-                    ],
-                    warnings: [
-                        {
-                            depotPath: basicFiles.edit().depotPath,
-                            resolvePath: basicFiles.edit().depotPath + "@=1",
-                        },
-                    ],
-                });
-
-                await PerforceSCMProvider.ShelveOrUnshelve(resource);
-
-                expect(items.stubModel.shelve).not.to.have.been.called;
-                expect(warn).to.have.been.calledWithMatch("needs resolving");
-                expect(items.refresh).to.have.been.called;
-            });
-            it("Does not delete the shelved file if the unshelve fails", async () => {
-                const resource = findResourceForShelvedFile(
-                    items.instance.resources[1],
-                    basicFiles.shelveEdit()
-                );
-
-                items.stubModel.unshelve.rejects("badness");
-
-                await PerforceSCMProvider.ShelveOrUnshelve(resource);
-
-                expect(items.stubModel.unshelve).to.have.been.calledWith(workspaceUri, {
-                    toChnum: "1",
-                    shelvedChnum: "1",
-                    paths: [basicFiles.shelveEdit().depotPath],
-                });
-
-                expect(items.stubModel.shelve).not.to.have.been.called;
-                expect(items.showImportantError).to.have.been.calledWith("badness");
                 expect(items.refresh).to.have.been.called;
             });
             it("Reverts without prompting when mode is `swap`", async () => {
@@ -1582,7 +1511,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     basicFiles.edit()
                 );
 
-                await PerforceSCMProvider.ShelveOrUnshelve(resource);
+                await PerforceSCMProvider.Shelve(resource);
 
                 expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
                     chnum: "1",
@@ -1597,29 +1526,6 @@ describe("Model & ScmProvider modules (integration)", () => {
                         ],
                     }
                 );
-                expect(items.refresh).to.have.been.called;
-            });
-            it("Deletes without prompting when mode is `swap`", async () => {
-                sinon
-                    .stub(configAccessor, "fileShelveMode")
-                    .get(() => FileShelveMode.SWAP);
-                const resource = findResourceForShelvedFile(
-                    items.instance.resources[1],
-                    basicFiles.shelveEdit()
-                );
-
-                await PerforceSCMProvider.ShelveOrUnshelve(resource);
-
-                expect(items.stubModel.unshelve).to.have.been.calledWith(workspaceUri, {
-                    toChnum: "1",
-                    shelvedChnum: "1",
-                    paths: [basicFiles.shelveEdit().depotPath],
-                });
-                expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
-                    chnum: "1",
-                    delete: true,
-                    paths: [basicFiles.shelveEdit().depotPath],
-                });
                 expect(items.refresh).to.have.been.called;
             });
             it("Does not revert when mode is `keep both`", async () => {
@@ -1635,7 +1541,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     basicFiles.edit()
                 );
 
-                await PerforceSCMProvider.ShelveOrUnshelve(resource);
+                await PerforceSCMProvider.Shelve(resource);
 
                 expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
                     chnum: "1",
@@ -1647,30 +1553,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                 expect(items.stubModel.revert).not.to.have.been.called;
                 expect(items.refresh).to.have.been.called;
             });
-            it("Does not delete when mode is `keep both`", async () => {
-                sinon
-                    .stub(configAccessor, "fileShelveMode")
-                    .get(() => FileShelveMode.KEEP_BOTH);
-                const warn = sinon
-                    .stub(vscode.window, "showWarningMessage")
-                    .resolvesArg(2);
-                const resource = findResourceForShelvedFile(
-                    items.instance.resources[1],
-                    basicFiles.shelveEdit()
-                );
-
-                await PerforceSCMProvider.ShelveOrUnshelve(resource);
-
-                expect(items.stubModel.unshelve).to.have.been.calledWith(workspaceUri, {
-                    toChnum: "1",
-                    shelvedChnum: "1",
-                    paths: [basicFiles.shelveEdit().depotPath],
-                });
-                expect(warn).not.to.have.been.called;
-                expect(items.stubModel.shelve).not.to.have.been.called;
-                expect(items.refresh).to.have.been.called;
-            });
-            it("Can shelve or unshelve multiple files", async () => {
+            it("Can shelve multiple files", async () => {
                 const warn = sinon
                     .stub(vscode.window, "showWarningMessage")
                     .resolvesArg(2);
@@ -1685,7 +1568,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                     basicFiles.delete()
                 );
 
-                await PerforceSCMProvider.ShelveOrUnshelve(resource1, resource2);
+                await PerforceSCMProvider.Shelve(resource1, resource2);
 
                 expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
                     chnum: "1",
@@ -1723,12 +1606,196 @@ describe("Model & ScmProvider modules (integration)", () => {
                     basicFiles.shelveDelete()
                 );
 
-                await PerforceSCMProvider.ShelveOrUnshelve(resource1, resource2);
+                await PerforceSCMProvider.Shelve(resource1, resource2);
 
-                expect(items.showModalMessage).to.have.been.calledWithMatch("mix");
+                expect(items.showModalMessage).to.have.been.calledWithMatch(
+                    "Some selected files are already shelved"
+                );
                 expect(items.stubModel.unshelve).not.to.have.been.called;
                 expect(items.stubModel.shelve).not.to.have.been.called;
                 expect(items.stubModel.shelve).not.to.have.been.called;
+            });
+        });
+
+        describe("Unshelve a file", () => {
+            it("Unshelves a shelved file and deletes the shelved file", async () => {
+                const warn = sinon
+                    .stub(vscode.window, "showWarningMessage")
+                    .resolvesArg(2);
+                const resource = findResourceForShelvedFile(
+                    items.instance.resources[1],
+                    basicFiles.shelveEdit()
+                );
+
+                await PerforceSCMProvider.Unshelve(resource);
+
+                expect(items.stubModel.unshelve).to.have.been.calledWith(workspaceUri, {
+                    toChnum: "1",
+                    shelvedChnum: "1",
+                    paths: [basicFiles.shelveEdit().depotPath],
+                });
+                expect(warn).to.have.been.calledOnce;
+                expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
+                    chnum: "1",
+                    delete: true,
+                    paths: [basicFiles.shelveEdit().depotPath],
+                });
+                expect(items.refresh).to.have.been.called;
+            });
+            it("Does not delete the shelved file if a resolve is needed", async () => {
+                const warn = sinon
+                    .stub(vscode.window, "showWarningMessage")
+                    .resolves(undefined);
+                const resource = findResourceForShelvedFile(
+                    items.instance.resources[1],
+                    basicFiles.shelveEdit()
+                );
+                items.stubModel.unshelve.resolves({
+                    files: [
+                        { depotPath: basicFiles.edit().depotPath, operation: "edit" },
+                        ,
+                    ],
+                    warnings: [
+                        {
+                            depotPath: basicFiles.edit().depotPath,
+                            resolvePath: basicFiles.edit().depotPath + "@=1",
+                        },
+                    ],
+                });
+
+                await PerforceSCMProvider.Unshelve(resource);
+
+                expect(items.stubModel.shelve).not.to.have.been.called;
+                expect(warn).to.have.been.calledWithMatch("needs resolving");
+                expect(items.refresh).to.have.been.called;
+            });
+            it("Does not delete the shelved file if the unshelve fails", async () => {
+                const resource = findResourceForShelvedFile(
+                    items.instance.resources[1],
+                    basicFiles.shelveEdit()
+                );
+
+                items.stubModel.unshelve.rejects("badness");
+
+                await PerforceSCMProvider.Unshelve(resource);
+
+                expect(items.stubModel.unshelve).to.have.been.calledWith(workspaceUri, {
+                    toChnum: "1",
+                    shelvedChnum: "1",
+                    paths: [basicFiles.shelveEdit().depotPath],
+                });
+
+                expect(items.stubModel.shelve).not.to.have.been.called;
+                expect(items.showImportantError).to.have.been.calledWith("badness");
+                expect(items.refresh).to.have.been.called;
+            });
+            it("Deletes without prompting when mode is `swap`", async () => {
+                sinon
+                    .stub(configAccessor, "fileShelveMode")
+                    .get(() => FileShelveMode.SWAP);
+                const resource = findResourceForShelvedFile(
+                    items.instance.resources[1],
+                    basicFiles.shelveEdit()
+                );
+
+                await PerforceSCMProvider.Unshelve(resource);
+
+                expect(items.stubModel.unshelve).to.have.been.calledWith(workspaceUri, {
+                    toChnum: "1",
+                    shelvedChnum: "1",
+                    paths: [basicFiles.shelveEdit().depotPath],
+                });
+                expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
+                    chnum: "1",
+                    delete: true,
+                    paths: [basicFiles.shelveEdit().depotPath],
+                });
+                expect(items.refresh).to.have.been.called;
+            });
+            it("Does not delete when mode is `keep both`", async () => {
+                sinon
+                    .stub(configAccessor, "fileShelveMode")
+                    .get(() => FileShelveMode.KEEP_BOTH);
+                const warn = sinon
+                    .stub(vscode.window, "showWarningMessage")
+                    .resolvesArg(2);
+                const resource = findResourceForShelvedFile(
+                    items.instance.resources[1],
+                    basicFiles.shelveEdit()
+                );
+
+                await PerforceSCMProvider.Unshelve(resource);
+
+                expect(items.stubModel.unshelve).to.have.been.calledWith(workspaceUri, {
+                    toChnum: "1",
+                    shelvedChnum: "1",
+                    paths: [basicFiles.shelveEdit().depotPath],
+                });
+                expect(warn).not.to.have.been.called;
+                expect(items.stubModel.shelve).not.to.have.been.called;
+                expect(items.refresh).to.have.been.called;
+            });
+            it("Does not allow a mix of shelved / unshelved files2", async () => {
+                const resource1 = findResourceForFile(
+                    items.instance.resources[1],
+                    basicFiles.edit()
+                );
+
+                const resource2 = findResourceForShelvedFile(
+                    items.instance.resources[1],
+                    basicFiles.shelveDelete()
+                );
+
+                await PerforceSCMProvider.Unshelve(resource1, resource2);
+
+                expect(items.showModalMessage).to.have.been.calledWithMatch(
+                    "Some selected files are not shelved"
+                );
+                expect(items.stubModel.unshelve).not.to.have.been.called;
+                expect(items.stubModel.shelve).not.to.have.been.called;
+                expect(items.stubModel.shelve).not.to.have.been.called;
+            });
+            it("Can unshelve multiple files", async () => {
+                const warn = sinon
+                    .stub(vscode.window, "showWarningMessage")
+                    .resolvesArg(2);
+
+                const resource1 = findResourceForShelvedFile(
+                    items.instance.resources[1],
+                    basicFiles.shelveEdit()
+                );
+
+                const resource2 = findResourceForShelvedFile(
+                    items.instance.resources[1],
+                    basicFiles.shelveDelete()
+                );
+
+                await PerforceSCMProvider.Unshelve(resource1, resource2);
+
+                expect(items.stubModel.unshelve).to.have.been.calledWith(workspaceUri, {
+                    toChnum: "1",
+                    shelvedChnum: "1",
+                    paths: [basicFiles.shelveEdit().depotPath],
+                });
+                expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
+                    chnum: "1",
+                    delete: true,
+                    paths: [basicFiles.shelveEdit().depotPath],
+                });
+
+                expect(warn).to.have.been.calledTwice;
+
+                expect(items.stubModel.unshelve).to.have.been.calledWith(workspaceUri, {
+                    toChnum: "1",
+                    shelvedChnum: "1",
+                    paths: [basicFiles.shelveDelete().depotPath],
+                });
+                expect(items.stubModel.shelve).to.have.been.calledWith(workspaceUri, {
+                    chnum: "1",
+                    delete: true,
+                    paths: [basicFiles.shelveDelete().depotPath],
+                });
+                expect(items.refresh).to.have.been.called;
             });
         });
 


### PR DESCRIPTION
Now that my PR has been merged in vs code, we are able to use context about specific files in when clauses. The actual API is not expected to be finalised until September VS Code release (which happens in October) - so, while this would work as is, even without the finalised API or any workarounds, it is best to wait until the API is finalised before merging this PR.

This PR mainly concerns the difference between shelved / normal files. For example:

- We no longer see "Delete shelved file" on a file that is not shelved
  - But we do see a new delete $(trash) icon on the inline menu for shelved files
- We no longer see "Revert", or "Move to changelist" on a shelved file
- We no longer need a combined command to shelve or unshelve a file (along with its mysterious "pair of files" icon on the inline view), so we now have a separate "shelve" and "unshelve" command, and these each have their own icons (double chevrons up / down) - couldn't find a better codicon to represent shelving and unshelving

Additionally, if a file needs resolving, or can be re-resolved, this PR adds a right-click context item to do so for a single file. Since this is spawned as a task, I discovered any commands spawned in this way were not correctly quoted, so I updated it to use `ShellQuotedString` instead of string. Need to test this works correclty on linux

![recording (3)](https://user-images.githubusercontent.com/49367953/92989797-cb54e400-f4ce-11ea-9bf0-b37fa6f30097.gif)

One thing to consider - prior to this I implemented the 'file shelve mode' setting to control shelving behaviour, whether to 'swap' by default, i.e. 'shelve and revert' or 'unshelve and delete'. Now we have more control of the menus, it may make sense to just have different menu items for each option instead, e.g. an explicit shelve and revert menu item (or even make it configurable whether to have a single menu item with a default or separate menu items)

Another thing to consider - "Open workspace v shelved changes" - this could be hidden if that action is not possible, but the logic to set the `contextValue` for the file is a bit more complicated

One more thing, should think about whether any of this belongs in sub-menus when that API is finalised... not sure when that will be. Given the new short length it seems unecessary for this menu.

fixes #49