### PR TITLE
Fixes illegal URI formatting for perforce URIs

### DIFF
--- a/src/PerforceUri.ts
+++ b/src/PerforceUri.ts
@@ -66,7 +66,9 @@ function uriWithRev(uri: vscode.Uri, revOrAtLabel: string | undefined) {
     const args = decodeUriQuery(uri.query);
     const origAuthority = args.authority ?? uri.authority ?? "";
     return uri.with({
-        authority: revOrLabelAsSuffix(revOrAtLabel),
+        authority: revOrLabelAsSuffix(revOrAtLabel)
+            .replace("#", "-rev-")
+            .replace("=", "shelved-"),
         fragment: revOrAtLabel,
         query: encodeQuery({ ...args, authority: origAuthority || "null" }),
     });

--- a/src/test/suite/model.test.ts
+++ b/src/test/suite/model.test.ts
@@ -1120,7 +1120,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                         path: basicFiles.add().localFile.path,
                         scheme: "perforce",
                         fragment: "have",
-                        authority: "#have",
+                        authority: "-rev-have",
                         query: "command=print&p4Args=-q&rev=have&authority=null",
                     })
                 );
@@ -1140,7 +1140,7 @@ describe("Model & ScmProvider modules (integration)", () => {
                         path: "/testArea/testFolderOld/movedFrom.txt",
                         scheme: "perforce",
                         fragment: "4",
-                        authority: "#4",
+                        authority: "-rev-4",
                         query:
                             "command=print&p4Args=-q&authority=depot&depot&workspace=" +
                             encodeURIComponent(basicFiles.moveAdd().localFile.fsPath) +

--- a/src/test/suite/perforceUri.test.ts
+++ b/src/test/suite/perforceUri.test.ts
@@ -63,7 +63,7 @@ describe("Perforce Uris", () => {
         it("Produces a URI for a depot path, including the depot parameter", () => {
             const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
             expect(uri.scheme).to.equal("perforce");
-            expect(uri.authority).to.equal("#2");
+            expect(uri.authority).to.equal("-rev-2");
             expect(uri.path).to.equal("/my/path/file.txt");
             expect(uri.query).to.equal(
                 "command=print&p4Args=-q&authority=depot&depot&" +
@@ -90,7 +90,7 @@ describe("Perforce Uris", () => {
             const uri = PerforceUri.fromUriWithRevision(localUri, "@=99");
             expect(uri.scheme).to.equal("perforce");
             expect(uri.fsPath).to.equal(localUri.fsPath);
-            expect(uri.authority).to.equal("@=99");
+            expect(uri.authority).to.equal("@shelved-99");
             expect(uri.query).to.equal(
                 "command=print&p4Args=-q&rev=%40%3D99&authority=null"
             );
@@ -101,7 +101,7 @@ describe("Perforce Uris", () => {
             const uri = PerforceUri.fromUriWithRevision(start, "@=98");
             expect(uri.scheme).to.equal("perforce");
             expect(uri.fsPath).to.equal(localUri.fsPath);
-            expect(uri.authority).to.equal("@=98");
+            expect(uri.authority).to.equal("@shelved-98");
             expect(uri.query).to.equal(
                 "command=print&p4Args=-q&rev=%40%3D98&authority=null"
             );
@@ -133,7 +133,7 @@ describe("Perforce Uris", () => {
         it("Accepts an optional revision", () => {
             const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
             const augmented = PerforceUri.withArgs(uri, { p4Args: "hello" }, "3");
-            expect(augmented.authority).to.equal("#3");
+            expect(augmented.authority).to.equal("-rev-3");
             expect(augmented.query).to.equal(
                 "command=print&p4Args=hello&authority=depot&depot&" +
                     workspaceArg +
@@ -144,7 +144,7 @@ describe("Perforce Uris", () => {
         it("Does not override the fragment if no revision supplied", () => {
             const uri = PerforceUri.fromDepotPath(localUri, depotPath, "2");
             const augmented = PerforceUri.withArgs(uri, { p4Args: "hello" });
-            expect(augmented.authority).to.equal("#2");
+            expect(augmented.authority).to.equal("-rev-2");
             expect(augmented.query).to.equal(
                 "command=print&p4Args=hello&authority=depot&depot&" +
                     workspaceArg +


### PR DESCRIPTION
Fixes #260 

To format the editor title with the depot revision we use the authority (with # and @= - for example if the depot path is `//depot/my/file#2` then we would parse that to a URI something like `perforce://#2/my/file?depot=true&depotName=depot&rev=2#2`) - this is specified in the package.json `resourceLabelFormatters` where we don't have the ability to parse the query string and we don't receive the fragment (IIRC)

However, this results in technically illegally encoded URIs that don't meet the RFC. We generally get away with it, but it causes the C# extension to break when parsing the URIs (i.e. whenever you open any editor)

Replacing '#' with '-rev-' and '=' with 'shelved-' prevents such errors because the - is valid in the authority.

This does mean that titles are now displayed slightly differently when a single file is open - where previously a tab might say filename#3 it will now say filename-rev-3
and where it said filename@=2234 it will say filename@shelved-2234

For diffs it still shows the revision / changelist number in the previous way as we have more control over that formatting!

I don't think these 'authority' encodings are used for anything else and I don't *think* it will cause any other issues. However the URI handling gets quite hard to follow when you haven't touched it in a few years...