### PR TITLE
Evaluate symbolic link directory in cwd

### DIFF
--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -166,6 +166,14 @@ export namespace PerforceService {
         } catch {}
         return false;
     }
+	
+	async function isSymbolicLinkAndDirectory(uri: Uri): Promise<boolean> {
+        try {
+            const linkAndDir = FileType.SymbolicLink | FileType.Directory;
+            return (await workspace.fs.stat(uri)).type === linkAndDir;
+        } catch {}
+        return false;
+    }
 
     async function execCommand(
         resource: Uri,
@@ -186,8 +194,11 @@ export namespace PerforceService {
         }
 
         const isDir = await isDirectory(actualResource);
-
-        const cwd = isDir ? actualResource.fsPath : Path.dirname(actualResource.fsPath);
+		const isLinkAndDir = isDir ? false : await isSymbolicLinkAndDirectory(actualResource);
+        const cwd =
+            isDir || isLinkAndDir
+                ? actualResource.fsPath
+                : Path.dirname(actualResource.fsPath);
 
         const env = { ...process.env, PWD: cwd };
         const spawnArgs: CP.SpawnOptions = { cwd, env };

--- a/src/PerforceService.ts
+++ b/src/PerforceService.ts
@@ -162,15 +162,11 @@ export namespace PerforceService {
 
     async function isDirectory(uri: Uri): Promise<boolean> {
         try {
-            return (await workspace.fs.stat(uri)).type === FileType.Directory;
-        } catch {}
-        return false;
-    }
-	
-	async function isSymbolicLinkAndDirectory(uri: Uri): Promise<boolean> {
-        try {
-            const linkAndDir = FileType.SymbolicLink | FileType.Directory;
-            return (await workspace.fs.stat(uri)).type === linkAndDir;
+            const ftype = (await workspace.fs.stat(uri)).type;
+            return (
+                ftype === FileType.Directory ||
+                ftype === (FileType.SymbolicLink | FileType.Directory)
+            );
         } catch {}
         return false;
     }
@@ -194,11 +190,7 @@ export namespace PerforceService {
         }
 
         const isDir = await isDirectory(actualResource);
-		const isLinkAndDir = isDir ? false : await isSymbolicLinkAndDirectory(actualResource);
-        const cwd =
-            isDir || isLinkAndDir
-                ? actualResource.fsPath
-                : Path.dirname(actualResource.fsPath);
+        const cwd = isDir ? actualResource.fsPath : Path.dirname(actualResource.fsPath);
 
         const env = { ...process.env, PWD: cwd };
         const spawnArgs: CP.SpawnOptions = { cwd, env };


### PR DESCRIPTION
Problem:
Perforce workspaces are not detected when symbolic link of client root opened from editor. This happens because "isDirectory" function evaluation does not accept symbolic link directories, so, the cwd is taken only up to the previous directory of the symbolic link. As a result, All the p4 commands (e.g p4 info) executed at different path, leading to workspaces not being detected.
e.g: /user/jan/p4_link-->/user/jan/p4_workspace

currently, operations are working fine when using ""/user/jan/p4_workspace". However, workspace is not detected when the symbolic link "/user/jan/p4_link" used.

Solution:
I've added a symbolic directory evaluation when deciding cwd. 
 
@mjcrouch Can you please look into it?
