### PR TITLE
fix workspace detection for command-only URIs

### DIFF
--- a/src/PerforceUri.ts
+++ b/src/PerforceUri.ts
@@ -130,7 +130,7 @@ export function getWorkspaceFromQuery(uri: vscode.Uri) {
 }
 
 export function getUsableWorkspace(uri: vscode.Uri) {
-    return !isDepotUri(uri) && !!uri.fsPath
+    return !isDepotUri(uri) && !!uri.fsPath && uri.fsPath !== "/Command_Output"
         ? vscode.Uri.file(uriWithoutRev(uri).fsPath)
         : getWorkspaceFromQuery(uri);
 }


### PR DESCRIPTION
A special value is used where a URI is just for printing command output
This wasn't handled when getting the workspace, therefore the job output wasn't working