### PR TITLE
Add file decorations to the explorer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -193,9 +193,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.46.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.46.0.tgz",
-            "integrity": "sha512-8m9wPEB2mcRqTWNKs9A9Eqs8DrQZt0qNFO8GkxBOnyW6xR//3s77SoMgb/nY1ctzACsZXwZj3YRTDsn4bAoaUw==",
+            "version": "1.53.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.53.0.tgz",
+            "integrity": "sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -1771,7 +1771,7 @@
             },
             {
                 "id": "perforceDecoration.editForeground",
-                "description": "File decoration color for files open for delete",
+                "description": "File decoration color for files open for edit",
                 "defaults": {
                     "dark": "gitDecoration.modifiedResourceForeground",
                     "light": "gitDecoration.modifiedResourceForeground",
@@ -1780,7 +1780,7 @@
             },
             {
                 "id": "perforceDecoration.integrateForeground",
-                "description": "File decoration color for files open for delete",
+                "description": "File decoration color for files open for integrate",
                 "defaults": {
                     "dark": "gitDecoration.modifiedResourceForeground",
                     "light": "gitDecoration.modifiedResourceForeground",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.50.0"
+        "vscode": "^1.53.0"
     },
     "enableProposedApi": false,
     "keywords": [
@@ -1705,6 +1705,114 @@
                     "light": "#00BCF299",
                     "highContrast": "#00BCF299"
                 }
+            },
+            {
+                "id": "perforceDecoration.addForeground",
+                "description": "File decoration color for files open for add",
+                "defaults": {
+                    "dark": "gitDecoration.addedResourceForeground",
+                    "light": "gitDecoration.addedResourceForeground",
+                    "highContrast": "gitDecoration.addedResourceForeground"
+                }
+            },
+            {
+                "id": "perforceDecoration.moveAddForeground",
+                "description": "File decoration color for files open for move / add",
+                "defaults": {
+                    "dark": "gitDecoration.addedResourceForeground",
+                    "light": "gitDecoration.addedResourceForeground",
+                    "highContrast": "gitDecoration.addedResourceForeground"
+                }
+            },
+            {
+                "id": "perforceDecoration.branchForeground",
+                "description": "File decoration color for files open for branch",
+                "defaults": {
+                    "dark": "gitDecoration.addedResourceForeground",
+                    "light": "gitDecoration.addedResourceForeground",
+                    "highContrast": "gitDecoration.addedResourceForeground"
+                }
+            },
+            {
+                "id": "perforceDecoration.archiveForeground",
+                "description": "File decoration color for files open for archive",
+                "defaults": {
+                    "dark": "gitDecoration.deletedResourceForeground",
+                    "light": "gitDecoration.deletedResourceForeground",
+                    "highContrast": "gitDecoration.deletedResourceForeground"
+                }
+            },
+            {
+                "id": "perforceDecoration.deleteForeground",
+                "description": "File decoration color for files open for delete",
+                "defaults": {
+                    "dark": "gitDecoration.deletedResourceForeground",
+                    "light": "gitDecoration.deletedResourceForeground",
+                    "highContrast": "gitDecoration.deletedResourceForeground"
+                }
+            },
+            {
+                "id": "perforceDecoration.moveDeleteForeground",
+                "description": "File decoration color for files open for move/delete",
+                "defaults": {
+                    "dark": "gitDecoration.deletedResourceForeground",
+                    "light": "gitDecoration.deletedResourceForeground",
+                    "highContrast": "gitDecoration.deletedResourceForeground"
+                }
+            },
+            {
+                "id": "perforceDecoration.purgeForeground",
+                "description": "File decoration color for files open for purge",
+                "defaults": {
+                    "dark": "gitDecoration.deletedResourceForeground",
+                    "light": "gitDecoration.deletedResourceForeground",
+                    "highContrast": "gitDecoration.deletedResourceForeground"
+                }
+            },
+            {
+                "id": "perforceDecoration.editForeground",
+                "description": "File decoration color for files open for delete",
+                "defaults": {
+                    "dark": "gitDecoration.modifiedResourceForeground",
+                    "light": "gitDecoration.modifiedResourceForeground",
+                    "highContrast": "gitDecoration.modifiedResourceForeground"
+                }
+            },
+            {
+                "id": "perforceDecoration.integrateForeground",
+                "description": "File decoration color for files open for delete",
+                "defaults": {
+                    "dark": "gitDecoration.modifiedResourceForeground",
+                    "light": "gitDecoration.modifiedResourceForeground",
+                    "highContrast": "gitDecoration.modifiedResourceForeground"
+                }
+            },
+            {
+                "id": "perforceDecoration.importForeground",
+                "description": "File decoration color for files open for import",
+                "defaults": {
+                    "dark": "gitDecoration.conflictingResourceForeground",
+                    "light": "gitDecoration.conflictingResourceForeground",
+                    "highContrast": "gitDecoration.conflictingResourceForeground"
+                }
+            },
+            {
+                "id": "perforceDecoration.lockForeground",
+                "description": "File decoration color for files open for lock",
+                "defaults": {
+                    "dark": "gitDecoration.conflictingResourceForeground",
+                    "light": "gitDecoration.conflictingResourceForeground",
+                    "highContrast": "gitDecoration.conflictingResourceForeground"
+                }
+            },
+            {
+                "id": "perforceDecoration.unresolvedForeground",
+                "description": "File decoration color for unresolved files",
+                "defaults": {
+                    "dark": "gitDecoration.conflictingResourceForeground",
+                    "light": "gitDecoration.conflictingResourceForeground",
+                    "highContrast": "gitDecoration.conflictingResourceForeground"
+                }
             }
         ],
         "keybindings": [
@@ -1839,7 +1947,7 @@
         "@types/node": "^12.12.29",
         "@types/sinon": "^9.0.0",
         "@types/sinon-chai": "^3.2.3",
-        "@types/vscode": "^1.46.0",
+        "@types/vscode": "^1.53.0",
         "@typescript-eslint/eslint-plugin": "^2.22.0",
         "@typescript-eslint/parser": "^2.22.0",
         "chai": "^4.2.0",

--- a/src/TreeView.ts
+++ b/src/TreeView.ts
@@ -20,6 +20,10 @@ export abstract class SelfExpandingTreeItem<T extends SelfExpandingTreeItem<any>
     >;
     private _parent?: SelfExpandingTreeItem<any>;
 
+    public get labelText() {
+        return typeof this.label === "string" ? this.label : this.label?.label;
+    }
+
     public get onDisposed() {
         return this._onDisposed.event;
     }

--- a/src/scm/DecorationProvider.ts
+++ b/src/scm/DecorationProvider.ts
@@ -1,8 +1,14 @@
-import { SourceControlResourceDecorations, Uri } from "vscode";
+import {
+    FileDecoration,
+    SourceControlResourceDecorations,
+    ThemeColor,
+    Uri,
+} from "vscode";
 import { Status } from "./Status";
 import * as path from "path";
 import { getStatusText } from "../test/helpers/testUtils";
 import { isTruthy } from "../TsUtils";
+import { TextDecoder } from "util";
 
 export class DecorationProvider {
     private static _iconsRootPath: string = path.join(
@@ -39,6 +45,23 @@ export class DecorationProvider {
         const tooltip = this.getTooltipText(status, isShelved, isUnresolved);
 
         return { strikeThrough, faded, light, dark, tooltip };
+    }
+
+    public static getFileDecorations(
+        statuses: Status[],
+        isUnresolved: boolean
+    ): FileDecoration {
+        const status = this.getDominantStatus(statuses);
+        const text = DecorationProvider.getStatusDecorations(status);
+        const tooltip = isUnresolved ? text.tooltip + " - unresolved" : text.tooltip;
+        const colorName = isUnresolved ? "unresolved" : text.colorName;
+        return {
+            tooltip,
+            badge: text.badge,
+            color: colorName
+                ? new ThemeColor("perforceDecoration." + colorName + "Foreground")
+                : undefined,
+        };
     }
 
     private static getDominantStatus(statuses: Status[]) {
@@ -130,5 +153,36 @@ export class DecorationProvider {
 
     private static useStrikeThrough(status?: Status): boolean {
         return status === Status.DELETE || status === Status.MOVE_DELETE;
+    }
+
+    private static getStatusDecorations(
+        status?: Status
+    ): { badge?: string; tooltip?: string; colorName?: string } {
+        switch (status) {
+            case Status.ADD:
+                return { badge: "A", tooltip: "Add", colorName: "add" };
+            case Status.ARCHIVE:
+                return { badge: "a", tooltip: "Archive", colorName: "archive" };
+            case Status.BRANCH:
+                return { badge: "B", tooltip: "Branch", colorName: "branch" };
+            case Status.DELETE:
+                return { badge: "D", tooltip: "Delete", colorName: "delete" };
+            case Status.EDIT:
+                return { badge: "E", tooltip: "Edit", colorName: "edit" };
+            case Status.IMPORT:
+                return { badge: "i", tooltip: "Import", colorName: "import" };
+            case Status.INTEGRATE:
+                return { badge: "I", tooltip: "Integrate", colorName: "integrate" };
+            case Status.LOCK:
+                return { badge: "L", tooltip: "Lock", colorName: "lock" };
+            case Status.MOVE_ADD:
+                return { badge: "M", tooltip: "Move/Add", colorName: "moveAdd" };
+            case Status.MOVE_DELETE:
+                return { badge: "M", tooltip: "Move/Delete", colorName: "moveDelete" };
+            case Status.PURGE:
+                return { badge: "P", tooltip: "Purge", colorName: "purge" };
+            default:
+                return {};
+        }
     }
 }

--- a/src/scm/DecorationProvider.ts
+++ b/src/scm/DecorationProvider.ts
@@ -8,7 +8,6 @@ import { Status } from "./Status";
 import * as path from "path";
 import { getStatusText } from "../test/helpers/testUtils";
 import { isTruthy } from "../TsUtils";
-import { TextDecoder } from "util";
 
 export class DecorationProvider {
     private static _iconsRootPath: string = path.join(

--- a/src/scm/DecorationProvider.ts
+++ b/src/scm/DecorationProvider.ts
@@ -60,6 +60,7 @@ export class DecorationProvider {
             color: colorName
                 ? new ThemeColor("perforceDecoration." + colorName + "Foreground")
                 : undefined,
+            propagate: true,
         };
     }
 

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -28,6 +28,7 @@ import { isTruthy, pluralise } from "../TsUtils";
 import { showQuickPickForChangelist } from "../quickPick/ChangeQuickPick";
 import { showQuickPickForJob } from "../quickPick/JobQuickPick";
 import { changeSpecEditor, jobSpecEditor } from "../SpecEditor";
+import { DecorationProvider } from "./DecorationProvider";
 
 function isResourceGroup(arg: any): arg is SourceControlResourceGroup {
     return arg && arg.id !== undefined;
@@ -70,7 +71,7 @@ class ChangelistContext {
     }
 }
 
-export class Model implements Disposable {
+export class Model implements Disposable, vscode.FileDecorationProvider {
     private static _resolvable = new ChangelistContext("resolvable");
     private static _reResolvable = new ChangelistContext("reresolvable");
 
@@ -118,6 +119,13 @@ export class Model implements Disposable {
 
     private _refresh: DebouncedFunction<any[], Promise<void>>;
 
+    private _onDidChangeFileDecorationsEmitter = new EventEmitter<
+        Uri | Uri[] | undefined
+    >();
+    get onDidChangeFileDecorations() {
+        return this._onDidChangeFileDecorationsEmitter.event;
+    }
+
     get workspaceUri() {
         return this._workspaceUri;
     }
@@ -145,6 +153,7 @@ export class Model implements Disposable {
         private _clientName: string,
         public _sourceControl: SourceControl
     ) {
+        this._disposables.push(vscode.window.registerFileDecorationProvider(this));
         this._fullCleanOnNextRefresh = false;
         this._config = configAccessor;
         this._refresh = debounce<(boolean | undefined)[], Promise<void>>(
@@ -156,6 +165,20 @@ export class Model implements Disposable {
         this._disposables.push(
             Display.onActiveFileStatusKnown(this.checkForConflicts.bind(this))
         );
+    }
+
+    provideFileDecoration(
+        uri: Uri,
+        _token: vscode.CancellationToken
+    ): vscode.ProviderResult<vscode.FileDecoration> {
+        const resource = this._openResourcesByPath.get(uri.fsPath);
+        if (resource) {
+            return DecorationProvider.getFileDecorations(
+                [resource.status],
+                resource.isUnresolved
+            );
+        }
+        return null;
     }
 
     private assertIsNotDefault(input: ResourceGroup) {
@@ -1071,6 +1094,7 @@ export class Model implements Disposable {
         this._knownHaveListByPath.clear();
         Model._resolvable.removeChangelists([...this._pendingGroups.keys()]);
         Model._reResolvable.removeChangelists([...this._pendingGroups.keys()]);
+        this._onDidChangeFileDecorationsEmitter.fire(undefined);
     }
 
     private cleanPendingGroups() {
@@ -1169,6 +1193,13 @@ export class Model implements Disposable {
         this._reResolvable.addChangelists(
             this.getChangelistsWhereSome(groups, (r) => r.isReresolvable)
         );
+    }
+
+    private updateDecorations() {
+        const uris = [...this._openResourcesByPath.values()]
+            .map((file) => file.underlyingUri)
+            .filter(isTruthy);
+        this._onDidChangeFileDecorationsEmitter.fire(uris);
     }
 
     private shouldDisplayChangelist(resourceStates: Resource[]) {
@@ -1293,6 +1324,7 @@ export class Model implements Disposable {
         });
 
         Model.updateContextVars(groups);
+        this.updateDecorations();
         this._fullCleanOnNextRefresh = false;
     }
 

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -119,7 +119,7 @@ export class Model implements Disposable, vscode.FileDecorationProvider {
 
     private _refresh: DebouncedFunction<any[], Promise<void>>;
 
-    private _onDidChangeFileDecorationsEmitter = new EventEmitter<
+    private readonly _onDidChangeFileDecorationsEmitter = new EventEmitter<
         Uri | Uri[] | undefined
     >();
     get onDidChangeFileDecorations() {
@@ -154,6 +154,7 @@ export class Model implements Disposable, vscode.FileDecorationProvider {
         public _sourceControl: SourceControl
     ) {
         this._disposables.push(vscode.window.registerFileDecorationProvider(this));
+        this._disposables.push(this._onDidChangeFileDecorationsEmitter);
         this._fullCleanOnNextRefresh = false;
         this._config = configAccessor;
         this._refresh = debounce<(boolean | undefined)[], Promise<void>>(

--- a/src/search/ChangelistTreeView.ts
+++ b/src/search/ChangelistTreeView.ts
@@ -355,7 +355,7 @@ class SearchResultItem extends SelfExpandingTreeItem<
     addShelvedFiles(detail: DescribedChangelist) {
         // remove any existing shelved file group, in case of timing issues
         this.getChildren()
-            .filter((child) => child.label?.startsWith("Shelved Files"))
+            .filter((child) => child.labelText?.startsWith("Shelved Files"))
             .forEach((child) => child.dispose());
         if (detail.shelvedFiles.length > 0) {
             this.insertChild(new SearchResultShelvedSubTree(this._resource, detail));
@@ -484,7 +484,7 @@ abstract class SearchResultTree extends SelfExpandingTreeItem<SearchResultItem> 
     showInQuickPick() {
         showResultsInQuickPick(
             this._resource,
-            this.label ?? "Search Results",
+            this.labelText ?? "Search Results",
             this._results
         );
     }

--- a/src/search/Filters.ts
+++ b/src/search/Filters.ts
@@ -379,7 +379,7 @@ export class FileFilterValue extends SelfExpandingTreeItem<any> {
                     return "Please enter a value";
                 }
             },
-            value: this.label,
+            value: this.labelText,
         });
         if (value) {
             this.label = value;
@@ -597,7 +597,7 @@ export class FileFilterRoot extends SelfExpandingTreeItem<
     get value(): string[] {
         return this.getChildren()
             .filter((child) => child.contextValue === "fileFilter")
-            .map((file) => file.label)
+            .map((file) => file.labelText)
             .filter(isTruthy);
     }
 


### PR DESCRIPTION
Implements the `FileDecorationProvider` api that was added in vscode 1.52

Creates a bunch of new theme colors that inherit from the git colors that represent similar concepts

Ups minimum version to 1.53 - there were some API changes to the tree view in 1.52 that also needed minor handling

fixes #201 

![image](https://user-images.githubusercontent.com/49367953/107874172-969aed80-6eaf-11eb-8a86-f4f5bf32e8c9.png)
