### PR TITLE
Don't validate job name input

### DIFF
--- a/src/api/commands/describe.ts
+++ b/src/api/commands/describe.ts
@@ -155,7 +155,7 @@ export async function getShelvedFiles(
 }
 
 function parseFixedJobsSection(subLines: string[]): FixedJob[] {
-    return sectionArrayBy(subLines, (line) => /^\w*? on/.test(line)).map((job) => {
+    return sectionArrayBy(subLines, (line) => /^\S*? on/.test(line)).map((job) => {
         return {
             id: job[0].split(" ")[0],
             description: job

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -921,16 +921,12 @@ export class Model implements Disposable, vscode.FileDecorationProvider {
     }
 
     private async requestJobId(chnum: string) {
-        const re = new RegExp(/^[a-z0-9]+$/i);
         return await window.showInputBox({
             prompt: "Enter the job to be fixed by changelist " + chnum,
             placeHolder: "jobNNNNNN",
             validateInput: (val) => {
                 if (val.trim() === "") {
                     return "Enter a job name";
-                }
-                if (!re.exec(val)) {
-                    return "Job names can only contain letters and numbers";
                 }
             },
         });


### PR DESCRIPTION
Previously the job input was expecting only letters and numbers,
however other non whitespace characters are also allowed
Also updated the parsing of changelists to handle other non-ws chars

fixes #208