### PR TITLE
increase timeout for test that times out on mac

### DIFF
--- a/src/test/suite/perforceCommands.test.ts
+++ b/src/test/suite/perforceCommands.test.ts
@@ -73,7 +73,7 @@ describe("Perforce Command Module (integration)", () => {
                 localFile,
                 "a.txt#2 ⟷ a.txt (workspace)"
             );
-        });
+        }).timeout(10000);
         it("Opens the supplied revision for the currently open file", async () => {
             const localFile = getLocalFile(workspaceUri, "testFolder", "new.txt");
             await vscode.window.showTextDocument(localFile);


### PR DESCRIPTION
For some reason this test takes ages on mac, increasing the timeout so that the test runs don't all get marked as broken