### PR TITLE
Add debugP4Commands setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,13 @@
                 "perforce.debugModeActive": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Whether debug mode is active or not."
+                    "description": "When enabled, logs information about command throttling to the javascript console (open with 'Toggle Developer Tools')"
+                },
+                "perforce.debugP4Commands": {
+                    "type": "boolean",
+                    "default": false,
+                    "scope": "window",
+                    "description": "When enabled, logs all perforce commands and their output to the javascript console (open with 'Toggle Developer Tools'). This may be a *lot* of output and will include raw passwords if present"
                 },
                 "perforce.activationMode": {
                     "type": "string",

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -217,6 +217,8 @@ export namespace PerforceService {
         }
     }
 
+    let spawnedId = 0;
+
     function spawnNormally(
         cmd: string,
         allArgs: string[],
@@ -224,12 +226,22 @@ export namespace PerforceService {
         responseCallback: (err: Error | null, stdout: string, stderr: string) => void,
         input?: string
     ) {
+        const config = workspace.getConfiguration("perforce");
+        const debug = config.get("debugP4Commands", false);
+        const id = ++spawnedId;
+        if (debug) {
+            console.log("[P4 RUN]", id, cmd, allArgs, spawnArgs);
+        }
+
         const child = spawn(cmd, allArgs, spawnArgs);
 
         let called = false;
         child.on("error", (err: Error) => {
             if (!called) {
                 called = true;
+                if (debug) {
+                    console.log("[P4 ERR]", id, err);
+                }
                 responseCallback(err, "", "");
             }
         });
@@ -243,6 +255,9 @@ export namespace PerforceService {
 
         getResults(child).then((value: string[]) => {
             if (!called) {
+                if (debug) {
+                    console.log("[P4 RES]", id, value[0], value[1]);
+                }
                 responseCallback(null, value[0] ?? "", value[1] ?? "");
             }
         });

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -256,7 +256,13 @@ export namespace PerforceService {
         getResults(child).then((value: string[]) => {
             if (!called) {
                 if (debug) {
-                    console.log("[P4 RES]", id, value[0], value[1]);
+                    console.log(
+                        "[P4 RES]",
+                        id,
+                        "Stdout:\n" + value[0],
+                        "\n============================",
+                        "\nStderr:\n" + value[1] + "\n"
+                    );
                 }
                 responseCallback(null, value[0] ?? "", value[1] ?? "");
             }


### PR DESCRIPTION
Enabling the setting logs all perforce commands and their output in to the console

Format is:

Running a command:

`[P4 RUN] <unique id> <cmd> <args> <spawn args>`

spawn args will include things like the env variables in the shell

Results:

`[P4 RES] <same unique id> <stdin> <stderr>`

Or

`[P4 ERR] <same unique id> <exception>`

if there was an exception