### PR TITLE
Fixing isDirectory for symlinks

### DIFF
--- a/src/FileSystemActions.ts
+++ b/src/FileSystemActions.ts
@@ -158,7 +158,10 @@ export default class FileSystemActions {
     private static async isDirectory(uri: Uri) {
         try {
             const stat = await workspace.fs.stat(uri);
-            return stat.type === FileType.Directory;
+            return (
+                stat.type === FileType.Directory ||
+                stat.type === (FileType.Directory | FileType.SymbolicLink)
+            );
         } catch (err) {
             // still try to revert
             Display.channel.appendLine(err);

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -162,7 +162,11 @@ export namespace PerforceService {
 
     async function isDirectory(uri: Uri): Promise<boolean> {
         try {
-            return (await workspace.fs.stat(uri)).type === FileType.Directory;
+            const stat = await workspace.fs.stat(uri);
+            return (
+                stat.type === FileType.Directory ||
+                stat.type === (FileType.Directory | FileType.SymbolicLink)
+            );
         } catch {}
         return false;
     }


### PR DESCRIPTION
isDirectory should return True for symlinked directories too. VSCode separates Director + Symlinked Directory.
Can result in wrong PWD used for p4 commands.