### PR TITLE
fix command limiter bottlenecking when opening search in editor

### DIFF
--- a/src/CommandLimiter.ts
+++ b/src/CommandLimiter.ts
@@ -93,7 +93,7 @@ export class CommandLimiter {
      * @returns a promise that resolves once the job has called the callback, or rejects if the job throws an error (regardless of whether it called the callback)
      */
     public submit(
-        command: (callback: LimiterCallback) => any,
+        command: (callback: LimiterCallback) => Promise<any>,
         id: string
     ): Promise<void> {
         let item: QueuedCommand;
@@ -106,7 +106,10 @@ export class CommandLimiter {
                 id,
                 command: () => {
                     try {
-                        command(doneCallback);
+                        command(doneCallback).catch((err) => {
+                            this.completed(id);
+                            rej(err);
+                        });
                     } catch (err) {
                         this.completed(id);
                         rej(err);

--- a/src/CommandLimiter.ts
+++ b/src/CommandLimiter.ts
@@ -89,6 +89,7 @@ export class CommandLimiter {
     /**
      * Submit a job to be executed
      * @param command the command to run when the job is dequeued. The command MUST call the callback to indicate that it has completed.
+     * The command must also return a promise so we can catch errors in async operations that are not handled by the callback. This is incredibly confusing because of the mix of async functions and callback. Running commands should be reworked to be entirely async instead of using a callback!
      * @param id an identifier for the job. MUST BE UNIQUE (TODO validate uniqueness)
      * @returns a promise that resolves once the job has called the callback, or rejects if the job throws an error (regardless of whether it called the callback)
      */

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -102,7 +102,7 @@ export namespace Display {
 
         const doc = editor.document;
 
-        if (!doc.isUntitled) {
+        if (!doc.isUntitled && doc.uri.fsPath !== "") {
             let active: ActiveEditorStatus = ActiveEditorStatus.NOT_IN_WORKSPACE;
             let details: p4.OpenedFile | undefined;
             try {

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -112,20 +112,27 @@ export namespace PerforceService {
             limiter.debugMode = true;
             debugModeSetup = true;
         }
-        limiter.submit((onDone) => {
-            execCommand(
-                resource,
-                command,
-                (...rest) => {
-                    // call done first in case responseCallback throws - the important part is done
-                    onDone();
-                    responseCallback(...rest);
-                },
-                args,
-                input,
-                useTerminal
-            );
-        }, `<JOB_ID:${++id}:${command}>`);
+        limiter
+            .submit(
+                (onDone) =>
+                    execCommand(
+                        resource,
+                        command,
+                        (...rest) => {
+                            // call done first in case responseCallback throws - the important part is done
+                            onDone();
+                            responseCallback(...rest);
+                        },
+                        args,
+                        input,
+                        useTerminal
+                    ),
+                `<JOB_ID:${++id}:${command}>`
+            )
+            .catch((err) => {
+                console.error("Error while running perforce command:", err);
+                responseCallback(err, "", "");
+            });
     }
 
     export function executeAsPromise(

--- a/src/api/CommonTypes.ts
+++ b/src/api/CommonTypes.ts
@@ -38,5 +38,5 @@ export type FstatInfo = {
 export type PerforceFile = Uri | string;
 
 export function isUri(obj: any): obj is Uri {
-    return obj && obj.fsPath && obj.scheme !== undefined;
+    return obj && obj.fsPath !== undefined && obj.scheme !== undefined;
 }

--- a/src/test/suite/unit/CommandLimiter.test.ts
+++ b/src/test/suite/unit/CommandLimiter.test.ts
@@ -193,9 +193,12 @@ describe("Command Limiter (unit)", () => {
 
             const p1 = cl.submit(
                 (c) =>
-                    setTimeout(() => {
-                        c1(c);
-                    }, 40),
+                    new Promise((res) =>
+                        setTimeout(() => {
+                            c1(c);
+                            res();
+                        }, 40)
+                    ),
                 "1"
             );
 
@@ -203,9 +206,12 @@ describe("Command Limiter (unit)", () => {
 
             const p2 = cl.submit(
                 (c) =>
-                    setTimeout(() => {
-                        c2(c);
-                    }, 5),
+                    new Promise((res) =>
+                        setTimeout(() => {
+                            c2(c);
+                            res();
+                        }, 5)
+                    ),
                 "2"
             );
 

--- a/src/test/suite/unit/CommandLimiter.test.ts
+++ b/src/test/suite/unit/CommandLimiter.test.ts
@@ -104,7 +104,14 @@ describe("Command Limiter (unit)", () => {
     });
 
     describe("Limiter", () => {
+        type LimiterCallback = () => void;
         let cbs: sinon.SinonStub[];
+        const asPromise = (cb: (lcb: LimiterCallback) => void) => (
+            lcb: LimiterCallback
+        ) => {
+            cb(lcb);
+            return Promise.resolve(null);
+        };
         beforeEach(() => {
             cbs = [
                 sinon.stub().callsArg(0),
@@ -127,7 +134,7 @@ describe("Command Limiter (unit)", () => {
         });
         it("Runs the command as a callback", async () => {
             const cl = new CommandLimiter(1);
-            const promise = cl.submit(cbs[0], "1");
+            const promise = cl.submit(asPromise(cbs[0]), "1");
             expect(cl).to.include({ queueLength: 0, runningCount: 1 });
             expect(cbs[0]).not.to.have.been.called;
             await promise;
@@ -137,11 +144,11 @@ describe("Command Limiter (unit)", () => {
         it("Queues while maxConcurrent commands are running (1)", async () => {
             const cl = new CommandLimiter(1);
 
-            const p1 = cl.submit(cbs[0], "1");
+            const p1 = cl.submit(asPromise(cbs[0]), "1");
             expect(cl).to.include({ queueLength: 0, runningCount: 1 });
-            const p2 = cl.submit(cbs[1], "2");
+            const p2 = cl.submit(asPromise(cbs[1]), "2");
             expect(cl).to.include({ queueLength: 1, runningCount: 1 });
-            const p3 = cl.submit(cbs[2], "3");
+            const p3 = cl.submit(asPromise(cbs[2]), "3");
             expect(cl).to.include({ queueLength: 2, runningCount: 1 });
 
             expect(cbs[0]).not.to.have.been.called;
@@ -162,11 +169,11 @@ describe("Command Limiter (unit)", () => {
         it("Queues while maxConcurrent commands are running (2)", async () => {
             const cl = new CommandLimiter(2);
 
-            const p1 = cl.submit(cbs[0], "1");
+            const p1 = cl.submit(asPromise(cbs[0]), "1");
             expect(cl).to.include({ queueLength: 0, runningCount: 1 });
-            const p2 = cl.submit(cbs[1], "2");
+            const p2 = cl.submit(asPromise(cbs[1]), "2");
             expect(cl).to.include({ queueLength: 0, runningCount: 2 });
-            const p3 = cl.submit(cbs[2], "3");
+            const p3 = cl.submit(asPromise(cbs[2]), "3");
             expect(cl).to.include({ queueLength: 1, runningCount: 2 });
 
             expect(cbs[0]).not.to.have.been.called;
@@ -234,9 +241,9 @@ describe("Command Limiter (unit)", () => {
         it("Does not queue when maxConcurrent is 0", async () => {
             const cl = new CommandLimiter(0);
 
-            cl.submit(cbs[0], "1");
-            cl.submit(cbs[1], "2");
-            const p3 = cl.submit(cbs[2], "3");
+            cl.submit(asPromise(cbs[0]), "1");
+            cl.submit(asPromise(cbs[1]), "2");
+            const p3 = cl.submit(asPromise(cbs[2]), "3");
             expect(cl).to.include({ queueLength: 0, runningCount: 3 });
 
             expect(cbs[0]).not.to.have.been.called;
@@ -253,7 +260,22 @@ describe("Command Limiter (unit)", () => {
             const cl = new CommandLimiter(1);
             const thrower = sinon.fake.throws(new Error("an error"));
             const p1 = cl.submit(thrower, "1");
-            const p2 = cl.submit(cbs[0], "2");
+            const p2 = cl.submit(asPromise(cbs[0]), "2");
+            expect(cl).to.include({ queueLength: 1, runningCount: 1 });
+            expect(thrower).not.to.have.been.called;
+
+            await expect(p1).to.eventually.be.rejectedWith("an error");
+
+            expect(cl).to.include({ queueLength: 0, runningCount: 1 });
+
+            await p2;
+            expect(cbs[0]).to.have.been.calledOnce;
+        });
+        it("Completes jobs that throw an error async", async () => {
+            const cl = new CommandLimiter(1);
+            const thrower = sinon.fake.rejects(new Error("an error"));
+            const p1 = cl.submit(thrower, "1");
+            const p2 = cl.submit(asPromise(cbs[0]), "2");
             expect(cl).to.include({ queueLength: 1, runningCount: 1 });
             expect(thrower).not.to.have.been.called;
 


### PR DESCRIPTION
fixes #234

- Properly handle errors from async operations in command limiter
- Editor uri has fsPath='' which wasn't being considered as a URI, leading to an exception when trying to log the command to be run. Updated the isUri check to handle empty fsPath
- Don't get status for any URIs with an empty fsPath since they don't make sense anyway