### PR TITLE
Reduce fstat commands to one per pending change and one per shelved c…

### DIFF
--- a/src/api/commands/fstat.ts
+++ b/src/api/commands/fstat.ts
@@ -15,6 +15,8 @@ export interface FstatOptions {
     chnum?: string;
     limitToShelved?: boolean;
     outputPendingRecord?: boolean;
+    limitToOpened?: boolean;
+    limitToClient?: boolean;
 }
 
 function parseZTagField(field: string) {
@@ -47,6 +49,8 @@ const fstatFlags = flagMapper<FstatOptions>(
         ["e", "chnum"],
         ["Or", "outputPendingRecord"],
         ["Rs", "limitToShelved"],
+        ["Ro", "limitToOpened"],
+        ["Rc", "limitToClient"],
     ],
     "depotPaths"
 );


### PR DESCRIPTION
…hange.

When a user has thousands of opened files, it produces
  N (number of opened files) / 32 fstat commands.
  With each fstat command containing 32 file arguments.
For example:
```
p4 fstat -Or file1 file1 file3 ... file32
```

The plug-in also issues p4 commands asynchronously with `perforce.bottleneck.maxConcurrent` concurrent commands per user.

With hundreds or thousands of users, this creates considerable load on the Perforce Server. Each command holding database read locks that prevent write operations from obtaining necessary locks.

A more concurrent solution is to issue an fstat command with a single path argument (in client syntax.)
For example to return all open files:
```
p4 fstat -Or -Ro -Rc //<clientname>/...
```

This implementation takes a slightly more conservative approach of issuing one fstat per change/shelf.
For example:
```
p4 fstat -e <change> -Or -Ro -Rc //<clientname>/...
p4 fstat -e <change> -Or -Rs //<clientname>/...
```

This is a proposed fix for https://github.com/mjcrouch/vscode-perforce/issues/301