### PR TITLE
Fix win symbol link

### DIFF
--- a/src/Display.ts
+++ b/src/Display.ts
@@ -107,7 +107,7 @@ export namespace Display {
             let active: ActiveEditorStatus = ActiveEditorStatus.NOT_IN_WORKSPACE;
             let details: p4.OpenedFile | undefined;
             try {
-                const docUri = Utils.getResolvedUri(doc.uri) ?? doc.uri;
+                const docUri = Utils.getResolvedCurDocUri() ?? doc.uri;
                 const opened = await p4.getOpenedFileDetails(docUri, {
                     files: [docUri],
                 });

--- a/src/Display.ts
+++ b/src/Display.ts
@@ -12,6 +12,7 @@ import { debounce } from "./Debounce";
 import * as p4 from "./api/PerforceApi";
 import * as PerforceUri from "./PerforceUri";
 import { isPositiveOrZero } from "./TsUtils";
+import { Utils } from "./Utils";
 
 let _statusBarItem: StatusBarItem;
 
@@ -106,8 +107,9 @@ export namespace Display {
             let active: ActiveEditorStatus = ActiveEditorStatus.NOT_IN_WORKSPACE;
             let details: p4.OpenedFile | undefined;
             try {
-                const opened = await p4.getOpenedFileDetails(doc.uri, {
-                    files: [doc.uri],
+                const docUri = Utils.getResolvedUri(doc.uri) ?? doc.uri;
+                const opened = await p4.getOpenedFileDetails(docUri, {
+                    files: [docUri],
                 });
                 if (opened.open.length > 0) {
                     _statusBarItem.text = "P4: $(check)";

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -19,6 +19,7 @@ import spawn from "cross-spawn";
 import { CommandLimiter } from "./CommandLimiter";
 import * as Path from "path";
 import { configAccessor } from "./ConfigService";
+import { Utils } from "./Utils";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace PerforceService {
@@ -175,6 +176,7 @@ export namespace PerforceService {
         input?: string,
         useTerminal?: boolean
     ) {
+        resource = Utils.getResolvedUri(resource) ?? resource;
         const actualResource = PerforceUri.getUsableWorkspace(resource) ?? resource;
         const cmd = getPerforceCmdPath(actualResource);
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,6 +1,8 @@
-import { Event, workspace } from "vscode";
+import { Event, workspace, Uri } from "vscode";
 
-import * as fs from "fs";
+import * as Fs from "fs";
+import * as Path from "path";
+import { execSync } from "child_process";
 
 export function mapEvent<I, O>(event: Event<I>, map: (i: I) => O): Event<O> {
     return (listener, thisArgs = null, disposables?) =>
@@ -24,8 +26,8 @@ export namespace Utils {
     // Use ASCII expansion for special characters
     export function expansePath(path: string): string {
         if (workspace.getConfiguration("perforce").get("realpath", false)) {
-            if (fs.existsSync(path)) {
-                path = fs.realpathSync(path);
+            if (Fs.existsSync(path)) {
+                path = Fs.realpathSync(path);
             }
         }
 
@@ -35,5 +37,71 @@ export namespace Utils {
             .replace(/#/g, "%23")
             .replace(/@/g, "%40");
         return fixup;
+    }
+
+    function isVolumeLabel(path: string): boolean {
+        return /^[a-zA-Z]:\\?$/.test(path);
+    }
+
+    function parseLastLink(path: string): string {
+        try {
+            if (!path || isVolumeLabel(path)) {
+                return path;
+            }
+            let respath = path;
+            try {
+                const dirname = Path.dirname(path);
+                const basename = Path.basename(path);
+                const output = execSync(
+                    `dir "${dirname}" | findstr "${basename}" | findstr "<SYMLINKD> <JUNCTION>"`
+                ).toString();
+                if (output) {
+                    const matches = new RegExp(/\[([^\]]+)\]/).exec(output);
+                    if (matches && matches[1]) {
+                        respath = matches[1];
+                    }
+                }
+            } catch (error) {}
+            return respath;
+        } catch (error) {
+            console.error("Error resolving symbolic link or junction: ", error);
+            return path;
+        }
+    }
+
+    function parseAllLinks(path: string): string {
+        try {
+            let realpath = Fs.realpathSync(path);
+            realpath = Path.normalize(realpath);
+            const parts = realpath.split("\\");
+
+            let respath = "";
+            for (let i = 0; i < parts.length; ++i) {
+                if (i === 0) {
+                    respath = parts[i];
+                } else {
+                    respath = Path.join(respath, parts[i]);
+                }
+                respath = parseLastLink(respath);
+            }
+            return respath;
+        } catch (error) {
+            console.error("Error resolving symbolic link or junction: ", error);
+            return path;
+        }
+    }
+
+    export function getResolvedPath(path: string | undefined): string | undefined {
+        if (!path || !Fs.existsSync(path)) {
+            return path;
+        }
+        return parseAllLinks(path);
+    }
+
+    export function getResolvedUri(uri: Uri | undefined): Uri | undefined {
+        if (!uri || !Fs.existsSync(uri.fsPath)) {
+            return uri;
+        }
+        return Uri.file(parseAllLinks(uri.fsPath));
     }
 }

--- a/src/api/commands/annotate.ts
+++ b/src/api/commands/annotate.ts
@@ -16,7 +16,7 @@ const annotateFlags = flagMapper<AnnotateOptions>(
         ["i", "followBranches"],
     ],
     "file",
-    ["-q"]
+    ["-tq"]
 );
 
 const annotateCommand = makeSimpleCommand("annotate", annotateFlags);

--- a/src/scm/Model.ts
+++ b/src/scm/Model.ts
@@ -29,6 +29,7 @@ import { showQuickPickForChangelist } from "../quickPick/ChangeQuickPick";
 import { showQuickPickForJob } from "../quickPick/JobQuickPick";
 import { changeSpecEditor, jobSpecEditor } from "../SpecEditor";
 import { DecorationProvider } from "./DecorationProvider";
+import { Utils } from "../Utils";
 
 function isResourceGroup(arg: any): arg is SourceControlResourceGroup {
     return arg && arg.id !== undefined;
@@ -295,6 +296,7 @@ export class Model implements Disposable, vscode.FileDecorationProvider {
      * @param uri the local file to check
      */
     public async haveFile(uri: Uri): Promise<boolean> {
+        uri = Utils.getResolvedUri(uri) ?? uri;
         const cachedHave = this._knownHaveListByPath.get(uri.fsPath);
         if (cachedHave !== undefined) {
             return cachedHave;


### PR DESCRIPTION
1. Recognize symbol link directories on windows.
2. Annotate can be operated on binary files. 