### PR TITLE
Remove unused changelists after submission or deletion

### DIFF
--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -1232,6 +1232,7 @@ export class Model implements Disposable {
         this._pendingGroups.forEach((group) => {
             if (!usedGroups.includes(group.group)) {
                 group.group.dispose();
+                this._pendingGroups.delete(group.group.chnum);
             }
         });
     }


### PR DESCRIPTION
- previously updated to re-use changelist objects for cleaner refresh
- however, forgot to remove from collection
- this caused the badge count on scm to be too high after submitting a changelist
- also caused old changelists to be visible in the move quick pick

fixes #205 